### PR TITLE
Add fallback to site-level Composer autoloader

### DIFF
--- a/atmosphere.php
+++ b/atmosphere.php
@@ -24,9 +24,15 @@ namespace Atmosphere;
 \define( 'ATMOSPHERE_PLUGIN_URL', \plugin_dir_url( __FILE__ ) );
 \define( 'ATMOSPHERE_PLUGIN_FILE', __FILE__ );
 
-// Composer autoloader (classes).
+/*
+ * Composer autoloader — prefer the plugin's own vendor (standalone
+ * install / release ZIP), then try the site-level autoloader
+ * (installed as a Composer dependency).
+ */
 if ( \file_exists( ATMOSPHERE_PLUGIN_DIR . 'vendor/autoload.php' ) ) {
 	require_once ATMOSPHERE_PLUGIN_DIR . 'vendor/autoload.php';
+} elseif ( \file_exists( ABSPATH . 'vendor/autoload.php' ) ) {
+	require_once ABSPATH . 'vendor/autoload.php';
 }
 
 // Helper functions (loaded after ABSPATH is available).


### PR DESCRIPTION
## Proposed changes:
* When the plugin is installed as a Composer dependency (e.g. `composer require automattic/atmosphere`), it has no local `vendor/` directory. Fall back to `ABSPATH . 'vendor/autoload.php'` so dependencies like `jwt-library` are still loaded.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Install the plugin via `composer require automattic/atmosphere` in a WordPress root.
* Verify the plugin activates and functions without a local `vendor/` directory.
* Verify standalone installs (with local `vendor/`) continue to work.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

</details>