### PR TITLE
Add extensible content parser interface

### DIFF
--- a/.github/changelog/content-parser-interface
+++ b/.github/changelog/content-parser-interface
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add extensible content parser support and a JSON preview endpoint for AT Protocol records.

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -44,6 +44,9 @@ class Atmosphere {
 		// Plugin integrations.
 		Load::init();
 
+		// JSON preview for AT Protocol records.
+		\add_action( 'template_redirect', array( $this, 'preview' ) );
+
 		// Post lifecycle hooks.
 		\add_action( 'transition_post_status', array( $this, 'on_status_change' ), 10, 3 );
 
@@ -142,6 +145,45 @@ class Atmosphere {
 		\status_header( 200 );
 		\header( 'Content-Type: text/plain; charset=utf-8' );
 		echo \esc_html( $uri );
+		exit;
+	}
+
+	/**
+	 * Serve a JSON preview of the AT Protocol record for a post.
+	 *
+	 * Append ?atproto to a singular post URL to see the document
+	 * record JSON. Optionally pass ?atproto={parser} to preview
+	 * with a specific content parser (requires the parser to be
+	 * registered via the atmosphere_content_parser filter).
+	 */
+	public function preview(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET['atproto'] ) || ! \is_singular() ) {
+			return;
+		}
+
+		if ( ! \current_user_can( 'edit_posts' ) ) {
+			return;
+		}
+
+		$post = \get_queried_object();
+
+		if ( ! $post instanceof \WP_Post ) {
+			return;
+		}
+
+		if ( ! \in_array( $post->post_type, Backfill::syncable_post_types(), true ) ) {
+			\status_header( 404 );
+			exit;
+		}
+
+		$transformer = new Document( $post );
+		$record      = $transformer->transform();
+
+		\status_header( 200 );
+		\header( 'Content-Type: application/json; charset=utf-8' );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+		echo \wp_json_encode( $record, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 		exit;
 	}
 

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -152,9 +152,7 @@ class Atmosphere {
 	 * Serve a JSON preview of the AT Protocol record for a post.
 	 *
 	 * Append ?atproto to a singular post URL to see the document
-	 * record JSON. Optionally pass ?atproto={parser} to preview
-	 * with a specific content parser (requires the parser to be
-	 * registered via the atmosphere_content_parser filter).
+	 * record JSON. Requires the edit_posts capability.
 	 */
 	public function preview(): void {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/includes/content-parser/interface-content-parser.php
+++ b/includes/content-parser/interface-content-parser.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Content parser interface for AT Protocol content formats.
+ *
+ * Plugins can implement this interface to provide custom content
+ * parsers for the site.standard.document content union field.
+ *
+ * @package Atmosphere
+ */
+
+namespace Atmosphere\Content_Parser;
+
+\defined( 'ABSPATH' ) || exit;
+
+/**
+ * Content parser contract.
+ */
+interface Content_Parser {
+
+	/**
+	 * Parse WordPress post content into an AT Protocol content object.
+	 *
+	 * The returned array must include a '$type' key identifying the
+	 * lexicon type (e.g. 'at.markpub.markdown').
+	 *
+	 * Receives raw post content so parsers can choose their own
+	 * strategy: parse_blocks() for block-aware parsing, or
+	 * apply_filters( 'the_content', ... ) for rendered HTML.
+	 *
+	 * @param string   $content Raw post content (post_content).
+	 * @param \WP_Post $post    The WordPress post object.
+	 * @return array AT Protocol content object.
+	 */
+	public function parse( string $content, \WP_Post $post ): array;
+
+	/**
+	 * The lexicon NSID this parser produces.
+	 *
+	 * @return string e.g. 'at.markpub.markdown'.
+	 */
+	public function get_type(): string;
+}

--- a/includes/transformer/class-document.php
+++ b/includes/transformer/class-document.php
@@ -13,6 +13,7 @@ namespace Atmosphere\Transformer;
 
 \defined( 'ABSPATH' ) || exit;
 
+use Atmosphere\Content_Parser\Content_Parser;
 use function Atmosphere\build_at_uri;
 use function Atmosphere\get_did;
 use function Atmosphere\sanitize_text;
@@ -55,10 +56,13 @@ class Document extends Base {
 			'publishedAt' => $this->to_iso8601( $this->object->post_date_gmt ),
 		);
 
-		// Publication reference.
+		// Publication reference (required by spec).
 		$pub_tid = \get_option( 'atmosphere_publication_tid' );
 		if ( $pub_tid ) {
 			$record['site'] = build_at_uri( get_did(), 'site.standard.publication', $pub_tid );
+		} else {
+			// Fall back to site URL for standalone documents.
+			$record['site'] = \untrailingslashit( \get_home_url() );
 		}
 
 		// Relative path.
@@ -87,6 +91,12 @@ class Document extends Base {
 		$text_content = $this->get_text_content();
 		if ( ! empty( $text_content ) ) {
 			$record['textContent'] = $text_content;
+		}
+
+		// Parsed rich content (open union).
+		$content = $this->get_content();
+		if ( ! empty( $content ) ) {
+			$record['content'] = $content;
 		}
 
 		// Tags.
@@ -138,6 +148,43 @@ class Document extends Base {
 		}
 
 		return $rkey;
+	}
+
+	/**
+	 * Get parsed content for the document's content union field.
+	 *
+	 * @return array|null Parsed content object or null.
+	 */
+	private function get_content(): ?array {
+		if ( empty( \trim( $this->object->post_content ) ) ) {
+			return null;
+		}
+
+		/**
+		 * Filters the content parser used for site.standard.document records.
+		 *
+		 * Return a Content_Parser instance to provide a parser.
+		 * Return null to disable the content field entirely.
+		 *
+		 * @param Content_Parser|null $parser The content parser. Default: null.
+		 * @param \WP_Post            $post   The WordPress post.
+		 */
+		$parser = \apply_filters( 'atmosphere_content_parser', null, $this->object );
+
+		if ( ! $parser instanceof Content_Parser ) {
+			return null;
+		}
+
+		$content = $parser->parse( $this->object->post_content, $this->object );
+
+		/**
+		 * Filters the parsed content object before adding to the document record.
+		 *
+		 * @param array          $content The parsed content object.
+		 * @param \WP_Post       $post    The WordPress post.
+		 * @param Content_Parser $parser  The parser that produced the content.
+		 */
+		return \apply_filters( 'atmosphere_document_content', $content, $this->object, $parser );
 	}
 
 	/**

--- a/tests/phpunit/tests/transformer/class-stub-parser.php
+++ b/tests/phpunit/tests/transformer/class-stub-parser.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Stub content parser for testing.
+ *
+ * @package Atmosphere
+ */
+
+namespace Atmosphere\Tests\Transformer;
+
+use Atmosphere\Content_Parser\Content_Parser;
+
+/**
+ * Stub content parser that returns raw content as-is.
+ */
+class Stub_Parser implements Content_Parser {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_type(): string {
+		return 'test.stub.parser';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param string   $content Raw post content.
+	 * @param \WP_Post $post    The WordPress post object.
+	 */
+	public function parse( string $content, \WP_Post $post ): array { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return array(
+			'$type' => 'test.stub.parser',
+			'text'  => $content,
+		);
+	}
+}

--- a/tests/phpunit/tests/transformer/class-test-document.php
+++ b/tests/phpunit/tests/transformer/class-test-document.php
@@ -9,32 +9,10 @@
 
 namespace Atmosphere\Tests\Transformer;
 
+require_once __DIR__ . '/class-stub-parser.php';
+
 use WP_UnitTestCase;
-use Atmosphere\Content_Parser\Content_Parser;
 use Atmosphere\Transformer\Document;
-
-/**
- * Stub content parser for testing.
- */
-class Stub_Parser implements Content_Parser {
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function get_type(): string {
-		return 'test.stub.parser';
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function parse( string $content, \WP_Post $post ): array { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		return array(
-			'$type' => 'test.stub.parser',
-			'text'  => $content,
-		);
-	}
-}
 
 /**
  * Document transformer tests.

--- a/tests/phpunit/tests/transformer/class-test-document.php
+++ b/tests/phpunit/tests/transformer/class-test-document.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Tests for the Document transformer content parser integration.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group transformer
+ */
+
+namespace Atmosphere\Tests\Transformer;
+
+use WP_UnitTestCase;
+use Atmosphere\Content_Parser\Content_Parser;
+use Atmosphere\Transformer\Document;
+
+/**
+ * Stub content parser for testing.
+ */
+class Stub_Parser implements Content_Parser {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_type(): string {
+		return 'test.stub.parser';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function parse( string $content, \WP_Post $post ): array { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return array(
+			'$type' => 'test.stub.parser',
+			'text'  => $content,
+		);
+	}
+}
+
+/**
+ * Document transformer tests.
+ */
+class Test_Document extends WP_UnitTestCase {
+
+	/**
+	 * Test that content field is absent when no parser is registered.
+	 */
+	public function test_content_absent_without_parser() {
+		$post = self::factory()->post->create_and_get(
+			array( 'post_content' => 'Some content here.' )
+		);
+
+		$transformer = new Document( $post );
+		$record      = $transformer->transform();
+
+		$this->assertArrayNotHasKey( 'content', $record );
+	}
+
+	/**
+	 * Test that content field is present when a parser is registered via filter.
+	 */
+	public function test_content_present_with_parser_filter() {
+		\add_filter(
+			'atmosphere_content_parser',
+			static fn() => new Stub_Parser()
+		);
+
+		$post = self::factory()->post->create_and_get(
+			array( 'post_content' => 'Hello world.' )
+		);
+
+		$transformer = new Document( $post );
+		$record      = $transformer->transform();
+
+		$this->assertArrayHasKey( 'content', $record );
+		$this->assertSame( 'test.stub.parser', $record['content']['$type'] );
+		$this->assertSame( 'Hello world.', $record['content']['text'] );
+
+		\remove_all_filters( 'atmosphere_content_parser' );
+	}
+
+	/**
+	 * Test that returning null from the parser filter disables content.
+	 */
+	public function test_content_disabled_with_null_filter() {
+		\add_filter( 'atmosphere_content_parser', '__return_null' );
+
+		$post = self::factory()->post->create_and_get(
+			array( 'post_content' => 'Some content.' )
+		);
+
+		$transformer = new Document( $post );
+		$record      = $transformer->transform();
+
+		$this->assertArrayNotHasKey( 'content', $record );
+
+		\remove_all_filters( 'atmosphere_content_parser' );
+	}
+
+	/**
+	 * Test that a non-Content_Parser return from the filter is ignored.
+	 */
+	public function test_content_ignored_with_invalid_parser() {
+		\add_filter(
+			'atmosphere_content_parser',
+			static fn() => 'not a parser'
+		);
+
+		$post = self::factory()->post->create_and_get(
+			array( 'post_content' => 'Some content.' )
+		);
+
+		$transformer = new Document( $post );
+		$record      = $transformer->transform();
+
+		$this->assertArrayNotHasKey( 'content', $record );
+
+		\remove_all_filters( 'atmosphere_content_parser' );
+	}
+
+	/**
+	 * Test that content field is absent for empty post content.
+	 */
+	public function test_content_absent_for_empty_content() {
+		\add_filter(
+			'atmosphere_content_parser',
+			static fn() => new Stub_Parser()
+		);
+
+		$post = self::factory()->post->create_and_get(
+			array( 'post_content' => '' )
+		);
+
+		$transformer = new Document( $post );
+		$record      = $transformer->transform();
+
+		$this->assertArrayNotHasKey( 'content', $record );
+
+		\remove_all_filters( 'atmosphere_content_parser' );
+	}
+
+	/**
+	 * Test the atmosphere_document_content filter can modify parsed content.
+	 */
+	public function test_document_content_filter() {
+		\add_filter(
+			'atmosphere_content_parser',
+			static fn() => new Stub_Parser()
+		);
+
+		\add_filter(
+			'atmosphere_document_content',
+			static function ( array $content ) {
+				$content['modified'] = true;
+				return $content;
+			}
+		);
+
+		$post = self::factory()->post->create_and_get(
+			array( 'post_content' => 'Hello.' )
+		);
+
+		$transformer = new Document( $post );
+		$record      = $transformer->transform();
+
+		$this->assertArrayHasKey( 'content', $record );
+		$this->assertTrue( $record['content']['modified'] );
+
+		\remove_all_filters( 'atmosphere_content_parser' );
+		\remove_all_filters( 'atmosphere_document_content' );
+	}
+
+	/**
+	 * Test that site field falls back to home URL without publication TID.
+	 */
+	public function test_site_fallback_to_home_url() {
+		\delete_option( 'atmosphere_publication_tid' );
+
+		$post = self::factory()->post->create_and_get();
+
+		$transformer = new Document( $post );
+		$record      = $transformer->transform();
+
+		$this->assertArrayHasKey( 'site', $record );
+		$this->assertSame( \untrailingslashit( \get_home_url() ), $record['site'] );
+	}
+
+	/**
+	 * Test that site field uses AT-URI when publication TID exists.
+	 */
+	public function test_site_uses_at_uri_with_publication_tid() {
+		\update_option( 'atmosphere_publication_tid', 'test-tid-123' );
+		\update_option( 'atmosphere_did', 'did:plc:test' );
+
+		$post = self::factory()->post->create_and_get();
+
+		$transformer = new Document( $post );
+		$record      = $transformer->transform();
+
+		$this->assertArrayHasKey( 'site', $record );
+		$this->assertStringStartsWith( 'at://', $record['site'] );
+		$this->assertStringContainsString( 'site.standard.publication', $record['site'] );
+		$this->assertStringContainsString( 'test-tid-123', $record['site'] );
+
+		\delete_option( 'atmosphere_publication_tid' );
+		\delete_option( 'atmosphere_did' );
+	}
+
+	/**
+	 * Test the collection NSID.
+	 */
+	public function test_collection() {
+		$post        = self::factory()->post->create_and_get();
+		$transformer = new Document( $post );
+
+		$this->assertSame( 'site.standard.document', $transformer->get_collection() );
+	}
+}


### PR DESCRIPTION
## Proposed changes:
* Add a `Content_Parser` interface for pluggable content parsing of the `content` union field in `site.standard.document` records.
* Wire content parsing into the Document transformer with two filters: `atmosphere_content_parser` (swap/disable parser) and `atmosphere_document_content` (modify parsed output).
* Add `?atproto` preview endpoint on singular posts to inspect the document record JSON (requires `edit_posts` capability).
* Always set the required `site` field in document records, falling back to the site URL when no publication record exists.

Split from #3 — this PR contains the generic extensible infrastructure. The Markpub parser implementation follows in a stacked PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Verify `?atproto` preview on a published post returns valid JSON (when logged in with `edit_posts` capability).
* Verify `?atproto` is not accessible when logged out.
* Verify the `content` field is absent from the record (no parser registered by default).
* Verify the `site` field is always present in document records.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

</details>