### PR TITLE
Replace JWT library with native OpenSSL and add custom autoloader

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,7 @@
 /.gitattributes   export-ignore
 /.gitignore       export-ignore
 /.wp-env.json     export-ignore
+/composer.json    export-ignore
 /composer.lock    export-ignore
 /package.json     export-ignore
 /package-lock.json export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 /.claude         export-ignore
 /.github         export-ignore
 /bin             export-ignore
+/vendor          export-ignore
 /docs            export-ignore
 /node_modules    export-ignore
 /tests           export-ignore

--- a/.github/changelog/update-custom-autoloader
+++ b/.github/changelog/update-custom-autoloader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace third-party JWT library with native OpenSSL signing and add a custom class autoloader.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ The plugin uses native AT Protocol OAuth with PKCE and DPoP — no third-party p
 
 - PHP 8.2+
 - WordPress 6.2+
-- Composer
 
 ## Installation
 
@@ -39,13 +38,8 @@ The plugin uses native AT Protocol OAuth with PKCE and DPoP — no third-party p
    ```bash
    git clone https://github.com/pfefferle/atmosphere.git wp-content/plugins/atmosphere
    ```
-2. Install dependencies:
-   ```bash
-   cd wp-content/plugins/atmosphere
-   composer install --no-dev
-   ```
-3. Activate the plugin through the "Plugins" menu in WordPress.
-4. Go to **Settings → ATmosphere** and connect your AT Protocol account.
+2. Activate the plugin through the "Plugins" menu in WordPress.
+3. Go to **Settings → ATmosphere** and connect your AT Protocol account.
 
 ## Development
 

--- a/atmosphere.php
+++ b/atmosphere.php
@@ -30,8 +30,8 @@ namespace Atmosphere;
  */
 require_once ATMOSPHERE_PLUGIN_DIR . 'includes/class-autoloader.php';
 
-Autoloader::register_path( __NAMESPACE__, ATMOSPHERE_PLUGIN_DIR . 'includes' );
 Autoloader::register_path( __NAMESPACE__ . '\Integrations', ATMOSPHERE_PLUGIN_DIR . 'integrations' );
+Autoloader::register_path( __NAMESPACE__, ATMOSPHERE_PLUGIN_DIR . 'includes' );
 
 // Helper functions.
 require_once ATMOSPHERE_PLUGIN_DIR . 'includes/functions.php';

--- a/atmosphere.php
+++ b/atmosphere.php
@@ -25,17 +25,15 @@ namespace Atmosphere;
 \define( 'ATMOSPHERE_PLUGIN_FILE', __FILE__ );
 
 /*
- * Composer autoloader — prefer the plugin's own vendor (standalone
- * install / release ZIP), then try the site-level autoloader
- * (installed as a Composer dependency).
+ * Custom autoloader for Atmosphere classes — maps the Atmosphere
+ * namespace to includes/ using WordPress filename conventions.
  */
-if ( \file_exists( ATMOSPHERE_PLUGIN_DIR . 'vendor/autoload.php' ) ) {
-	require_once ATMOSPHERE_PLUGIN_DIR . 'vendor/autoload.php';
-} elseif ( \file_exists( ABSPATH . 'vendor/autoload.php' ) ) {
-	require_once ABSPATH . 'vendor/autoload.php';
-}
+require_once ATMOSPHERE_PLUGIN_DIR . 'includes/class-autoloader.php';
 
