### PR TITLE
Fix wp-env test path to match repository name

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	"scripts": {
 		"env-start": "wp-env start",
 		"env-stop": "wp-env stop",
-		"env-test": "wp-env run tests-cli --env-cwd=\"wp-content/plugins/atmosphere\" vendor/bin/phpunit"
+		"env-test": "wp-env run tests-cli --env-cwd=\"wp-content/plugins/wordpress-atmosphere\" vendor/bin/phpunit"
 	},
 	"devDependencies": {
 		"@wordpress/env": "^11.2.0"


### PR DESCRIPTION
## Proposed changes:
* Fix the `env-test` script in `package.json` to use `wordpress-atmosphere` instead of `atmosphere` as the plugin directory, matching how wp-env maps the repository.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

N/A — build config fix.

## Testing instructions:

* Run `npm run env-test` and verify all tests pass.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

</details>