### PR TITLE
Fix auto-publish defaulting to disabled after saving settings

### DIFF
--- a/.github/changelog/fix-auto-publish-default
+++ b/.github/changelog/fix-auto-publish-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix auto-publish being disabled by default after saving settings.

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -236,7 +236,7 @@ class Atmosphere {
 			return;
 		}
 
-		if ( ! \get_option( 'atmosphere_auto_publish', '1' ) ) {
+		if ( '0' === \get_option( 'atmosphere_auto_publish', '1' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## Proposed changes:
* Check for explicit `'0'` instead of falsy value when evaluating the auto-publish option. An empty string (stored by WordPress when an unchecked checkbox form is saved) was being treated as "disabled", even though the intended default is enabled.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

One-line logic fix — existing tests cover the status change flow.

## Testing instructions:

* Go to **Settings → ATmosphere**.
* Save the settings page without changing anything.
* Verify the "Automatically publish new posts to AT Protocol" checkbox remains checked.
* Uncheck it, save, and verify it stays unchecked.
* Publish a post — verify it syncs only when the checkbox is checked.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix auto-publish being disabled by default after saving settings.

</details>