### PR TITLE
Fix restoring a trashed post not republishing to Bluesky

### DIFF
--- a/.github/changelog/fix-restore-from-trash
+++ b/.github/changelog/fix-restore-from-trash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix restoring a trashed post not republishing it to Bluesky.

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -258,11 +258,16 @@ class Atmosphere {
 			// Update.
 			\wp_schedule_single_event( \time(), 'atmosphere_update_post', array( $post->ID ) );
 		} elseif ( 'publish' === $old_status && 'publish' !== $new_status ) {
-			// Genuine unpublish — transitioning away from publish.
+			/*
+			 * Genuine unpublish — transitioning away from publish.
+			 * Use atmosphere_delete_post (not delete_records) so that
+			 * post meta is cleaned up on success, allowing a subsequent
+			 * restore (trash → publish) to republish correctly.
+			 */
 			$bsky_tid = \get_post_meta( $post->ID, Transformer\Post::META_TID, true );
 			$doc_tid  = \get_post_meta( $post->ID, Transformer\Document::META_TID, true );
 			if ( $bsky_tid || $doc_tid ) {
-				\wp_schedule_single_event( \time(), 'atmosphere_delete_records', array( $bsky_tid, $doc_tid ) );
+				\wp_schedule_single_event( \time(), 'atmosphere_delete_post', array( $post->ID ) );
 			}
 		}
 	}

--- a/tests/phpunit/tests/class-test-status-change.php
+++ b/tests/phpunit/tests/class-test-status-change.php
@@ -231,9 +231,6 @@ class Test_Status_Change extends WP_UnitTestCase {
 
 	/**
 	 * Test that trash → publish (restore) schedules a publish event.
-	 *
-	 * After trashing a published post, the delete handler cleans up
-	 * post meta. Restoring the post should trigger a fresh publish.
 	 */
 	public function test_restore_from_trash_schedules_publish() {
 		$post = self::factory()->post->create_and_get(

--- a/tests/phpunit/tests/class-test-status-change.php
+++ b/tests/phpunit/tests/class-test-status-change.php
@@ -57,6 +57,7 @@ class Test_Status_Change extends WP_UnitTestCase {
 		// Clear any scheduled events.
 		\wp_clear_scheduled_hook( 'atmosphere_publish_post' );
 		\wp_clear_scheduled_hook( 'atmosphere_update_post' );
+		\wp_clear_scheduled_hook( 'atmosphere_delete_post' );
 		\wp_clear_scheduled_hook( 'atmosphere_delete_records' );
 
 		parent::tear_down();
@@ -123,8 +124,8 @@ class Test_Status_Change extends WP_UnitTestCase {
 		$this->atmosphere->on_status_change( 'draft', 'publish', $post );
 
 		$this->assertNotFalse(
-			\wp_next_scheduled( 'atmosphere_delete_records', array( 'bsky-tid-123', 'doc-tid-456' ) ),
-			'Expected atmosphere_delete_records to be scheduled.'
+			\wp_next_scheduled( 'atmosphere_delete_post', array( $post->ID ) ),
+			'Expected atmosphere_delete_post to be scheduled.'
 		);
 	}
 
@@ -143,8 +144,8 @@ class Test_Status_Change extends WP_UnitTestCase {
 		$this->atmosphere->on_status_change( 'trash', 'publish', $post );
 
 		$this->assertNotFalse(
-			\wp_next_scheduled( 'atmosphere_delete_records', array( 'bsky-tid-123', 'doc-tid-456' ) ),
-			'Expected atmosphere_delete_records to be scheduled.'
+			\wp_next_scheduled( 'atmosphere_delete_post', array( $post->ID ) ),
+			'Expected atmosphere_delete_post to be scheduled.'
 		);
 	}
 
@@ -166,7 +167,7 @@ class Test_Status_Change extends WP_UnitTestCase {
 		$this->atmosphere->on_status_change( 'draft', 'draft', $post );
 
 		$this->assertFalse(
-			\wp_next_scheduled( 'atmosphere_delete_records', array( 'bsky-tid-123', 'doc-tid-456' ) ),
+			\wp_next_scheduled( 'atmosphere_delete_post', array( $post->ID ) ),
 			'Draft → draft must NOT schedule a delete.'
 		);
 	}
@@ -186,7 +187,7 @@ class Test_Status_Change extends WP_UnitTestCase {
 		$this->atmosphere->on_status_change( 'pending', 'pending', $post );
 
 		$this->assertFalse(
-			\wp_next_scheduled( 'atmosphere_delete_records', array( 'bsky-tid-123', 'doc-tid-456' ) ),
+			\wp_next_scheduled( 'atmosphere_delete_post', array( $post->ID ) ),
 			'Pending → pending must NOT schedule a delete.'
 		);
 	}
@@ -206,7 +207,7 @@ class Test_Status_Change extends WP_UnitTestCase {
 		$this->atmosphere->on_status_change( 'pending', 'draft', $post );
 
 		$this->assertFalse(
-			\wp_next_scheduled( 'atmosphere_delete_records', array( 'bsky-tid-123', 'doc-tid-456' ) ),
+			\wp_next_scheduled( 'atmosphere_delete_post', array( $post->ID ) ),
 			'Draft → pending must NOT schedule a delete.'
 		);
 	}
@@ -223,8 +224,28 @@ class Test_Status_Change extends WP_UnitTestCase {
 		$this->atmosphere->on_status_change( 'draft', 'publish', $post );
 
 		$this->assertFalse(
-			\wp_next_scheduled( 'atmosphere_delete_records', array( '', '' ) ),
+			\wp_next_scheduled( 'atmosphere_delete_post', array( $post->ID ) ),
 			'Unpublish without TIDs must NOT schedule a delete.'
+		);
+	}
+
+	/**
+	 * Test that trash → publish (restore) schedules a publish event.
+	 *
+	 * After trashing a published post, the delete handler cleans up
+	 * post meta. Restoring the post should trigger a fresh publish.
+	 */
+	public function test_restore_from_trash_schedules_publish() {
+		$post = self::factory()->post->create_and_get(
+			array( 'post_status' => 'publish' )
+		);
+
+		$this->reset_publishing_action();
+		$this->atmosphere->on_status_change( 'publish', 'trash', $post );
+
+		$this->assertNotFalse(
+			\wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) ),
+			'Expected atmosphere_publish_post to be scheduled on restore.'
 		);
 	}
 


### PR DESCRIPTION
## Proposed changes:
* When trashing a published post, schedule `atmosphere_delete_post` (with post ID) instead of `atmosphere_delete_records` (with TIDs). This ensures `Publisher::delete()` runs and cleans up post meta on success.
* Restoring a trashed post now triggers a fresh publish because the stale TIDs/URIs/CIDs have been removed.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Connect the plugin to a Bluesky account.
* Publish a post — verify it appears on Bluesky.
* Trash the post — verify it is deleted from Bluesky.
* Restore the post from trash — verify it is republished to Bluesky.
* Run `npm run env-test` — 49 tests should pass.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix restoring a trashed post not republishing it to Bluesky.

</details>