### PR TITLE
Fix posts deleted from Bluesky when editing

### DIFF
--- a/.github/changelog/fix-post-update-and-delete-safety
+++ b/.github/changelog/fix-post-update-and-delete-safety
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix published posts being incorrectly deleted from Bluesky when editing.

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -257,8 +257,8 @@ class Atmosphere {
 		} elseif ( 'publish' === $new_status && 'publish' === $old_status ) {
 			// Update.
 			\wp_schedule_single_event( \time(), 'atmosphere_update_post', array( $post->ID ) );
-		} elseif ( 'publish' !== $new_status ) {
-			// Any transition away from publish (or trashing a draft that has TIDs).
+		} elseif ( 'publish' === $old_status && 'publish' !== $new_status ) {
+			// Genuine unpublish — transitioning away from publish.
 			$bsky_tid = \get_post_meta( $post->ID, Transformer\Post::META_TID, true );
 			$doc_tid  = \get_post_meta( $post->ID, Transformer\Document::META_TID, true );
 			if ( $bsky_tid || $doc_tid ) {

--- a/includes/class-publisher.php
+++ b/includes/class-publisher.php
@@ -88,6 +88,10 @@ class Publisher {
 		$bsky_tid = \get_post_meta( $post->ID, Post::META_TID, true );
 		$doc_tid  = \get_post_meta( $post->ID, Document::META_TID, true );
 
+		if ( ! $bsky_tid || ! $doc_tid ) {
+			return new \WP_Error( 'atmosphere_missing_tid', \__( 'Record URIs exist but TIDs are missing.', 'atmosphere' ) );
+		}
+
 		$bsky_transformer = new Post( $post );
 		$doc_transformer  = new Document( $post );
 

--- a/includes/class-publisher.php
+++ b/includes/class-publisher.php
@@ -77,13 +77,16 @@ class Publisher {
 	 * @return array|\WP_Error
 	 */
 	public static function update( \WP_Post $post ): array|\WP_Error {
-		$bsky_tid = \get_post_meta( $post->ID, Post::META_TID, true );
-		$doc_tid  = \get_post_meta( $post->ID, Document::META_TID, true );
+		$bsky_uri = \get_post_meta( $post->ID, Post::META_URI, true );
+		$doc_uri  = \get_post_meta( $post->ID, Document::META_URI, true );
 
-		if ( ! $bsky_tid || ! $doc_tid ) {
+		if ( ! $bsky_uri || ! $doc_uri ) {
 			// Not yet published — do a fresh publish instead.
 			return self::publish( $post );
 		}
+
+		$bsky_tid = \get_post_meta( $post->ID, Post::META_TID, true );
+		$doc_tid  = \get_post_meta( $post->ID, Document::META_TID, true );
 
 		$bsky_transformer = new Post( $post );
 		$doc_transformer  = new Document( $post );
@@ -110,6 +113,9 @@ class Publisher {
 		}
 
 		self::store_results( $post->ID, $result, $bsky_transformer, $doc_transformer );
+
+		// Update document with bsky post reference (CID may have changed).
+		self::update_document_bsky_ref( $post, $doc_transformer );
 
 		return $result;
 	}

--- a/tests/phpunit/tests/class-test-publisher.php
+++ b/tests/phpunit/tests/class-test-publisher.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Tests for the Publisher class.
+ *
+ * Verifies publish, update, and delete flows including the
+ * URI-based existence check and bsky cross-reference refresh.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group publisher
+ */
+
+namespace Atmosphere\Tests;
+
+use WP_UnitTestCase;
+use Atmosphere\Publisher;
+use Atmosphere\Transformer\Post;
+use Atmosphere\Transformer\Document;
+
+/**
+ * Publisher tests.
+ */
+class Test_Publisher extends WP_UnitTestCase {
+
+	/**
+	 * Set up each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		// Simulate a connected state with a DID.
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'access_token' => 'encrypted-token',
+				'did'          => 'did:plc:test123',
+				'pds_endpoint' => 'https://pds.example.com',
+				'dpop_jwk'     => 'encrypted-jwk',
+			)
+		);
+		\update_option( 'atmosphere_did', 'did:plc:test123' );
+	}
+
+	/**
+	 * Tear down each test.
+	 */
+	public function tear_down(): void {
+		\delete_option( 'atmosphere_connection' );
+		\delete_option( 'atmosphere_did' );
+		\delete_option( 'atmosphere_publication_tid' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that update() falls back to publish() when no URIs exist.
+	 *
+	 * TIDs may exist (generated locally by get_rkey) but URIs are
+	 * only set after a successful API call. Missing URIs means the
+	 * records were never created on the PDS.
+	 */
+	public function test_update_falls_back_to_publish_without_uris() {
+		$post = self::factory()->post->create_and_get(
+			array( 'post_status' => 'publish' )
+		);
+
+		// Set TIDs but no URIs — simulates a failed initial publish.
+		\update_post_meta( $post->ID, Post::META_TID, 'bsky-tid-123' );
+		\update_post_meta( $post->ID, Document::META_TID, 'doc-tid-456' );
+
+		/*
+		 * The publish fallback will try to call API::apply_writes()
+		 * which makes an HTTP request. The bootstrap blocks all HTTP,
+		 * so we'll get a WP_Error back — but the important thing is
+		 * that it attempted a publish (create), not an update.
+		 */
+		$result = Publisher::update( $post );
+
+		$this->assertWPError( $result );
+	}
+
+	/**
+	 * Test that update() falls back to publish() when only bsky URI exists.
+	 */
+	public function test_update_falls_back_without_doc_uri() {
+		$post = self::factory()->post->create_and_get(
+			array( 'post_status' => 'publish' )
+		);
+
+		\update_post_meta( $post->ID, Post::META_TID, 'bsky-tid-123' );
+		\update_post_meta( $post->ID, Document::META_TID, 'doc-tid-456' );
+		\update_post_meta( $post->ID, Post::META_URI, 'at://did:plc:test/app.bsky.feed.post/bsky-tid-123' );
+		// No document URI.
+
+		$result = Publisher::update( $post );
+
+		$this->assertWPError( $result );
+	}
+
+	/**
+	 * Test that update() returns an error when URIs exist but TIDs are missing.
+	 */
+	public function test_update_errors_with_uris_but_no_tids() {
+		$post = self::factory()->post->create_and_get(
+			array( 'post_status' => 'publish' )
+		);
+
+		// URIs without TIDs — should not happen, but guard against it.
+		\update_post_meta( $post->ID, Post::META_URI, 'at://did:plc:test/app.bsky.feed.post/bsky-tid-123' );
+		\update_post_meta( $post->ID, Document::META_URI, 'at://did:plc:test/site.standard.document/doc-tid-456' );
+
+		$result = Publisher::update( $post );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'atmosphere_missing_tid', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that update() sends applyWrites#update when URIs and TIDs exist.
+	 */
+	public function test_update_sends_update_writes() {
+		$post = self::factory()->post->create_and_get(
+			array( 'post_status' => 'publish' )
+		);
+
+		\update_post_meta( $post->ID, Post::META_TID, 'bsky-tid-123' );
+		\update_post_meta( $post->ID, Document::META_TID, 'doc-tid-456' );
+		\update_post_meta( $post->ID, Post::META_URI, 'at://did:plc:test/app.bsky.feed.post/bsky-tid-123' );
+		\update_post_meta( $post->ID, Document::META_URI, 'at://did:plc:test/site.standard.document/doc-tid-456' );
+
+		/*
+		 * Intercept the HTTP request to verify the payload contains
+		 * #update operations (not #create or #delete).
+		 */
+		$captured_body = null;
+
+		\add_filter(
+			'pre_http_request',
+			static function ( $response, $args, $url ) use ( &$captured_body ) {
+				if ( false !== \strpos( $url, 'applyWrites' ) ) {
+					$captured_body = \json_decode( $args['body'], true );
+
+					return array(
+						'response' => array( 'code' => 200 ),
+						'body'     => \wp_json_encode(
+							array(
+								'results' => array(
+									array(
+										'uri' => 'at://did:plc:test/app.bsky.feed.post/bsky-tid-123',
+										'cid' => 'bafyreib-new-bsky-cid',
+									),
+									array(
+										'uri' => 'at://did:plc:test/site.standard.document/doc-tid-456',
+										'cid' => 'bafyreib-new-doc-cid',
+									),
+								),
+							)
+						),
+					);
+				}
+
+				return $response;
+			},
+			10,
+			3
+		);
+
+		$result = Publisher::update( $post );
+
+		\remove_all_filters( 'pre_http_request' );
+
+		/*
+		 * The API call requires a valid access token and DPoP proof,
+		 * which we can't easily mock. If the request reached our
+		 * filter, captured_body will be set. If it failed before
+		 * reaching the HTTP layer (auth errors), we still verify the
+		 * flow didn't crash.
+		 */
+		if ( null !== $captured_body ) {
+			$this->assertIsArray( $captured_body['writes'] );
+			$this->assertCount( 2, $captured_body['writes'] );
+			$this->assertSame( 'com.atproto.repo.applyWrites#update', $captured_body['writes'][0]['$type'] );
+			$this->assertSame( 'com.atproto.repo.applyWrites#update', $captured_body['writes'][1]['$type'] );
+			$this->assertSame( 'bsky-tid-123', $captured_body['writes'][0]['rkey'] );
+			$this->assertSame( 'doc-tid-456', $captured_body['writes'][1]['rkey'] );
+		} else {
+			// Auth layer blocked the request — still verify no crash.
+			$this->assertWPError( $result );
+		}
+	}
+
+	/**
+	 * Test that delete() returns error when not connected.
+	 *
+	 * The API layer requires a valid OAuth connection. Without one,
+	 * delete() returns a WP_Error and post meta is preserved.
+	 */
+	public function test_delete_preserves_meta_on_api_error() {
+		$post = self::factory()->post->create_and_get(
+			array( 'post_status' => 'trash' )
+		);
+
+		\update_post_meta( $post->ID, Post::META_TID, 'bsky-tid-123' );
+		\update_post_meta( $post->ID, Document::META_TID, 'doc-tid-456' );
+
+		$result = Publisher::delete( $post );
+
+		// API call will fail (no valid OAuth), meta should be preserved.
+		$this->assertWPError( $result );
+		$this->assertSame( 'bsky-tid-123', \get_post_meta( $post->ID, Post::META_TID, true ) );
+		$this->assertSame( 'doc-tid-456', \get_post_meta( $post->ID, Document::META_TID, true ) );
+	}
+
+	/**
+	 * Test that delete() returns error when no TIDs exist.
+	 */
+	public function test_delete_errors_without_tids() {
+		$post = self::factory()->post->create_and_get(
+			array( 'post_status' => 'trash' )
+		);
+
+		$result = Publisher::delete( $post );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'atmosphere_not_published', $result->get_error_code() );
+	}
+}

--- a/tests/phpunit/tests/class-test-status-change.php
+++ b/tests/phpunit/tests/class-test-status-change.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * Tests for status change handling in the Atmosphere class.
+ *
+ * Verifies that post status transitions schedule the correct
+ * async hooks (publish, update, delete) and that non-publish
+ * transitions do not accidentally delete AT Protocol records.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group status-change
+ */
+
+namespace Atmosphere\Tests;
+
+use WP_UnitTestCase;
+use Atmosphere\Atmosphere;
+use Atmosphere\Transformer\Post;
+use Atmosphere\Transformer\Document;
+
+/**
+ * Status change tests.
+ */
+class Test_Status_Change extends WP_UnitTestCase {
+
+	/**
+	 * Atmosphere instance.
+	 *
+	 * @var Atmosphere
+	 */
+	private Atmosphere $atmosphere;
+
+	/**
+	 * Set up each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->atmosphere = new Atmosphere();
+
+		// Simulate a connected state.
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'access_token' => 'encrypted-token',
+				'did'          => 'did:plc:test123',
+			)
+		);
+	}
+
+	/**
+	 * Tear down each test.
+	 */
+	public function tear_down(): void {
+		\delete_option( 'atmosphere_connection' );
+
+		// Clear any scheduled events.
+		\wp_clear_scheduled_hook( 'atmosphere_publish_post' );
+		\wp_clear_scheduled_hook( 'atmosphere_update_post' );
+		\wp_clear_scheduled_hook( 'atmosphere_delete_records' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Reset the atmosphere_publishing action counter.
+	 *
+	 * The plugin's own transition_post_status hook fires when the
+	 * factory creates a test post, incrementing the counter. Reset
+	 * it before calling on_status_change() directly.
+	 */
+	private function reset_publishing_action(): void {
+		global $wp_actions;
+		unset( $wp_actions['atmosphere_publishing'] );
+	}
+
+	/**
+	 * Test that draft → publish schedules a publish event.
+	 */
+	public function test_draft_to_publish_schedules_publish() {
+		$post = self::factory()->post->create_and_get(
+			array( 'post_status' => 'publish' )
+		);
+
+		$this->reset_publishing_action();
+		$this->atmosphere->on_status_change( 'publish', 'draft', $post );
+
+		$this->assertNotFalse(
+			\wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) ),
+			'Expected atmosphere_publish_post to be scheduled.'
+		);
+	}
+
+	/**
+	 * Test that publish → publish schedules an update event.
+	 */
+	public function test_publish_to_publish_schedules_update() {
+		$post = self::factory()->post->create_and_get(
+			array( 'post_status' => 'publish' )
+		);
+
+		$this->reset_publishing_action();
+		$this->atmosphere->on_status_change( 'publish', 'publish', $post );
+
+		$this->assertNotFalse(
+			\wp_next_scheduled( 'atmosphere_update_post', array( $post->ID ) ),
+			'Expected atmosphere_update_post to be scheduled.'
+		);
+	}
+
+	/**
+	 * Test that publish → draft schedules a delete event.
+	 */
+	public function test_publish_to_draft_schedules_delete() {
+		$post = self::factory()->post->create_and_get(
+			array( 'post_status' => 'draft' )
+		);
+
+		\update_post_meta( $post->ID, Post::META_TID, 'bsky-tid-123' );
+		\update_post_meta( $post->ID, Document::META_TID, 'doc-tid-456' );
+
+		$this->reset_publishing_action();
+		$this->atmosphere->on_status_change( 'draft', 'publish', $post );
+
+		$this->assertNotFalse(
+			\wp_next_scheduled( 'atmosphere_delete_records', array( 'bsky-tid-123', 'doc-tid-456' ) ),
+			'Expected atmosphere_delete_records to be scheduled.'
+		);
+	}
+
+	/**
+	 * Test that publish → trash schedules a delete event.
+	 */
+	public function test_publish_to_trash_schedules_delete() {
+		$post = self::factory()->post->create_and_get(
+			array( 'post_status' => 'trash' )
+		);
+
+		\update_post_meta( $post->ID, Post::META_TID, 'bsky-tid-123' );
+		\update_post_meta( $post->ID, Document::META_TID, 'doc-tid-456' );
+
+		$this->reset_publishing_action();
+		$this->atmosphere->on_status_change( 'trash', 'publish', $post );
+
+		$this->assertNotFalse(
+			\wp_next_scheduled( 'atmosphere_delete_records', array( 'bsky-tid-123', 'doc-tid-456' ) ),
+			'Expected atmosphere_delete_records to be scheduled.'
+		);
+	}
+
+	/**
+	 * Test that draft → draft does NOT schedule a delete event.
+	 *
+	 * This is the key regression test: previously, any non-publish
+	 * new_status would schedule a delete if TIDs existed.
+	 */
+	public function test_draft_to_draft_does_not_schedule_delete() {
+		$post = self::factory()->post->create_and_get(
+			array( 'post_status' => 'draft' )
+		);
+
+		\update_post_meta( $post->ID, Post::META_TID, 'bsky-tid-123' );
+		\update_post_meta( $post->ID, Document::META_TID, 'doc-tid-456' );
+
+		$this->reset_publishing_action();
+		$this->atmosphere->on_status_change( 'draft', 'draft', $post );
+
+		$this->assertFalse(
+			\wp_next_scheduled( 'atmosphere_delete_records', array( 'bsky-tid-123', 'doc-tid-456' ) ),
+			'Draft → draft must NOT schedule a delete.'
+		);
+	}
+
+	/**
+	 * Test that pending → pending does NOT schedule a delete event.
+	 */
+	public function test_pending_to_pending_does_not_schedule_delete() {
+		$post = self::factory()->post->create_and_get(
+			array( 'post_status' => 'pending' )
+		);
+
+		\update_post_meta( $post->ID, Post::META_TID, 'bsky-tid-123' );
+		\update_post_meta( $post->ID, Document::META_TID, 'doc-tid-456' );
+
+		$this->reset_publishing_action();
+		$this->atmosphere->on_status_change( 'pending', 'pending', $post );
+
+		$this->assertFalse(
+			\wp_next_scheduled( 'atmosphere_delete_records', array( 'bsky-tid-123', 'doc-tid-456' ) ),
+			'Pending → pending must NOT schedule a delete.'
+		);
+	}
+
+	/**
+	 * Test that draft → pending does NOT schedule a delete event.
+	 */
+	public function test_draft_to_pending_does_not_schedule_delete() {
+		$post = self::factory()->post->create_and_get(
+			array( 'post_status' => 'pending' )
+		);
+
+		\update_post_meta( $post->ID, Post::META_TID, 'bsky-tid-123' );
+		\update_post_meta( $post->ID, Document::META_TID, 'doc-tid-456' );
+
+		$this->reset_publishing_action();
+		$this->atmosphere->on_status_change( 'pending', 'draft', $post );
+
+		$this->assertFalse(
+			\wp_next_scheduled( 'atmosphere_delete_records', array( 'bsky-tid-123', 'doc-tid-456' ) ),
+			'Draft → pending must NOT schedule a delete.'
+		);
+	}
+
+	/**
+	 * Test that publish → draft without TIDs does NOT schedule a delete.
+	 */
+	public function test_unpublish_without_tids_does_not_schedule_delete() {
+		$post = self::factory()->post->create_and_get(
+			array( 'post_status' => 'draft' )
+		);
+
+		$this->reset_publishing_action();
+		$this->atmosphere->on_status_change( 'draft', 'publish', $post );
+
+		$this->assertFalse(
+			\wp_next_scheduled( 'atmosphere_delete_records', array( '', '' ) ),
+			'Unpublish without TIDs must NOT schedule a delete.'
+		);
+	}
+
+	/**
+	 * Test that non-syncable post types are ignored.
+	 */
+	public function test_non_syncable_post_type_ignored() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_status' => 'publish',
+				'post_type'   => 'page',
+			)
+		);
+
+		$this->reset_publishing_action();
+		$this->atmosphere->on_status_change( 'publish', 'draft', $post );
+
+		$this->assertFalse(
+			\wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) ),
+			'Non-syncable post types must be ignored.'
+		);
+	}
+
+	/**
+	 * Test that disconnected state prevents scheduling.
+	 */
+	public function test_disconnected_state_prevents_scheduling() {
+		\delete_option( 'atmosphere_connection' );
+
+		$post = self::factory()->post->create_and_get(
+			array( 'post_status' => 'publish' )
+		);
+
+		$this->reset_publishing_action();
+		$this->atmosphere->on_status_change( 'publish', 'draft', $post );
+
+		$this->assertFalse(
+			\wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) ),
+			'Disconnected state must prevent scheduling.'
+		);
+	}
+}


### PR DESCRIPTION
## Proposed changes:
* Fix the delete guard in `on_status_change()` to only trigger when a post is genuinely unpublished (`old_status=publish → new_status≠publish`). Previously, any non-publish status transition with stored TIDs would schedule a deletion — this caused posts to be deleted from Bluesky when editing.
* Check URIs instead of TIDs in `Publisher::update()` to determine if records exist on the PDS. TIDs are generated locally before the API call and are always present, making them unreliable as an existence check.
* Call `update_document_bsky_ref()` after updates to keep the document's bsky cross-reference CID fresh.
* Add a defensive guard against missing TIDs when URIs exist.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Publish a post — verify it appears on Bluesky.
* Edit the post and click Update — verify the post is NOT deleted from Bluesky and the content is updated.
* Move a published post to Draft — verify the records ARE deleted from Bluesky.
* Trash a published post — verify the records ARE deleted from Bluesky.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix published posts being incorrectly deleted from Bluesky when editing.

</details>