### PR TITLE
Register Admin and Backfill on init instead of admin_init

### DIFF
--- a/.github/changelog/fix-admin-registration-on-init
+++ b/.github/changelog/fix-admin-registration-on-init
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the settings page, meta box, and backfill actions not loading after the previous admin hook change.

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -26,15 +26,13 @@ class Atmosphere {
 	 */
 	public function init(): void {
 		/*
-		 * Admin and Backfill self-register on admin_init, which only
-		 * fires in admin context (including admin-ajax.php). Priority 5
-		 * runs before the default-priority admin_init phase so the
-		 * sub-hooks Admin::register() installs at admin_init priority 10
-		 * (handle_oauth_callback, register_settings) still fire on this
-		 * request.
+		 * Admin and Backfill self-register on init. This runs before
+		 * admin_init, rest_api_init, and wp_ajax_* so sub-hooks those
+		 * callbacks add are wired up in time, and it also ensures
+		 * REST/AJAX endpoints are available on non-admin requests.
 		 */
-		\add_action( 'admin_init', array( Admin::class, 'register' ), 5 );
-		\add_action( 'admin_init', array( Backfill::class, 'register' ), 5 );
+		\add_action( 'init', array( Admin::class, 'register' ), 5 );
+		\add_action( 'init', array( Backfill::class, 'register' ), 5 );
 
 		// REST route (always active for client-metadata).
 		\add_action( 'rest_api_init', array( Admin::class, 'register_rest_routes' ) );


### PR DESCRIPTION
## Proposed changes:

* Move `Admin::register()` and `Backfill::register()` from `admin_init` (priority 5) back to `init` (priority 5).

Hooking them on `admin_init` (introduced in d3e2d88) broke the admin integration in practice. Registering on `init` ensures the sub-hooks those callbacks install — `admin_menu`, `admin_init` sub-hooks, `admin_post_*`, `add_meta_boxes`, `rest_api_init`, and `wp_ajax_*` — are wired up in time regardless of request type. The hooks they register are admin-context-only and are silently ignored on frontend, cron, and REST requests, so there is no meaningful overhead.

### Other information:

- [ ] Have you written new tests for your changes, if applicable? (No behavior change beyond fixing the regression; existing suite passes.)

## Testing instructions:

* On a site with the previous build applied, confirm the Atmosphere settings page, post meta box, and backfill AJAX actions work again.
* Go to **Settings → ATmosphere** and verify the page renders and settings save.
* Open a post edit screen for a syncable post type and confirm the ATmosphere meta box appears.
* Trigger a backfill from the settings page and confirm it progresses without 400/0 responses.
* Run `composer lint` and `npm run env-test` — both clean.

### Changelog entry

Included in `.github/changelog/fix-admin-registration-on-init`.