### PR TITLE
Update license to correct GPLv2-or-greater link

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,25 @@
+ATmosphere - Publish WordPress posts to AT Protocol (Bluesky and standard.site)
+
+Copyright (C) 2025 Automattic and ATmosphere contributors
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+The full text of GPL version 2 follows.
+
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 

--- a/atmosphere.php
+++ b/atmosphere.php
@@ -7,7 +7,7 @@
  * Author: Automattic
  * Author URI: https://automattic.com
  * License: GPL-2.0-or-later
- * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ * License URI: https://spdx.org/licenses/GPL-2.0-or-later.html
  * Text Domain: atmosphere
  * Requires PHP: 8.2
  * Requires at least: 6.2

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 7.0
 Requires PHP: 8.2
 Stable tag: unreleased
 License: GPL-2.0-or-later
-License URI: https://www.gnu.org/licenses/gpl-2.0.html
+License URI: https://spdx.org/licenses/GPL-2.0-or-later.html
 
 Publish WordPress posts to AT Protocol (Bluesky and standard.site) via native OAuth.
 


### PR DESCRIPTION
## Proposed changes:

This corrects the license link from the GPLv2 version to the SPDX one for GPLv2 or greater: https://spdx.org/licenses/GPL-2.0-or-later.html.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Verify the `License URI` in `atmosphere.php` and `readme.txt` matches the License header.