### PR TITLE
Install Composer dependencies in release script

### DIFF
--- a/.github/changelog/release-composer-install
+++ b/.github/changelog/release-composer-install
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fixed
+
+Install production Composer dependencies before building release packages.

--- a/bin/release.js
+++ b/bin/release.js
@@ -282,9 +282,16 @@ async function createRelease() {
 		] );
 	} );
 
-	// Stage and commit changes
+	// Install production-only Composer dependencies
+	exec( 'composer run release' );
+
+	// Stage and commit changes (force-add vendor/ which is gitignored)
 	exec( 'git add .' );
+	exec( 'git add --force vendor/' );
 	exec( `git commit -m "Release ${ version }"` );
+
+	// Restore dev dependencies for continued development
+	exec( 'composer install' );
 
 	// Push to remote
 	exec( `git push -u origin ${ branchName }` );


### PR DESCRIPTION
Fixes #

## Proposed changes:
* Add `composer run release` step to install production-only Composer dependencies before building a release commit.
* Force-add `vendor/` (which is gitignored) so production dependencies are included in the release branch.
* Restore dev dependencies after the release commit so the working tree remains usable.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Run `node bin/release.js` and verify the release commit includes the `vendor/` directory with only production dependencies.
* After the script completes, verify dev dependencies are restored locally.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Install production Composer dependencies before building release packages.

</details>