### PR TITLE
Fix PHPCS warnings about unprefixed global variables

### DIFF
--- a/.github/changelog/fix-phpcs-prefix-warnings
+++ b/.github/changelog/fix-phpcs-prefix-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHPCS warnings about unprefixed global variables and hook names.

--- a/includes/transformer/class-document.php
+++ b/includes/transformer/class-document.php
@@ -193,7 +193,7 @@ class Document extends Base {
 	 * @return string
 	 */
 	private function get_text_content(): string {
-		$content = \apply_filters( 'the_content', $this->object->post_content );
+		$content = \apply_filters( 'the_content', $this->object->post_content ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core WordPress filter.
 		$content = \wp_strip_all_tags( $content );
 		$content = \html_entity_decode( $content, ENT_QUOTES, 'UTF-8' );
 

--- a/templates/meta-box.php
+++ b/templates/meta-box.php
@@ -13,29 +13,29 @@ use Atmosphere\Transformer\Post as BskyPost;
 \defined( 'ABSPATH' ) || exit;
 
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- $args is set by load_template().
-$the_post = $args['post'];
-$bsky_uri = \get_post_meta( $the_post->ID, BskyPost::META_URI, true );
-$doc_uri  = \get_post_meta( $the_post->ID, Document::META_URI, true );
-$synced   = ! empty( $bsky_uri ) || ! empty( $doc_uri );
+$atmosphere_post     = $args['post'];
+$atmosphere_bsky_uri = \get_post_meta( $atmosphere_post->ID, BskyPost::META_URI, true );
+$atmosphere_doc_uri  = \get_post_meta( $atmosphere_post->ID, Document::META_URI, true );
+$atmosphere_synced   = ! empty( $atmosphere_bsky_uri ) || ! empty( $atmosphere_doc_uri );
 ?>
 <div class="atmosphere-meta-box">
-	<?php if ( $synced ) : ?>
+	<?php if ( $atmosphere_synced ) : ?>
 		<p>
 			<span class="dashicons dashicons-yes-alt" style="color: #00a32a;"></span>
 			<?php \esc_html_e( 'Synced to AT Protocol', 'atmosphere' ); ?>
 		</p>
 
-		<?php if ( $bsky_uri ) : ?>
+		<?php if ( $atmosphere_bsky_uri ) : ?>
 			<p class="description">
 				<strong><?php \esc_html_e( 'Bluesky post:', 'atmosphere' ); ?></strong><br>
-				<code style="font-size: 11px; word-break: break-all;"><?php echo \esc_html( $bsky_uri ); ?></code>
+				<code style="font-size: 11px; word-break: break-all;"><?php echo \esc_html( $atmosphere_bsky_uri ); ?></code>
 			</p>
 		<?php endif; ?>
 
-		<?php if ( $doc_uri ) : ?>
+		<?php if ( $atmosphere_doc_uri ) : ?>
 			<p class="description">
 				<strong><?php \esc_html_e( 'Document:', 'atmosphere' ); ?></strong><br>
-				<code style="font-size: 11px; word-break: break-all;"><?php echo \esc_html( $doc_uri ); ?></code>
+				<code style="font-size: 11px; word-break: break-all;"><?php echo \esc_html( $atmosphere_doc_uri ); ?></code>
 			</p>
 		<?php endif; ?>
 	<?php else : ?>

--- a/uninstall.php
+++ b/uninstall.php
@@ -26,7 +26,7 @@ wp_clear_scheduled_hook( 'atmosphere_delete_post' );
 // Remove post meta.
 global $wpdb;
 
-$meta_keys = array(
+$atmosphere_meta_keys = array(
 	'_atmosphere_bsky_tid',
 	'_atmosphere_bsky_uri',
 	'_atmosphere_bsky_cid',
@@ -36,8 +36,8 @@ $meta_keys = array(
 	'_atmosphere_blob_ref',
 );
 
-foreach ( $meta_keys as $key ) {
-	$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => $key ) ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+foreach ( $atmosphere_meta_keys as $atmosphere_key ) {
+	$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => $atmosphere_key ) ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 }
 
 // Remove transients.


### PR DESCRIPTION
Fixes PHPCS `WordPress.NamingConventions.PrefixAllGlobals` warnings across three files.

## Proposed changes:
* Prefix global variables in `uninstall.php` (`$meta_keys` → `$atmosphere_meta_keys`, `$key` → `$atmosphere_key`).
* Prefix template variables in `templates/meta-box.php` with `atmosphere_` (`$the_post`, `$bsky_uri`, `$doc_uri`, `$synced`).
* Suppress false-positive warning for core `the_content` filter in `includes/transformer/class-document.php`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

No logic changes — purely mechanical PHPCS fixes.

## Testing instructions:

* Run `composer lint` — should pass with zero warnings.
* Run `npm run env-test` — all tests should pass.
* Verify the meta box on the post editor still displays correctly.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix PHPCS warnings about unprefixed global variables and hook names.

</details>