-// Helper functions (loaded after ABSPATH is available).
+Autoloader::register_path( __NAMESPACE__, ATMOSPHERE_PLUGIN_DIR . 'includes' );
+Autoloader::register_path( __NAMESPACE__ . '\Integrations', ATMOSPHERE_PLUGIN_DIR . 'integrations' );
+
+// Helper functions.
 require_once ATMOSPHERE_PLUGIN_DIR . 'includes/functions.php';
 
 /**

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
 		}
 	],
 	"require": {
-		"php": ">=8.2",
-		"web-token/jwt-library": "^4.1"
+		"php": ">=8.2"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9",
@@ -25,12 +24,7 @@
 		"phpcsstandards/phpcsextra": "^1.1.0",
 		"automattic/jetpack-changelogger": "^6.0"
 	},
-	"autoload": {
-		"classmap": [
-			"includes/",
-			"integrations/"
-		]
-	},
+	"autoload": {},
 	"scripts": {
 		"test": [
 			"composer install",
@@ -54,10 +48,7 @@
 			"composer install",
 			"vendor/bin/changelogger write --add-pr-num"
 		],
-		"release": [
-			"@composer install --no-dev --optimize-autoloader",
-			"@composer dump-autoload --optimize --no-dev"
-		]
+		"release": []
 	},
 	"extra": {
 		"changelogger": {

--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,7 @@
 		"changelog:write": [
 			"composer install",
 			"vendor/bin/changelogger write --add-pr-num"
-		],
-		"release": []
+		]
 	},
 	"extra": {
 		"changelogger": {

--- a/includes/class-autoloader.php
+++ b/includes/class-autoloader.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Autoloader for Atmosphere.
+ *
+ * PSR-4-like autoloader that respects WordPress's filename conventions
+ * (lowercase, hyphenated, `class-` / `interface-` / `trait-` prefixed).
+ *
+ * Based on the ActivityPub plugin's autoloader.
+ *
+ * @package Atmosphere
+ */
+
+namespace Atmosphere;
+
+/**
+ * An Autoloader that respects WordPress's filename standards.
+ */
+class Autoloader {
+
+	/**
+	 * Namespace separator.
+	 */
+	const NS_SEPARATOR = '\\';
+
+	/**
+	 * The prefix to compare classes against.
+	 *
+	 * @var string
+	 */
+	protected $prefix;
+
+	/**
+	 * Length of the prefix string.
+	 *
+	 * @var int
+	 */
+	protected $prefix_length;
+
+	/**
+	 * Path to the file to be loaded.
+	 *
+	 * @var string
+	 */
+	protected $path;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $prefix Namespace prefix all classes have in common.
+	 * @param string $path   Path to the files to be loaded.
+	 */
+	public function __construct( $prefix, $path ) {
+		$this->prefix        = $prefix;
+		$this->prefix_length = \strlen( $prefix );
+		$this->path          = \rtrim( $path, '/' ) . '/';
+	}
+
+	/**
+	 * Registers Autoloader's autoload function.
+	 *
+	 * @param string $prefix Namespace prefix all classes have in common.
+	 * @param string $path   Path to the files to be loaded.
+	 */
+	public static function register_path( $prefix, $path ) {
+		$loader = new self( $prefix, $path );
+		\spl_autoload_register( array( $loader, 'load' ) );
+	}
+
+	/**
+	 * Loads a class if its namespace starts with `$this->prefix`.
+	 *
+	 * @param string $class_name The class to be loaded.
+	 */
+	public function load( $class_name ) {
+		if ( \strpos( $class_name, $this->prefix . self::NS_SEPARATOR ) !== 0 ) {
+			return;
+		}
+
+		// Strip prefix from the start (ala PSR-4).
+		$class_name = \substr( $class_name, $this->prefix_length + 1 );
+		$class_name = \strtolower( $class_name );
+		$dir        = '';
+
+		$last_ns_pos = \strripos( $class_name, self::NS_SEPARATOR );
+		if ( false !== $last_ns_pos ) {
+			$namespace  = \substr( $class_name, 0, $last_ns_pos );
+			$namespace  = \str_replace( '_', '-', $namespace );
+			$class_name = \substr( $class_name, $last_ns_pos + 1 );
+			$dir        = \str_replace( self::NS_SEPARATOR, DIRECTORY_SEPARATOR, $namespace ) . DIRECTORY_SEPARATOR;
+		}
+
+		$class_name = \str_replace( '_', '-', $class_name );
+
+		$path = $this->path . $dir . 'class-' . $class_name . '.php';
+
+		if ( ! \file_exists( $path ) ) {
+			$path = $this->path . $dir . 'interface-' . $class_name . '.php';
+		}
+
+		if ( ! \file_exists( $path ) ) {
+			$path = $this->path . $dir . 'trait-' . $class_name . '.php';
+		}
+
+		if ( \file_exists( $path ) ) {
+			require_once $path;
+		}
+	}
+}

