### PR TITLE
Move async hook registration into init()

### DIFF
--- a/.github/changelog/fix-async-hooks-registration
+++ b/.github/changelog/fix-async-hooks-registration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Move scheduled action hook registration into the standard plugin initialization flow.

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -65,6 +65,9 @@ class Atmosphere {
 		if ( ! \wp_next_scheduled( 'atmosphere_refresh_token' ) && is_connected() ) {
 			\wp_schedule_event( \time(), 'twicedaily', 'atmosphere_refresh_token' );
 		}
+
+		// Async action hooks (called by WP-Cron).
+		self::register_async_hooks();
 	}
 
 	/**
@@ -366,6 +369,3 @@ class Atmosphere {
 		);
 	}
 }
-
-// Register async hooks outside the class so they're available to WP-Cron.
-Atmosphere::register_async_hooks();


### PR DESCRIPTION
## Proposed changes:
* Move WP-Cron action hook registration from file scope into `Atmosphere::init()`, which runs on `plugins_loaded`.

The async hooks were registered via a bare `Atmosphere::register_async_hooks()` call outside the class at file-include time. Since `plugins_loaded` fires during WP-Cron requests before scheduled actions are processed, there is no need for the file-scope call.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Publish, update, and delete a post — verify that WP-Cron callbacks (`atmosphere_publish_post`, `atmosphere_update_post`, `atmosphere_delete_records`) still fire correctly.
* Confirm scheduled publication sync and token refresh cron continue to work.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Move scheduled action hook registration into the standard plugin initialization flow.

</details>