### PR TITLE
Publish short-form posts as native Bluesky posts (post-format-aware composition)

### DIFF
--- a/.github/changelog/add-short-form-post-path
+++ b/.github/changelog/add-short-form-post-path
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Short-form posts (untitled or with a post format) now publish as native Bluesky posts instead of link cards, matching the ActivityPub plugin's Note discriminator. Added the `atmosphere_is_short_form_post` filter for downstream override.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -60,10 +60,10 @@ function sanitize_text( string $text ): string {
 }
 
 /**
- * Truncate text to a grapheme limit, breaking at word boundaries.
+ * Truncate text to a character limit, breaking at word boundaries.
  *
  * @param string $text   Text to truncate.
- * @param int    $limit  Maximum graphemes.
+ * @param int    $limit  Maximum characters (mb_strlen code points).
  * @param string $marker Ellipsis marker.
  * @return string
  */

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -146,9 +146,7 @@ abstract class Base {
 	 */
 	protected function render_post_content_plain( \WP_Post $post ): string {
 		$content = \apply_filters( 'the_content', $post->post_content ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core WordPress filter.
-		$content = \wp_strip_all_tags( $content );
-		$content = \html_entity_decode( $content, ENT_QUOTES, 'UTF-8' );
 
-		return \trim( \preg_replace( '/\s+/', ' ', $content ) );
+		return sanitize_text( $content );
 	}
 }

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -133,4 +133,22 @@ abstract class Base {
 
 		return \wp_trim_words( sanitize_text( $post->post_content ), $word_limit, '...' );
 	}
+
+	/**
+	 * Render a post's content to plain text.
+	 *
+	 * Runs the_content filter, strips tags, decodes entities, and
+	 * collapses whitespace. Shared by short-form Bluesky post
+	 * composition and the document record's textContent field.
+	 *
+	 * @param \WP_Post $post Post object.
+	 * @return string
+	 */
+	protected function render_post_content_plain( \WP_Post $post ): string {
+		$content = \apply_filters( 'the_content', $post->post_content ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core WordPress filter.
+		$content = \wp_strip_all_tags( $content );
+		$content = \html_entity_decode( $content, ENT_QUOTES, 'UTF-8' );
+
+		return \trim( \preg_replace( '/\s+/', ' ', $content ) );
+	}
 }

--- a/includes/transformer/class-document.php
+++ b/includes/transformer/class-document.php
@@ -190,13 +190,13 @@ class Document extends Base {
 	/**
 	 * Render post content to plain text.
 	 *
+	 * Delegates to Transformer\Base::render_post_content_plain() so
+	 * the short-form Bluesky post path and the document textContent
+	 * field agree on plain-text rendering.
+	 *
 	 * @return string
 	 */
 	private function get_text_content(): string {
-		$content = \apply_filters( 'the_content', $this->object->post_content ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core WordPress filter.
-		$content = \wp_strip_all_tags( $content );
-		$content = \html_entity_decode( $content, ENT_QUOTES, 'UTF-8' );
-
-		return \trim( \preg_replace( '/\s+/', ' ', $content ) );
+		return $this->render_post_content_plain( $this->object );
 	}
 }

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -49,7 +49,32 @@ class Post extends Base {
 	 * @return array app.bsky.feed.post record.
 	 */
 	public function transform(): array {
-		$text = $this->build_text();
+		/**
+		 * Filters whether the post should be treated as short-form for Bluesky.
+		 *
+		 * Short-form posts publish natively (post body as text, no external
+		 * embed card). Long-form posts use the teaser composition (title +
+		 * excerpt + permalink) with an external card linking back to
+		 * WordPress. The default discriminator mirrors the ActivityPub
+		 * plugin's Post::get_type() logic: untitled posts OR posts with any
+		 * non-empty post_format are short-form.
+		 *
+		 * @param bool     $is_short Whether the post should be treated as short-form.
+		 * @param \WP_Post $post     The post being transformed.
+		 */
+		$is_short = \apply_filters(
+			'atmosphere_is_short_form_post',
+			$this->is_short_form( $this->object ),
+			$this->object
+		);
+
+		if ( $is_short ) {
+			$text  = $this->build_short_form_text();
+			$embed = null;
+		} else {
+			$text  = $this->build_text();
+			$embed = $this->build_embed();
+		}
 
 		$record = array(
 			'$type'     => 'app.bsky.feed.post',
@@ -63,7 +88,6 @@ class Post extends Base {
 			$record['facets'] = $facets;
 		}
 
-		$embed = $this->build_embed();
 		if ( $embed ) {
 			$record['embed'] = $embed;
 		}
@@ -208,5 +232,40 @@ class Post extends Base {
 		}
 
 		return $blob_ref;
+	}
+
+	/**
+	 * Whether the post should be treated as short-form for Bluesky.
+	 *
+	 * Mirrors the ActivityPub plugin's Post::get_type() discriminator so
+	 * a post federated as a Mastodon Note also goes to Bluesky as a
+	 * native post instead of a link-card teaser. Short-form when:
+	 * - the post type does not support titles, OR
+	 * - the post has an empty title, OR
+	 * - the post has any non-empty post_format.
+	 *
+	 * @param \WP_Post $post Post being transformed.
+	 * @return bool
+	 */
+	private function is_short_form( \WP_Post $post ): bool {
+		if ( ! \post_type_supports( $post->post_type, 'title' ) || empty( $post->post_title ) ) {
+			return true;
+		}
+
+		return (bool) \get_post_format( $post );
+	}
+
+	/**
+	 * Build the bsky.app post text for a short-form post.
+	 *
+	 * The post body becomes the Bluesky text directly, with no title
+	 * prefix or trailing permalink. Defensively clamped to 300
+	 * graphemes; a composer UI is expected to enforce the cap before
+	 * publish.
+	 *
+	 * @return string
+	 */
+	private function build_short_form_text(): string {
+		return truncate_text( $this->render_post_content_plain( $this->object ), 300 );
 	}
 }

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -3,7 +3,7 @@
  * Transforms a WordPress post into an app.bsky.feed.post record.
  *
  * The post text combines title + excerpt + permalink, truncated to
- * 300 graphemes.  An external embed card is attached with the
+ * 300 characters.  An external embed card is attached with the
  * post's URL, title, description, and optional thumbnail.
  *
  * @package Atmosphere
@@ -56,22 +56,25 @@ class Post extends Base {
 		 * embed card). Long-form posts use the teaser composition (title +
 		 * excerpt + permalink) with an external card linking back to
 		 * WordPress. The default discriminator mirrors the ActivityPub
-		 * plugin's Post::get_type() logic: untitled posts OR posts with any
-		 * non-empty post_format are short-form.
+		 * plugin's Post::get_type() logic: short-form when the post type
+		 * does not support titles, the post has an empty title, or the
+		 * post has any non-empty post_format.
 		 *
 		 * @param bool     $is_short Whether the post should be treated as short-form.
 		 * @param \WP_Post $post     The post being transformed.
 		 */
-		$is_short = \apply_filters(
-			'atmosphere_is_short_form_post',
-			$this->is_short_form( $this->object ),
-			$this->object
+		$is_short = \wp_validate_boolean(
+			\apply_filters(
+				'atmosphere_is_short_form_post',
+				$this->is_short_form( $this->object ),
+				$this->object
+			)
 		);
 
-		if ( $is_short ) {
-			$text  = $this->build_short_form_text();
-			$embed = null;
-		} else {
+		$text  = $is_short ? $this->build_short_form_text() : '';
+		$embed = null;
+
+		if ( '' === $text ) {
 			$text  = $this->build_text();
 			$embed = $this->build_embed();
 		}
@@ -128,7 +131,7 @@ class Post extends Base {
 	}
 
 	/**
-	 * Compose the post text: title + excerpt + permalink within 300 graphemes.
+	 * Compose the post text: title + excerpt + permalink within 300 characters.
 	 *
 	 * @return string
 	 */
@@ -260,7 +263,7 @@ class Post extends Base {
 	 *
 	 * The post body becomes the Bluesky text directly, with no title
 	 * prefix or trailing permalink. Defensively clamped to 300
-	 * graphemes; a composer UI is expected to enforce the cap before
+	 * characters; a composer UI is expected to enforce the cap before
 	 * publish.
 	 *
 	 * @return string

--- a/tests/phpunit/tests/transformer/class-test-post.php
+++ b/tests/phpunit/tests/transformer/class-test-post.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Tests for the Post transformer (bsky.app record composition).
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group transformer
+ */
+
+namespace Atmosphere\Tests\Transformer;
+
+use WP_UnitTestCase;
+use Atmosphere\Transformer\Post;
+
+/**
+ * Post transformer tests.
+ *
+ * @coversDefaultClass \Atmosphere\Transformer\Post
+ */
+class Test_Post extends WP_UnitTestCase {
+
+	/**
+	 * Tear down filters between tests so overrides don't leak.
+	 */
+	public function tear_down() {
+		\remove_all_filters( 'atmosphere_is_short_form_post' );
+		parent::tear_down();
+	}
+
+	/**
+	 * A titled post with no post format uses the long-form path:
+	 * title + excerpt + permalink as text, plus an external embed card.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_long_form_titled_no_format_has_external_embed() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'A Titled Post',
+				'post_content' => 'Long-form blog body.',
+				'post_excerpt' => 'Teaser excerpt.',
+			)
+		);
+
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertSame( 'app.bsky.feed.post', $record['$type'] );
+		$this->assertStringContainsString( 'A Titled Post', $record['text'] );
+		$this->assertArrayHasKey( 'embed', $record );
+		$this->assertSame( 'app.bsky.embed.external', $record['embed']['$type'] );
+	}
+
+	/**
+	 * An untitled post is short-form: body becomes the text, no embed.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_untitled_post_is_short_form() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => '',
+				'post_content' => 'A quick untitled thought.',
+			)
+		);
+
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertSame( 'A quick untitled thought.', $record['text'] );
+		$this->assertArrayNotHasKey( 'embed', $record );
+	}
+
+	/**
+	 * A titled post with post_format=status is short-form.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_titled_post_with_status_format_is_short_form() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Has a title but also a format',
+				'post_content' => 'Short-form body despite the title.',
+			)
+		);
+		\set_post_format( $post_id, 'status' );
+		$post = \get_post( $post_id );
+
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertSame( 'Short-form body despite the title.', $record['text'] );
+		$this->assertArrayNotHasKey( 'embed', $record );
+	}
+
+	/**
+	 * Any post format triggers short-form, not just status.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_titled_post_with_aside_format_is_short_form() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Has a title',
+				'post_content' => 'An aside.',
+			)
+		);
+		\set_post_format( $post_id, 'aside' );
+		$post = \get_post( $post_id );
+
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertSame( 'An aside.', $record['text'] );
+		$this->assertArrayNotHasKey( 'embed', $record );
+	}
+
+	/**
+	 * Short-form text over 300 graphemes is truncated.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_short_form_truncates_over_cap() {
+		$long_body = \str_repeat( 'Lorem ipsum dolor sit amet. ', 50 );
+		$post      = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => '',
+				'post_content' => $long_body,
+			)
+		);
+
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertLessThanOrEqual( 300, \mb_strlen( $record['text'] ) );
+		$this->assertStringContainsString( 'Lorem', $record['text'] );
+	}
+
+	/**
+	 * The atmosphere_is_short_form_post filter can force short-form on a
+	 * titled-no-format post that would otherwise be long-form.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_filter_can_force_short_form() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'A Titled Post',
+				'post_content' => 'Body overridden to short-form.',
+			)
+		);
+
+		\add_filter( 'atmosphere_is_short_form_post', '__return_true' );
+
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertSame( 'Body overridden to short-form.', $record['text'] );
+		$this->assertArrayNotHasKey( 'embed', $record );
+	}
+
+	/**
+	 * The filter can force long-form on an untitled post that would
+	 * otherwise be short-form.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_filter_can_force_long_form() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => '',
+				'post_content' => 'Would be short-form by default.',
+			)
+		);
+
+		\add_filter( 'atmosphere_is_short_form_post', '__return_false' );
+
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertArrayHasKey( 'embed', $record );
+		$this->assertSame( 'app.bsky.embed.external', $record['embed']['$type'] );
+	}
+
+	/**
+	 * The filter receives the computed default and the post.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_filter_receives_computed_default_and_post() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'A Titled Post',
+				'post_content' => 'Body.',
+			)
+		);
+
+		$received_default = null;
+		$received_post_id = null;
+		$callback         = function ( $is_short, $filter_post ) use ( &$received_default, &$received_post_id ) {
+			$received_default = $is_short;
+			$received_post_id = $filter_post->ID;
+			return $is_short;
+		};
+
+		\add_filter( 'atmosphere_is_short_form_post', $callback, 10, 2 );
+
+		( new Post( $post ) )->transform();
+
+		$this->assertFalse( $received_default, 'Default for titled-no-format post should be false (long-form).' );
+		$this->assertSame( $post->ID, $received_post_id, 'Filter should receive the post being transformed.' );
+	}
+}


### PR DESCRIPTION
## Context

Proposed as part of the FOSSE plugin's design plan for native Bluesky publishing — the design lives at [`Automattic/fosse#18`](https://github.com/Automattic/fosse/pull/18) (see `sdd/bluesky-native-publishing/`). The implementation here is a faithful expression of that plan.

- **If you disagree with WHAT this does** — the discriminator logic (mirrors AP's `get_type()`), the filter name, the short-form composition (body-as-text, no embed), or the small refactor — the FOSSE SDD is the right place to push back. Happy to carry feedback in either direction.
- **Code-level concerns** (style, edge cases, test coverage, whether the refactor should be split) are perfect for here.

Sibling PR adding `activitypub_post_object_type` to the AP plugin: [Automattic/wordpress-activitypub#3210](https://github.com/Automattic/wordpress-activitypub/pull/3210). A small FOSSE projector hooks both filters so a single user-level "always Note" preference projects onto both networks.

## Summary

Currently, every published post federates to Bluesky as `title + excerpt + permalink` truncated to 300 graphemes, with an `app.bsky.embed.external` link card pointing back to WordPress. That's correct for long-form blog posts — readers want a card, not a chopped-up essay in their timeline. But it's the wrong shape for a short post: the note *is* the content, and a link card back to a page that repeats those 50 characters is noise.

This PR makes the `app.bsky.feed.post` composition post-format-aware, mirroring the ActivityPub plugin's [`Post::get_type()`](https://github.com/Automattic/wordpress-activitypub/blob/trunk/includes/transformer/class-post.php) discriminator:

- **Short-form** (post has no title, OR has any non-empty `post_format`): body becomes the Bluesky text directly, defensively clamped at 300 graphemes; no external embed.
- **Long-form** (titled with no format): existing behavior unchanged — title + excerpt + permalink teaser with external card.

The change is symmetric with what the AP plugin already does for Mastodon (`Note` vs. `Article`), so a user who sets `post_format = status` on a post gets consistent short-form treatment on both networks without any extra setup.

## Changes

- `includes/transformer/class-post.php`
  - New private `is_short_form( WP_Post $post ): bool` mirroring AP's `get_type()`.
  - New private `build_short_form_text(): string` — rendered plain-text body, clamped to 300 via `truncate_text`.
  - `transform()` branches on the new `atmosphere_is_short_form_post` filter (default: the `is_short_form()` computed value). Short-form → body-as-text + null embed. Long-form → existing `build_text()` / `build_embed()` path unchanged.
- `includes/transformer/class-base.php` — new protected `render_post_content_plain( WP_Post $post ): string` extracting the plain-text rendering pattern currently inlined in `Document::get_text_content()`.
- `includes/transformer/class-document.php` — `get_text_content()` now delegates to the shared helper. Pure refactor, no behavior change.
- `tests/phpunit/tests/transformer/class-test-post.php` (new) — 8 tests covering long-form unchanged, all short-form triggers (untitled, status format, aside format), over-cap truncation, filter force short/long, filter receives the right arguments.
- `.github/changelog/add-short-form-post-path` — minor/added entry.

## Why a new filter and not a record-level rewrite

`atmosphere_transform_bsky_post` exists and could technically be used to rewrite the composed record, but it would force consumers to duplicate the short-form composition logic and re-extract facets against the new text. A yes/no discriminator filter (`atmosphere_is_short_form_post`) is the smaller extension point and composes naturally with the existing `atmosphere_transform_bsky_post` final-adjustment filter.

## Test plan

- [x] PHP syntax clean on all four modified/new files.
- [x] `composer lint` clean on all modified files.
- [ ] `composer test` / `npm run env-test` — I did not run locally (no MySQL / wp-env set up in my environment). Confident via reading + syntax check; please let me know if CI surfaces anything.

## Note on the refactor

The `Document::get_text_content()` → `Base::render_post_content_plain()` extraction is bundled here because the new short-form path needs the same rendering and it'd be strange to have two copies. Happy to split it into its own prep PR if you'd prefer that shape — let me know.

Fixes DOTCOM-16838