### PR TITLE
Plugin bootstrap and teardown cleanups

### DIFF
--- a/.github/changelog/cleanup-tweaks
+++ b/.github/changelog/cleanup-tweaks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Clear every plugin-owned scheduled event on deactivate and uninstall so leftover jobs don't linger after the plugin is removed.

--- a/atmosphere.php
+++ b/atmosphere.php
@@ -66,6 +66,8 @@ function activate() {
 function deactivate() {
 	\wp_clear_scheduled_hook( 'atmosphere_refresh_token' );
 	\wp_clear_scheduled_hook( 'atmosphere_sync_reactions' );
+	\wp_clear_scheduled_hook( 'atmosphere_sync_publication' );
+	\wp_clear_scheduled_hook( 'atmosphere_delete_records' );
 	// Clear the legacy hook name in case an earlier PR-6 build scheduled it.
 	\wp_clear_scheduled_hook( 'atmosphere_sync_comments' );
 	\flush_rewrite_rules();

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -25,11 +25,16 @@ class Atmosphere {
 	 * Wire up all hooks.
 	 */
 	public function init(): void {
-		// Admin.
-		if ( \is_admin() ) {
-			Admin::register();
-			Backfill::register();
-		}
+		/*
+		 * Admin and Backfill self-register on admin_init, which only
+		 * fires in admin context (including admin-ajax.php). Priority 5
+		 * runs before the default-priority admin_init phase so the
+		 * sub-hooks Admin::register() installs at admin_init priority 10
+		 * (handle_oauth_callback, register_settings) still fire on this
+		 * request.
+		 */
+		\add_action( 'admin_init', array( Admin::class, 'register' ), 5 );
+		\add_action( 'admin_init', array( Backfill::class, 'register' ), 5 );
 
 		// REST route (always active for client-metadata).
 		\add_action( 'rest_api_init', array( Admin::class, 'register_rest_routes' ) );

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -34,8 +34,11 @@ class Admin {
 		// Meta box on syncable post types.
 		\add_action( 'add_meta_boxes', array( self::class, 'add_meta_box' ) );
 
-		// REST route for client metadata.
-		\add_action( 'rest_api_init', array( self::class, 'register_rest_routes' ) );
+		/*
+		 * REST route for client metadata is registered globally from
+		 * Atmosphere::init() — rest_api_init does not fire on admin
+		 * requests, so wiring it up here is redundant.
+		 */
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === ATmosphere ===
-Contributors: automattic, pfefferle
+Contributors: automattic, pfefferle, kraftbj, ryancowles
 Tags: at-protocol, bluesky, fediverse, atproto, crossposting
 Requires at least: 6.2
 Tested up to: 7.0

--- a/uninstall.php
+++ b/uninstall.php
@@ -22,6 +22,9 @@ wp_clear_scheduled_hook( 'atmosphere_refresh_token' );
 wp_clear_scheduled_hook( 'atmosphere_publish_post' );
 wp_clear_scheduled_hook( 'atmosphere_update_post' );
 wp_clear_scheduled_hook( 'atmosphere_delete_post' );
+wp_clear_scheduled_hook( 'atmosphere_delete_records' );
+wp_clear_scheduled_hook( 'atmosphere_sync_publication' );
+wp_clear_scheduled_hook( 'atmosphere_sync_reactions' );
 
 // Remove post meta.
 global $wpdb;


### PR DESCRIPTION
## Proposed changes:

Grab bag of bootstrap / teardown cleanups found while sweeping the plugin for low-risk improvements:

- **Defer admin registration to `admin_init`.** `Atmosphere::init()` no longer branches on `is_admin()` to call `Admin::register()` / `Backfill::register()` at plugins_loaded time; both self-register on the `admin_init` action at priority 5. `admin_init` only fires on admin requests (including `admin-ajax.php`), so the `is_admin()` guard becomes redundant. Priority 5 is chosen so `Admin::register()` installs its own `admin_init` sub-hooks (`handle_oauth_callback`, `register_settings`, at priority 10) before this request's default-priority admin_init phase begins — behavior-identical to today.
- **Drop the duplicate `rest_api_init` registration in `Admin::register()`.** `Atmosphere::init()` already wires the client-metadata REST route globally, and `rest_api_init` is never fired on an admin request, so the duplicate line in `Admin::register()` only re-registered the callback on admin-screen loads where it would never be invoked.
- **Clear every plugin-owned scheduled event on deactivate / uninstall.** `uninstall.php` now clears `atmosphere_delete_records`, `atmosphere_sync_publication`, and `atmosphere_sync_reactions` alongside the hooks it already cleared. `atmosphere.php`'s `deactivate()` gains `atmosphere_sync_publication` and `atmosphere_delete_records`. Prevents stale events from lingering in the WP-Cron option table.

### Other information:

- [x] Have you written new tests for your changes, if applicable? (Pure lifecycle / teardown changes; existing suite still passes.)

## Testing instructions:

* Install and activate the plugin, then deactivate it — confirm `wp_get_scheduled_event( 'atmosphere_sync_publication' )` and `wp_get_scheduled_event( 'atmosphere_delete_records' )` both return `false`.
* Uninstall the plugin — confirm every `atmosphere_*` hook is gone from the cron option table.
* Visit the ATmosphere settings page (`Settings → ATmosphere`) — confirm the connect flow works, the connect notice displays, and the meta box renders on the post editor.
* Run the backfill via the admin UI — confirm the \`wp_ajax_atmosphere_backfill_*\` handlers still respond.
* Load any frontend page — confirm \`/wp-json/atmosphere/v1/client-metadata\` still returns the client metadata JSON.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fixed

#### Message

Clear every plugin-owned scheduled event on deactivate and uninstall so leftover jobs don't linger after the plugin is removed.

</details>