--- a/includes/oauth/class-dpop.php
+++ b/includes/oauth/class-dpop.php
@@ -2,7 +2,7 @@
 /**
  * DPoP (Demonstration of Proof-of-Possession) proof generation.
  *
- * Produces ES256-signed JWT proofs directly using the web-token/jwt-library,
+ * Produces ES256-signed JWT proofs using PHP's native OpenSSL extension,
  * as required by AT Protocol auth servers and PDS instances.
  *
  * @package Atmosphere
@@ -12,14 +12,11 @@ namespace Atmosphere\OAuth;
 
 \defined( 'ABSPATH' ) || exit;
 
-use Jose\Component\Core\AlgorithmManager;
-use Jose\Component\Core\JWK;
-use Jose\Component\Signature\Algorithm\ES256;
-use Jose\Component\Signature\JWSBuilder;
-use Jose\Component\Signature\Serializer\CompactSerializer;
-
 /**
  * Static helper for DPoP proof creation.
+ *
+ * Produces ES256-signed JWTs using PHP's OpenSSL extension directly,
+ * avoiding any third-party JWT library dependency.
  */
 class DPoP {
 
@@ -98,18 +95,7 @@ class DPoP {
 				$payload['ath'] = self::base64url( \hash( 'sha256', $access_token, true ) );
 			}
 
-			$algorithm_manager = new AlgorithmManager( array( new ES256() ) );
-			$jws_builder       = new JWSBuilder( $algorithm_manager );
-
-			$jws = $jws_builder
-				->create()
-				->withPayload( (string) \wp_json_encode( $payload ) )
-				->addSignature( new JWK( $jwk ), $header )
-				->build();
-
-			$serializer = new CompactSerializer();
-
-			return $serializer->serialize( $jws, 0 );
+			return self::sign_es256( $header, $payload, $jwk );
 		} catch ( \Throwable $e ) {
 			\wp_trigger_error( __METHOD__, 'DPoP proof generation failed: ' . $e->getMessage() );
 			return false;
@@ -125,6 +111,215 @@ class DPoP {
 	 */
 	public static function persist_nonce( array $jwk, string $url, string $nonce ): void {
 		Nonce_Storage::set( $url, $nonce );
+	}
+
+	/**
+	 * Sign a JWT with ES256 (ECDSA using P-256 and SHA-256).
+	 *
+	 * Produces a compact-serialized JWS: base64url(header).base64url(payload).base64url(signature).
+	 *
+	 * @param array $header  JWT header claims.
+	 * @param array $payload JWT payload claims.
+	 * @param array $jwk     JWK array with private key material (d, x, y, crv).
+	 * @return string|false Compact-serialized JWT, or false on error.
+	 */
+	private static function sign_es256( array $header, array $payload, array $jwk ): string|false {
+		$header_b64    = self::base64url( (string) \wp_json_encode( $header ) );
+		$payload_b64   = self::base64url( (string) \wp_json_encode( $payload ) );
+		$signing_input = $header_b64 . '.' . $payload_b64;
+
+		// Reconstruct PEM from JWK parameters.
+		$pem = self::jwk_to_pem( $jwk );
+		if ( false === $pem ) {
+			return false;
+		}
+
+		$key = \openssl_pkey_get_private( $pem );
+		if ( false === $key ) {
+			return false;
+		}
+
+		// OpenSSL produces a DER-encoded ASN.1 signature; JWT needs raw R‖S.
+		$der_signature = '';
+		if ( ! \openssl_sign( $signing_input, $der_signature, $key, OPENSSL_ALGO_SHA256 ) ) {
+			return false;
+		}
+
+		$raw_signature = self::der_to_raw( $der_signature, 64 );
+		if ( false === $raw_signature ) {
+			return false;
+		}
+
+		return $signing_input . '.' . self::base64url( $raw_signature );
+	}
+
+	/**
+	 * Convert a JWK EC private key to PEM format.
+	 *
+	 * @param array $jwk JWK with kty=EC, crv=P-256, x, y, d.
+	 * @return string|false PEM-encoded private key, or false on error.
+	 */
+	private static function jwk_to_pem( array $jwk ): string|false {
+		if ( ! isset( $jwk['d'], $jwk['x'], $jwk['y'] ) ) {
+			return false;
+		}
+
+		/*
+		 * Build a DER-encoded SEC1 EC private key structure:
+		 *
+		 * ECPrivateKey ::= SEQUENCE {
+		 *   version        INTEGER { ecPrivkeyVer1(1) },
+		 *   privateKey     OCTET STRING,
+		 *   parameters [0] OID (prime256v1),
+		 *   publicKey  [1] BIT STRING
+		 * }
+		 */
+		$d = self::base64url_decode( $jwk['d'] );
+		$x = self::base64url_decode( $jwk['x'] );
+		$y = self::base64url_decode( $jwk['y'] );
+
+		if ( false === $d || false === $x || false === $y ) {
+			return false;
+		}
+
+		// Pad to 32 bytes (P-256 field size).
+		$d = \str_pad( $d, 32, "\0", STR_PAD_LEFT );
+		$x = \str_pad( $x, 32, "\0", STR_PAD_LEFT );
+		$y = \str_pad( $y, 32, "\0", STR_PAD_LEFT );
+
+		// Uncompressed public key point: 0x04 || x || y.
+		$public_key = "\x04" . $x . $y;
+
+		// OID for prime256v1 (P-256): 1.2.840.10045.3.1.7.
+		$oid = "\x06\x08\x2a\x86\x48\xce\x3d\x03\x01\x07";
+
+		// Build the SEC1 structure.
+		$private_key = self::asn1_sequence(
+			self::asn1_integer( "\x01" )                                   // version.
+			. self::asn1_octet_string( $d )                                // privateKey.
+			. self::asn1_explicit_tag( 0, $oid )                           // parameters.
+			. self::asn1_explicit_tag( 1, self::asn1_bit_string( $public_key ) ) // publicKey.
+		);
+
+		return "-----BEGIN EC PRIVATE KEY-----\n"
+			. \chunk_split( \base64_encode( $private_key ), 64, "\n" ) // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			. '-----END EC PRIVATE KEY-----';
+	}
+
+	/**
+	 * Convert a DER-encoded ECDSA signature to raw R‖S format.
+	 *
+	 * @param string $der    DER-encoded signature.
+	 * @param int    $length Expected total length (64 for P-256).
+	 * @return string|false Raw signature, or false on error.
+	 */
+	private static function der_to_raw( string $der, int $length ): string|false {
+		$half = $length / 2;
+
+		// Parse SEQUENCE.
+		if ( \ord( $der[0] ) !== 0x30 ) {
+			return false;
+		}
+
+		$offset = 2; // Skip tag + length byte.
+
+		// Parse R.
+		if ( \ord( $der[ $offset ] ) !== 0x02 ) {
+			return false;
+		}
+		$r_len   = \ord( $der[ $offset + 1 ] );
+		$r       = \substr( $der, $offset + 2, $r_len );
+		$offset += 2 + $r_len;
+
+		// Parse S.
+		if ( \ord( $der[ $offset ] ) !== 0x02 ) {
+			return false;
+		}
+		$s_len = \ord( $der[ $offset + 1 ] );
+		$s     = \substr( $der, $offset + 2, $s_len );
+
+		// Strip leading zero padding, then pad to field size.
+		$r = \str_pad( \ltrim( $r, "\x00" ), $half, "\0", STR_PAD_LEFT );
+		$s = \str_pad( \ltrim( $s, "\x00" ), $half, "\0", STR_PAD_LEFT );
+
+		return $r . $s;
+	}
+
+	/**
+	 * ASN.1 DER helpers.
+	 *
+	 * @param string $content DER content.
+	 * @return string DER-encoded SEQUENCE.
+	 */
+	private static function asn1_sequence( string $content ): string {
+		return "\x30" . self::asn1_length( $content ) . $content;
+	}
+
+	/**
+	 * Encode an ASN.1 INTEGER.
+	 *
+	 * @param string $data Integer bytes.
+	 * @return string DER-encoded INTEGER.
+	 */
+	private static function asn1_integer( string $data ): string {
+		return "\x02" . self::asn1_length( $data ) . $data;
+	}
+
+	/**
+	 * Encode an ASN.1 OCTET STRING.
+	 *
+	 * @param string $data Octet string bytes.
+	 * @return string DER-encoded OCTET STRING.
+	 */
+	private static function asn1_octet_string( string $data ): string {
+		return "\x04" . self::asn1_length( $data ) . $data;
+	}
+
+	/**
+	 * Encode an ASN.1 BIT STRING.
+	 *
+	 * @param string $data Bit string content.
+	 * @return string DER-encoded BIT STRING.
+	 */
+	private static function asn1_bit_string( string $data ): string {
+		return "\x03" . self::asn1_length( "\x00" . $data ) . "\x00" . $data;
+	}
+
+	/**
+	 * Encode an ASN.1 context-specific explicit tag.
+	 *
+	 * @param int    $tag     Tag number.
+	 * @param string $content Tag content.
+	 * @return string DER-encoded tagged value.
+	 */
+	private static function asn1_explicit_tag( int $tag, string $content ): string {
+		$tag_byte = \chr( 0xA0 | $tag );
+		return $tag_byte . self::asn1_length( $content ) . $content;
+	}
+
+	/**
+	 * Encode an ASN.1 DER length.
+	 *
+	 * @param string $content Content to measure.
+	 * @return string DER-encoded length bytes.
+	 */
+	private static function asn1_length( string $content ): string {
+		$length = \strlen( $content );
+		if ( $length < 0x80 ) {
+			return \chr( $length );
+		}
+		$length_bytes = \ltrim( \pack( 'N', $length ), "\x00" );
+		return \chr( 0x80 | \strlen( $length_bytes ) ) . $length_bytes;
+	}
+
+	/**
+	 * Base64url decode.
+	 *
+	 * @param string $data Base64url-encoded string.
+	 * @return string|false Decoded bytes, or false on error.
+	 */
+	private static function base64url_decode( string $data ): string|false {
+		return \base64_decode( \strtr( $data, '-_', '+/' ), true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 	}
 
 	/**

--- a/includes/oauth/class-dpop.php
+++ b/includes/oauth/class-dpop.php
@@ -182,6 +182,11 @@ class DPoP {
 			return false;
 		}
 
+		// P-256 field size is 32 bytes; reject malformed keys.
+		if ( \strlen( $d ) > 32 || \strlen( $x ) > 32 || \strlen( $y ) > 32 ) {
+			return false;
+		}
+
 		// Pad to 32 bytes (P-256 field size).
 		$d = \str_pad( $d, 32, "\0", STR_PAD_LEFT );
 		$x = \str_pad( $x, 32, "\0", STR_PAD_LEFT );
@@ -216,12 +221,12 @@ class DPoP {
 	private static function der_to_raw( string $der, int $length ): string|false {
 		$half = $length / 2;
 
-		// Parse SEQUENCE.
-		if ( \ord( $der[0] ) !== 0x30 ) {
+		// Parse SEQUENCE (P-256 signatures are always < 128 bytes).
+		if ( \ord( $der[0] ) !== 0x30 || \ord( $der[1] ) & 0x80 ) {
 			return false;
 		}
 
-		$offset = 2; // Skip tag + length byte.
+		$offset = 2; // Skip tag + single-byte length.
 
 		// Parse R.
 		if ( \ord( $der[ $offset ] ) !== 0x02 ) {

--- a/tests/phpunit/tests/class-test-dpop.php
+++ b/tests/phpunit/tests/class-test-dpop.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Tests for the DPoP class.
+ *
+ * Verifies ES256 JWT signing produces valid, verifiable tokens
+ * using PHP's native OpenSSL extension.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group oauth
+ */
+
+namespace Atmosphere\Tests;
+
+use WP_UnitTestCase;
+use Atmosphere\OAuth\DPoP;
+
+/**
+ * DPoP tests.
+ */
+class Test_DPoP extends WP_UnitTestCase {
+
+	/**
+	 * Test that generate_key() produces a valid P-256 JWK.
+	 */
+	public function test_generate_key_produces_valid_jwk() {
+		$jwk = DPoP::generate_key();
+
+		$this->assertIsArray( $jwk );
+		$this->assertSame( 'EC', $jwk['kty'] );
+		$this->assertSame( 'P-256', $jwk['crv'] );
+		$this->assertArrayHasKey( 'x', $jwk );
+		$this->assertArrayHasKey( 'y', $jwk );
+		$this->assertArrayHasKey( 'd', $jwk );
+	}
+
+	/**
+	 * Test round-trip: generate key, create proof, verify signature.
+	 */
+	public function test_create_proof_produces_verifiable_jwt() {
+		$jwk = DPoP::generate_key();
+
+		$proof = DPoP::create_proof(
+			$jwk,
+			'POST',
+			'https://pds.example.com/xrpc/com.atproto.repo.applyWrites',
+			'test-nonce'
+		);
+
+		$this->assertIsString( $proof );
+
+		// Parse compact JWS: header.payload.signature.
+		$parts = \explode( '.', $proof );
+		$this->assertCount( 3, $parts, 'JWT must have three dot-separated parts.' );
+
+		// Decode and verify header.
+		$header = \json_decode( $this->base64url_decode( $parts[0] ), true );
+		$this->assertSame( 'ES256', $header['alg'] );
+		$this->assertSame( 'dpop+jwt', $header['typ'] );
+		$this->assertArrayHasKey( 'jwk', $header );
+		$this->assertArrayNotHasKey( 'd', $header['jwk'], 'Public JWK must not contain private key.' );
+
+		// Decode and verify payload.
+		$payload = \json_decode( $this->base64url_decode( $parts[1] ), true );
+		$this->assertSame( 'POST', $payload['htm'] );
+		$this->assertSame( 'https://pds.example.com/xrpc/com.atproto.repo.applyWrites', $payload['htu'] );
+		$this->assertSame( 'test-nonce', $payload['nonce'] );
+		$this->assertArrayHasKey( 'jti', $payload );
+		$this->assertArrayHasKey( 'iat', $payload );
+
+		// Verify the ES256 signature with OpenSSL.
+		$signing_input = $parts[0] . '.' . $parts[1];
+		$raw_signature = $this->base64url_decode( $parts[2] );
+
+		// Convert raw R‖S back to DER for OpenSSL verification.
+		$der_signature = $this->raw_to_der( $raw_signature );
+
+		// Reconstruct public key PEM from the JWK in the header.
+		$pub_pem = $this->jwk_to_public_pem( $header['jwk'] );
+
+		$result = \openssl_verify( $signing_input, $der_signature, $pub_pem, OPENSSL_ALGO_SHA256 );
+		$this->assertSame( 1, $result, 'OpenSSL signature verification must succeed.' );
+	}
+
+	/**
+	 * Test that create_proof includes ath claim when access token is provided.
+	 */
+	public function test_create_proof_includes_ath_claim() {
+		$jwk = DPoP::generate_key();
+
+		$proof = DPoP::create_proof(
+			$jwk,
+			'GET',
+			'https://pds.example.com/xrpc/com.atproto.repo.getRecord',
+			'nonce-123',
+			'my-access-token'
+		);
+
+		$parts   = \explode( '.', $proof );
+		$payload = \json_decode( $this->base64url_decode( $parts[1] ), true );
+
+		$this->assertArrayHasKey( 'ath', $payload );
+
+		// ath must be base64url(SHA-256(access_token)).
+		$expected_ath = \rtrim( \strtr( \base64_encode( \hash( 'sha256', 'my-access-token', true ) ), '+/', '-_' ), '=' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		$this->assertSame( $expected_ath, $payload['ath'] );
+	}
+
+	/**
+	 * Test that create_proof returns false for malformed JWK.
+	 */
+	public function test_create_proof_returns_false_for_malformed_jwk() {
+		$result = DPoP::create_proof(
+			array(
+				'kty' => 'EC',
+				'crv' => 'P-256',
+			),
+			'POST',
+			'https://pds.example.com/xrpc/test',
+			'nonce'
+		);
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Base64url decode helper.
+	 *
+	 * @param string $data Base64url-encoded string.
+	 * @return string Decoded bytes.
+	 */
+	private function base64url_decode( string $data ): string {
+		return \base64_decode( \strtr( $data, '-_', '+/' ), true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+	}
+
+	/**
+	 * Convert raw R‖S signature to DER format for OpenSSL verification.
+	 *
+	 * @param string $raw Raw signature (64 bytes for P-256).
+	 * @return string DER-encoded signature.
+	 */
+	private function raw_to_der( string $raw ): string {
+		$half = \intdiv( \strlen( $raw ), 2 );
+		$r    = \ltrim( \substr( $raw, 0, $half ), "\x00" );
+		$s    = \ltrim( \substr( $raw, $half ), "\x00" );
+
+		// Add leading zero if high bit is set (ASN.1 signed integer).
+		if ( \ord( $r[0] ) >= 0x80 ) {
+			$r = "\x00" . $r;
+		}
+		if ( \ord( $s[0] ) >= 0x80 ) {
+			$s = "\x00" . $s;
+		}
+
+		$r_der = "\x02" . \chr( \strlen( $r ) ) . $r;
+		$s_der = "\x02" . \chr( \strlen( $s ) ) . $s;
+
+		$sequence = $r_der . $s_der;
+
+		return "\x30" . \chr( \strlen( $sequence ) ) . $sequence;
+	}
+
+	/**
+	 * Convert a public JWK to PEM format for OpenSSL verification.
+	 *
+	 * @param array $jwk Public JWK with x and y coordinates.
+	 * @return string PEM-encoded public key.
+	 */
+	private function jwk_to_public_pem( array $jwk ): string {
+		$x = \base64_decode( \strtr( $jwk['x'], '-_', '+/' ), true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+		$y = \base64_decode( \strtr( $jwk['y'], '-_', '+/' ), true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+
+		$x = \str_pad( $x, 32, "\0", STR_PAD_LEFT );
+		$y = \str_pad( $y, 32, "\0", STR_PAD_LEFT );
+
+		// Uncompressed point: 0x04 || x || y.
+		$point = "\x04" . $x . $y;
+
+		/*
+		 * SubjectPublicKeyInfo ::= SEQUENCE {
+		 *   algorithm  AlgorithmIdentifier (EC + prime256v1),
+		 *   subjectPublicKey BIT STRING
+		 * }
+		 */
+		// AlgorithmIdentifier: OID ecPublicKey (1.2.840.10045.2.1) + OID prime256v1 (1.2.840.10045.3.1.7).
+		$algorithm = "\x30\x13\x06\x07\x2a\x86\x48\xce\x3d\x02\x01\x06\x08\x2a\x86\x48\xce\x3d\x03\x01\x07";
+
+		// BIT STRING wrapping the uncompressed point.
+		$bit_string = "\x03" . \chr( \strlen( $point ) + 1 ) . "\x00" . $point;
+
+		// SEQUENCE wrapper.
+		$der = $algorithm . $bit_string;
+		$der = "\x30" . \chr( \strlen( $der ) ) . $der;
+
+		return "-----BEGIN PUBLIC KEY-----\n"
+			. \chunk_split( \base64_encode( $der ), 64, "\n" ) // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			. '-----END PUBLIC KEY-----';
+	}
+}


### PR DESCRIPTION
Fixes #

## Proposed changes:
* Replace the `web-token/jwt-library` Composer dependency with native OpenSSL ES256 JWT signing (~200 lines), eliminating all runtime vendor dependencies.
* Add a custom WordPress-style class autoloader (based on the ActivityPub plugin's) so the plugin no longer needs Composer's classmap autoloader.
* The plugin now works as a self-contained WordPress plugin — drop in `wp-content/plugins/` and go, no `composer install` required.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Activate the plugin and connect to a Bluesky/AT Protocol account.
* Publish a post and verify it syncs to Bluesky — this exercises the DPoP proof signing.
* Edit the post and verify it updates on Bluesky.
* Run `npm run env-test` — 52 tests should pass, including 4 new DPoP round-trip signing tests.
* Run `composer lint` — should pass clean.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Changed - for changes in existing functionality

#### Message

Replace third-party JWT library with native OpenSSL signing and add a custom class autoloader.

</details>