### PR TITLE
Limit backfill to the 10 most recent unsynced posts

### DIFF
--- a/.github/changelog/backfill-limit
+++ b/.github/changelog/backfill-limit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Limit backfill to the 10 most recent unsynced posts to avoid overwhelming the server on large sites.

--- a/includes/class-backfill.php
+++ b/includes/class-backfill.php
@@ -39,11 +39,23 @@ class Backfill {
 
 		$post_types = self::syncable_post_types();
 
+		/**
+		 * Filters the maximum number of posts to backfill.
+		 *
+		 * Only the most recent unsynced posts (up to this limit) will
+		 * be included in each backfill run. Use 0 or -1 to backfill all.
+		 *
+		 * @param int $limit Maximum number of posts. Default 10.
+		 */
+		$limit = (int) \apply_filters( 'atmosphere_backfill_limit', 10 );
+
 		$all_ids = \get_posts(
 			array(
 				'post_type'      => $post_types,
 				'post_status'    => 'publish',
 				'posts_per_page' => -1,
+				'orderby'        => 'date',
+				'order'          => 'DESC',
 				'fields'         => 'ids',
 			)
 		);
@@ -54,6 +66,10 @@ class Backfill {
 		foreach ( $all_ids as $id ) {
 			if ( ! \get_post_meta( $id, Document::META_URI, true ) ) {
 				$unsynced[] = $id;
+			}
+
+			if ( $limit > 0 && \count( $unsynced ) >= $limit ) {
+				break;
 			}
 		}
 

--- a/templates/settings-page.php
+++ b/templates/settings-page.php
@@ -120,7 +120,15 @@ $connected  = is_connected();
 		<!-- Backfill -->
 		<div class="card">
 			<h2><?php \esc_html_e( 'Backfill', 'atmosphere' ); ?></h2>
-			<p><?php \esc_html_e( 'Sync existing published posts that haven\'t been sent to AT Protocol yet.', 'atmosphere' ); ?></p>
+			<p>
+			<?php
+			\printf(
+				/* translators: %d: maximum number of posts to backfill */
+				\esc_html__( 'Sync the last %d published posts that haven\'t been sent to AT Protocol yet.', 'atmosphere' ),
+				(int) \apply_filters( 'atmosphere_backfill_limit', 10 )
+			);
+			?>
+		</p>
 
 			<div id="atmosphere-backfill">
 				<button type="button" class="button" id="atmosphere-backfill-start">


### PR DESCRIPTION
## Proposed changes:
* Limit the backfill count handler to return only the 10 most recent unsynced posts (ordered by date descending), instead of every unsynced post on the site.
* Add `atmosphere_backfill_limit` filter so developers can customize the limit (use `0` or `-1` to backfill all).
* Dynamically render the limit in the settings page description so it stays in sync with the filter value.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
* Go to ATmosphere settings page → Backfill card.
* Verify the description reads "Sync the last 10 published posts…".
* Create more than 10 published posts, click Start Backfill, and confirm only 10 are processed.
* Test the filter: add `add_filter( 'atmosphere_backfill_limit', fn() => 5 );` and verify only 5 posts are backfilled and the UI reads "last 5".

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Changed - for changes in existing functionality

#### Message

Limit backfill to the 10 most recent unsynced posts to avoid overwhelming the server on large sites.

</details>