### PR TITLE
Add domain handle verification via /.well-known/atproto-did

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -32,7 +32,7 @@ Every PR **MUST** either:
 - Include a changelog file in `.github/changelog/` (see [Changelog](#changelog) below), **OR**
 - Add the `Skip Changelog` label to the PR
 
-If neither is present, **stop and ask** the user which they prefer before creating the PR.
+**Add the changelog entry as part of your initial commit, not after the PR is created.** If neither changelog nor label is present, **stop and ask** the user which they prefer before creating the PR.
 
 ### 3. Code review
 Delegate to the **code-review** agent to review all changes on the branch. Address any critical issues before proceeding.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr
-description: INVOKE THIS SKILL before creating any PR to ensure compliance with branch naming and reviewer assignment.
+description: MUST be invoked before creating any PR, pushing a branch for review, or running `gh pr create`. Covers changelog entries, branch naming, PHPCS/PHPUnit checks, and reviewer assignment.
 ---
 
 Read `.agents/skills/pr/SKILL.md` for full instructions.

--- a/.github/changelog/wellknown-atproto-did
+++ b/.github/changelog/wellknown-atproto-did
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Use your WordPress domain as your Bluesky handle with automatic domain verification.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,8 @@ Test files live in `tests/phpunit/tests/` mirroring `includes/` structure. Files
 
 **Publisher** — Atomic batch `applyWrites` for both bsky post + standard.site document. See `includes/class-publisher.php`.
 
+**Well-known endpoints** — Rewrite rules + `template_redirect` handlers in `Atmosphere` class serve `/.well-known/atproto-did` (domain handle verification) and `/.well-known/site.standard.publication` (publication AT-URI). All share the `atmosphere_wellknown` query var.
+
 ## Release Process
 
 Build a release ZIP with only production dependencies:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,9 @@ WordPress plugin that publishes posts to AT Protocol in both `app.bsky.feed.post
 
 **Tech stack:** PHP 8.2+, WordPress 6.2+, wp-env for local dev, PHPUnit for tests, Jetpack Changelogger for changelog management.
 
+**ALWAYS:**
+- Add a changelog entry in `.github/changelog/` as part of your initial commit — not after the PR is created. See the **pr** skill for format and end-user writing guidelines.
+
 **Do NOT:**
 - Edit WordPress core files
 - Hardcode new version numbers in changelog messages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,6 @@ WordPress plugin that publishes posts to AT Protocol in both `app.bsky.feed.post
 
 **Tech stack:** PHP 8.2+, WordPress 6.2+, wp-env for local dev, PHPUnit for tests, Jetpack Changelogger for changelog management.
 
-**ALWAYS:**
-- Add a changelog entry in `.github/changelog/` as part of your initial commit — not after the PR is created. See the **pr** skill for format and end-user writing guidelines.
-
 **Do NOT:**
 - Edit WordPress core files
 - Hardcode new version numbers in changelog messages

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The plugin uses native AT Protocol OAuth with PKCE and DPoP — no third-party p
 - **standard.site records** — Create `site.standard.publication` and `site.standard.document` records on your PDS.
 - **Facet detection** — Automatically detects links, mentions, and hashtags in post content.
 - **Per-post control** — Enable or disable publishing for individual posts via a meta box.
+- **Domain handle verification** — Use your WordPress domain as your Bluesky handle via `/.well-known/atproto-did`.
 - **Backfill** — Sync existing published posts to AT Protocol in bulk.
 
 ## How It Works
@@ -103,6 +104,10 @@ includes/
 ```
 
 ## FAQ
+
+### Can I use my domain as my Bluesky handle?
+
+Yes. Once you connect your account, the plugin serves your DID at `/.well-known/atproto-did`. Go to the Bluesky app settings, choose "Change Handle", select "I have my own domain", and enter your WordPress site's domain. Bluesky will verify it automatically.
 
 ### Do I need a Bluesky account?
 

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -37,8 +37,9 @@ class Atmosphere {
 		// Frontend verification headers.
 		\add_action( 'wp_head', array( $this, 'output_document_link' ) );
 
-		// Well-known publication endpoint.
+		// Well-known endpoints.
 		\add_action( 'init', array( $this, 'register_wellknown_rewrite' ) );
+		\add_action( 'template_redirect', array( $this, 'serve_wellknown_atproto_did' ) );
 		\add_action( 'template_redirect', array( $this, 'serve_wellknown_publication' ) );
 
 		// Plugin integrations.
@@ -104,9 +105,15 @@ class Atmosphere {
 	}
 
 	/**
-	 * Register the rewrite rule for /.well-known/site.standard.publication.
+	 * Register rewrite rules for well-known endpoints.
 	 */
 	public function register_wellknown_rewrite(): void {
+		\add_rewrite_rule(
+			'^\.well-known/atproto-did$',
+			'index.php?atmosphere_wellknown=atproto-did',
+			'top'
+		);
+
 		\add_rewrite_rule(
 			'^\.well-known/site\.standard\.publication$',
 			'index.php?atmosphere_wellknown=publication',
@@ -120,6 +127,30 @@ class Atmosphere {
 				return $vars;
 			}
 		);
+	}
+
+	/**
+	 * Serve the /.well-known/atproto-did response.
+	 *
+	 * Returns the connected DID as plain text so the domain can be
+	 * verified as an AT Protocol handle (domain handle verification).
+	 *
+	 * @see https://atproto.com/specs/handle#handle-resolution
+	 */
+	public function serve_wellknown_atproto_did(): void {
+		if ( \get_query_var( 'atmosphere_wellknown' ) !== 'atproto-did' ) {
+			return;
+		}
+
+		if ( ! is_connected() ) {
+			\status_header( 404 );
+			exit;
+		}
+
+		\status_header( 200 );
+		\header( 'Content-Type: text/plain; charset=utf-8' );
+		echo \esc_html( get_did() );
+		exit;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,7 @@ The plugin uses native AT Protocol OAuth with PKCE and DPoP — no third-party p
 * **standard.site records** — Create `site.standard.publication` and `site.standard.document` records on your PDS.
 * **Facet detection** — Automatically detects links, mentions, and hashtags in post content.
 * **Per-post control** — Enable or disable publishing for individual posts via a meta box.
+* **Domain handle verification** — Use your WordPress domain as your Bluesky handle via `/.well-known/atproto-did`.
 * **Backfill** — Sync existing published posts to AT Protocol in bulk.
 
 = How It Works =
@@ -55,6 +56,10 @@ Each published post creates:
 * A `site.standard.document` record (structured metadata for the ATmosphere).
 
 Your site itself is represented by a `site.standard.publication` record.
+
+= Can I use my domain as my Bluesky handle? =
+
+Yes. Once you connect your account, the plugin serves your DID at `/.well-known/atproto-did`. Go to the Bluesky app settings, choose "Change Handle", select "I have my own domain", and enter your WordPress site's domain. Bluesky will verify it automatically.
 
 = Can I disable Bluesky cross-posting? =
 


### PR DESCRIPTION
## Summary

- Serve the connected DID at `/.well-known/atproto-did` so users can use their WordPress domain as their Bluesky handle.
- Add rewrite rule, handler, and hook wiring in `Atmosphere` main class.
- Update README.md and readme.txt with feature description and FAQ entry.

## How it works

Once a user connects their AT Protocol account via OAuth, the plugin serves their DID (e.g. `did:plc:...`) as plain text at `/.well-known/atproto-did`. This allows Bluesky to verify the domain as the user's handle, per the [AT Protocol handle resolution spec](https://atproto.com/specs/handle#handle-resolution).

Returns 404 if no account is connected.

## Test plan

- [ ] Connect an AT Protocol account via OAuth.
- [ ] Visit `/.well-known/atproto-did` and confirm it returns the connected DID as plain text.
- [ ] Disconnect the account and confirm the endpoint returns 404.
- [ ] In the Bluesky app, change handle to the WordPress domain and verify it resolves.
- [ ] Flush permalinks if needed (Settings → Permalinks → Save).