### PR TITLE
Add OAuth redirect_uri filter and persist connect notice

### DIFF
--- a/.github/changelog/oauth-redirect-uri-filter
+++ b/.github/changelog/oauth-redirect-uri-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Preserve the connection success notice after completing Bluesky setup, and let integrating plugins customize the OAuth callback destination.

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -39,7 +39,18 @@ class Client {
 	 * @return string
 	 */
 	public static function redirect_uri(): string {
-		return \admin_url( 'options-general.php?page=atmosphere' );
+		$uri = \admin_url( 'options-general.php?page=atmosphere' );
+
+		/**
+		 * Filters the OAuth redirect URI.
+		 *
+		 * Allows consumers (e.g. wrapper plugins) to set their own callback
+		 * URL so the OAuth flow returns to their admin page instead of the
+		 * default Atmosphere settings page.
+		 *
+		 * @param string $uri Default redirect URI.
+		 */
+		return \apply_filters( 'atmosphere_oauth_redirect_uri', $uri );
 	}
 
 	/**

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -358,6 +358,7 @@ class Admin {
 			\__( 'Successfully connected to AT Protocol.', 'atmosphere' ),
 			'success'
 		);
+		\set_transient( 'settings_errors', \get_settings_errors(), 30 );
 
 		\wp_safe_redirect( \admin_url( 'options-general.php?page=atmosphere&connected=1' ) );
 		exit;


### PR DESCRIPTION
## Summary

Two small changes that let wrapper plugins integrate Atmosphere's OAuth flow into their own admin surface.

- **`atmosphere_oauth_redirect_uri` filter** on `Client::redirect_uri()` — consumers can set their own callback URL so the OAuth flow returns to their admin page instead of Atmosphere's settings page.
- **Persist connect success notice** via `set_transient()` before the redirect — matches what the disconnect handler already does on line 384. Without this, `add_settings_error()` is lost across the `wp_safe_redirect()`.

## Motivation

FOSSE ([Automattic/fosse](https://github.com/Automattic/fosse)) wraps Atmosphere and ActivityPub behind a unified admin UI. The Bluesky setup flow needs to redirect users back to the FOSSE page after OAuth, and display a success/error notice when they land. These two gaps are the only blockers.

Both changes are post-type-agnostic: any plugin wrapping Atmosphere's OAuth flow benefits, not just FOSSE. Per FOSSE's [upstream-first policy](https://github.com/Automattic/fosse/blob/trunk/AGENTS.md#upstream-contribution-policy), we land these upstream and consume via sync-bundled.

## CI note

The `changelog` check is failing with `Input required and not supplied: github-token` — this appears to be a repo-level workflow config issue (`actions/github-script@v9` not receiving a token), not related to this PR's changes.

## Test plan

- [ ] Existing OAuth flow still works unchanged (filter returns the default URL when no consumer hooks it)
- [ ] Connect success notice displays after redirect (previously lost)
- [ ] A consumer filtering `atmosphere_oauth_redirect_uri` receives the callback at their custom URL

<details>
<summary>Changelog Details</summary>

- [x] Automatically create a changelog entry from the details below

#### Significance
- [x] Patch
- [ ] Minor
- [ ] Major

#### Type
- [x] Added
- [ ] Changed
- [ ] Deprecated
- [ ] Removed
- [ ] Fixed
- [ ] Security

#### Message
Add `atmosphere_oauth_redirect_uri` filter and persist connect success notice across redirect.

</details>