### PR TITLE
Require PHPCS, PHPUnit, and changelog before creating PRs

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -16,16 +16,33 @@ description: INVOKE THIS SKILL before creating any PR to ensure compliance with 
 
 **Reserved:** `release/{X.Y.Z}` (releases only), `trunk` (main branch).
 
-## Pre-PR Review
+## Pre-PR Checks
 
-Before creating a PR, delegate to the **code-review** agent to review all changes on the branch. Address any critical issues before proceeding.
+Before creating a PR, you **MUST** complete these steps in order:
+
+### 1. Run PHPCS and PHPUnit
+```bash
+composer lint         # MUST pass with zero errors
+npm run env-test      # MUST pass all tests
+```
+Fix any failures before proceeding. Do not create a PR with failing checks.
+
+### 2. Changelog entry
+Every PR **MUST** either:
+- Include a changelog file in `.github/changelog/` (see [Changelog](#changelog) below), **OR**
+- Add the `Skip Changelog` label to the PR
+
+If neither is present, **stop and ask** the user which they prefer before creating the PR.
+
+### 3. Code review
+Delegate to the **code-review** agent to review all changes on the branch. Address any critical issues before proceeding.
 
 ## PR Creation
 
 **Every PR must:**
 - Assign `@me`
 - Include changelog entry OR "Skip Changelog" label
-- Pass CI checks
+- Pass PHPCS and PHPUnit (verified above)
 - Merge cleanly with trunk
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@ WordPress plugin that publishes posts to AT Protocol in both `app.bsky.feed.post
 **Do NOT:**
 - Edit WordPress core files
 - Hardcode new version numbers in changelog messages
+- Create a PR without running `composer lint` and `npm run env-test` first
+- Create a PR without a changelog entry in `.github/changelog/` or a "Skip Changelog" label
 
 ## Directory Structure
 


### PR DESCRIPTION
## Proposed changes:
* Update the PR skill (`.agents/skills/pr/SKILL.md`) to require running `composer lint` and `npm run env-test` before creating a PR.
* Require a changelog entry in `.github/changelog/` or explicit confirmation to add the "Skip Changelog" label.
* Add matching "Do NOT" rules to `AGENTS.md`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
* Documentation-only change. Verify the PR skill instructions in `.agents/skills/pr/SKILL.md` read correctly.