### PR TITLE
Split publish/cleanup gates so allowlist changes don't orphan remote records

### DIFF
--- a/.github/changelog/add-post-type-support
+++ b/.github/changelog/add-post-type-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Choose which post types are published to AT Protocol from the ATmosphere settings page. Plugins and themes can also opt their custom post types in directly with `add_post_type_support( 'your_type', 'atmosphere' )`.

--- a/.github/changelog/fix-cleanup-gate-split
+++ b/.github/changelog/fix-cleanup-gate-split
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Preserve remote cleanup of already-synced posts when their post type is removed from the syncable allowlist.

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -251,8 +251,36 @@ class Atmosphere {
 			return;
 		}
 
-		if ( ! \in_array( $post->post_type, Backfill::syncable_post_types(), true ) ) {
+		$is_new_publish = 'publish' === $new_status && 'publish' !== $old_status;
+		$is_update      = 'publish' === $new_status && 'publish' === $old_status;
+		$is_unpublish   = 'publish' === $old_status && 'publish' !== $new_status;
+
+		if ( ! $is_new_publish && ! $is_update && ! $is_unpublish ) {
+			// Transition between two non-publish states; nothing to schedule.
 			return;
+		}
+
+		/*
+		 * Publish-time decisions respect the allowlist so sites only sync
+		 * the post types they've opted into. Unpublish is a cleanup path
+		 * for records that were already synced, so narrowing the allowlist
+		 * later must not orphan those remote records: unpublish defers to
+		 * publication metadata (TIDs on the post) instead of the current
+		 * allowlist.
+		 */
+		if ( ( $is_new_publish || $is_update )
+			&& ! \in_array( $post->post_type, Backfill::syncable_post_types(), true )
+		) {
+			return;
+		}
+
+		if ( $is_unpublish ) {
+			$bsky_tid = \get_post_meta( $post->ID, Transformer\Post::META_TID, true );
+			$doc_tid  = \get_post_meta( $post->ID, Transformer\Document::META_TID, true );
+			if ( ! $bsky_tid && ! $doc_tid ) {
+				// Unpublish of a post that was never synced — nothing to clean up.
+				return;
+			}
 		}
 
 		// Prevent infinite loops from meta updates.
@@ -262,24 +290,18 @@ class Atmosphere {
 
 		\do_action( 'atmosphere_publishing' );
 
-		if ( 'publish' === $new_status && 'publish' !== $old_status ) {
-			// New publish — schedule async.
+		if ( $is_new_publish ) {
 			\wp_schedule_single_event( \time(), 'atmosphere_publish_post', array( $post->ID ) );
-		} elseif ( 'publish' === $new_status && 'publish' === $old_status ) {
-			// Update.
+		} elseif ( $is_update ) {
 			\wp_schedule_single_event( \time(), 'atmosphere_update_post', array( $post->ID ) );
-		} elseif ( 'publish' === $old_status && 'publish' !== $new_status ) {
+		} else {
 			/*
-			 * Genuine unpublish — transitioning away from publish.
-			 * Use atmosphere_delete_post (not delete_records) so that
-			 * post meta is cleaned up on success, allowing a subsequent
-			 * restore (trash → publish) to republish correctly.
+			 * Genuine unpublish — use atmosphere_delete_post (not
+			 * delete_records) so post meta is cleaned up on success,
+			 * allowing a subsequent restore (trash → publish) to
+			 * republish correctly.
 			 */
-			$bsky_tid = \get_post_meta( $post->ID, Transformer\Post::META_TID, true );
-			$doc_tid  = \get_post_meta( $post->ID, Transformer\Document::META_TID, true );
-			if ( $bsky_tid || $doc_tid ) {
-				\wp_schedule_single_event( \time(), 'atmosphere_delete_post', array( $post->ID ) );
-			}
+			\wp_schedule_single_event( \time(), 'atmosphere_delete_post', array( $post->ID ) );
 		}
 	}
 
@@ -298,10 +320,18 @@ class Atmosphere {
 
 		$post = \get_post( $post_id );
 
-		if ( ! $post || ! \in_array( $post->post_type, Backfill::syncable_post_types(), true ) ) {
+		if ( ! $post ) {
 			return;
 		}
 
+		/*
+		 * No allowlist check here. Permanent delete is a cleanup path: if
+		 * the post has Atmosphere publication metadata it was synced at
+		 * some point, and the remote records must be removed even if the
+		 * post type has since been dropped from the syncable allowlist.
+		 * Gating this on the current allowlist would orphan already-
+		 * published records whenever a site narrows its configuration.
+		 */
 		$bsky_tid = \get_post_meta( $post_id, Transformer\Post::META_TID, true );
 		$doc_tid  = \get_post_meta( $post_id, Transformer\Document::META_TID, true );
 

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -98,7 +98,7 @@ class Atmosphere {
 			return;
 		}
 
-		if ( ! \in_array( $post->post_type, Backfill::syncable_post_types(), true ) ) {
+		if ( ! is_supported_post_type( $post->post_type ) ) {
 			return;
 		}
 
@@ -220,7 +220,7 @@ class Atmosphere {
 			return;
 		}
 
-		if ( ! \in_array( $post->post_type, Backfill::syncable_post_types(), true ) ) {
+		if ( ! is_supported_post_type( $post->post_type ) ) {
 			\status_header( 404 );
 			exit;
 		}
@@ -261,16 +261,14 @@ class Atmosphere {
 		}
 
 		/*
-		 * Publish-time decisions respect the allowlist so sites only sync
-		 * the post types they've opted into. Unpublish is a cleanup path
-		 * for records that were already synced, so narrowing the allowlist
-		 * later must not orphan those remote records: unpublish defers to
-		 * publication metadata (TIDs on the post) instead of the current
-		 * allowlist.
+		 * Publish-time decisions respect the supported list so sites
+		 * only sync the post types they've opted into. Unpublish is a
+		 * cleanup path for records that were already synced, so
+		 * narrowing support later must not orphan those remote records:
+		 * unpublish defers to publication metadata (TIDs on the post)
+		 * instead of the current support list.
 		 */
-		if ( ( $is_new_publish || $is_update )
-			&& ! \in_array( $post->post_type, Backfill::syncable_post_types(), true )
-		) {
+		if ( ( $is_new_publish || $is_update ) && ! is_supported_post_type( $post->post_type ) ) {
 			return;
 		}
 
@@ -325,12 +323,12 @@ class Atmosphere {
 		}
 
 		/*
-		 * No allowlist check here. Permanent delete is a cleanup path: if
+		 * No support check here. Permanent delete is a cleanup path: if
 		 * the post has Atmosphere publication metadata it was synced at
 		 * some point, and the remote records must be removed even if the
-		 * post type has since been dropped from the syncable allowlist.
-		 * Gating this on the current allowlist would orphan already-
-		 * published records whenever a site narrows its configuration.
+		 * post type has since been removed from the supported list.
+		 * Gating this on current support would orphan already-published
+		 * records whenever a site narrows its configuration.
 		 */
 		$bsky_tid = \get_post_meta( $post_id, Transformer\Post::META_TID, true );
 		$doc_tid  = \get_post_meta( $post_id, Transformer\Document::META_TID, true );
@@ -368,11 +366,19 @@ class Atmosphere {
 	 * Register async action hooks (called by WP-Cron).
 	 */
 	public static function register_async_hooks(): void {
+		/*
+		 * Publish/update cron callbacks re-check post-type support.
+		 * A user (or downstream filter) can disable a post type after a
+		 * cron event was queued, and we must not still publish it.
+		 *
+		 * The delete callback intentionally skips this check so cleanup
+		 * still runs after support is removed.
+		 */
 		\add_action(
 			'atmosphere_publish_post',
 			static function ( int $post_id ): void {
 				$post = \get_post( $post_id );
-				if ( $post && 'publish' === $post->post_status ) {
+				if ( $post && 'publish' === $post->post_status && is_supported_post_type( $post->post_type ) ) {
 					Publisher::publish( $post );
 				}
 			}
@@ -382,7 +388,7 @@ class Atmosphere {
 			'atmosphere_update_post',
 			static function ( int $post_id ): void {
 				$post = \get_post( $post_id );
-				if ( $post && 'publish' === $post->post_status ) {
+				if ( $post && 'publish' === $post->post_status && is_supported_post_type( $post->post_type ) ) {
 					Publisher::update( $post );
 				}
 			}

--- a/includes/class-backfill.php
+++ b/includes/class-backfill.php
@@ -37,7 +37,21 @@ class Backfill {
 
 		\check_ajax_referer( 'atmosphere_backfill', 'nonce' );
 
-		$post_types = self::syncable_post_types();
+		$post_types = get_supported_post_types();
+
+		/*
+		 * Short-circuit when no post types are enabled. Passing an empty
+		 * array to get_posts() falls back to the default `post` query,
+		 * which would surface posts that nothing is configured to sync.
+		 */
+		if ( empty( $post_types ) ) {
+			\wp_send_json_success(
+				array(
+					'total'    => 0,
+					'post_ids' => array(),
+				)
+			);
+		}
 
 		/**
 		 * Filters the maximum number of posts to backfill.
@@ -99,12 +113,14 @@ class Backfill {
 			\wp_send_json_error( 'No post IDs provided.' );
 		}
 
-		$results = array();
+		// Resolve supported post types once for the whole batch.
+		$supported = get_supported_post_types();
+		$results   = array();
 
 		foreach ( $post_ids as $post_id ) {
 			$post = \get_post( $post_id );
 
-			if ( ! $post || 'publish' !== $post->post_status ) {
+			if ( ! $post || 'publish' !== $post->post_status || ! \in_array( $post->post_type, $supported, true ) ) {
 				$results[] = array(
 					'id'      => $post_id,
 					'success' => false,
@@ -132,19 +148,5 @@ class Backfill {
 		}
 
 		\wp_send_json_success( array( 'results' => $results ) );
-	}
-
-	/**
-	 * Get the post types eligible for syncing.
-	 *
-	 * @return string[]
-	 */
-	public static function syncable_post_types(): array {
-		/**
-		 * Filters the post types that can be synced to AT Protocol.
-		 *
-		 * @param string[] $post_types Post type slugs.
-		 */
-		return \apply_filters( 'atmosphere_syncable_post_types', array( 'post' ) );
 	}
 }

--- a/includes/class-post-types.php
+++ b/includes/class-post-types.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Post type support resolution and sanitization.
+ *
+ * @package Atmosphere
+ */
+
+namespace Atmosphere;
+
+\defined( 'ABSPATH' ) || exit;
+
+/**
+ * Post Types class.
+ */
+class Post_Types {
+
+	/**
+	 * Resolve the full set of supported post types.
+	 *
+	 * Combines the configured option with anything third parties opted
+	 * in via `\add_post_type_support( $post_type, 'atmosphere' )`.
+	 *
+	 * @return string[]
+	 */
+	public static function get_supported(): array {
+		$configured = (array) \get_option( 'atmosphere_support_post_types', array( 'post' ) );
+		$native     = \get_post_types_by_support( 'atmosphere' );
+
+		$post_types = \array_merge( $configured, $native );
+
+		/**
+		 * Filters the post types that support ATmosphere publishing.
+		 *
+		 * Runs after the option and native `add_post_type_support()`
+		 * opt-ins are merged, so plugins can add or remove either source.
+		 *
+		 * @param string[] $post_types Post type slugs.
+		 */
+		$post_types = (array) \apply_filters( 'atmosphere_syncable_post_types', $post_types );
+
+		// Normalise: drop empties / non-strings, dedupe, re-index.
+		$post_types = \array_filter( $post_types, '\is_string' );
+		$post_types = \array_map( 'sanitize_key', $post_types );
+		$post_types = \array_filter( $post_types );
+
+		return \array_values( \array_unique( $post_types ) );
+	}
+
+	/**
+	 * Whether a post type is supported.
+	 *
+	 * @param string $post_type Post type slug.
+	 * @return bool
+	 */
+	public static function supports( string $post_type ): bool {
+		return \in_array( $post_type, self::get_supported(), true );
+	}
+
+	/**
+	 * Sanitize the option on save.
+	 *
+	 * Normalises input to a clean string[] of unique public post type
+	 * slugs. Coerces empty input (e.g. all checkboxes unchecked) to an
+	 * empty array.
+	 *
+	 * @param mixed $value Submitted value.
+	 * @return string[]
+	 */
+	public static function sanitize( $value ): array {
+		if ( empty( $value ) ) {
+			return array();
+		}
+
+		$allowed = \get_post_types( array( 'public' => true ) );
+
+		$value = \array_filter( (array) $value, '\is_string' );
+		$value = \array_map( 'sanitize_key', $value );
+		$value = \array_filter( $value );
+
+		return \array_values( \array_unique( \array_intersect( $value, $allowed ) ) );
+	}
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -128,3 +128,22 @@ function get_did(): string {
 function get_pds_endpoint(): string {
 	return get_connection()['pds_endpoint'] ?? '';
 }
+
+/**
+ * Get post types that publish to AT Protocol.
+ *
+ * @return string[] Post type slugs.
+ */
+function get_supported_post_types(): array {
+	return Post_Types::get_supported();
+}
+
+/**
+ * Whether a post type publishes to AT Protocol.
+ *
+ * @param string $post_type Post type slug.
+ * @return bool
+ */
+function is_supported_post_type( string $post_type ): bool {
+	return Post_Types::supports( $post_type );
+}

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -9,10 +9,11 @@ namespace Atmosphere\WP_Admin;
 
 \defined( 'ABSPATH' ) || exit;
 
-use Atmosphere\Backfill;
 use Atmosphere\OAuth\Client;
+use Atmosphere\Post_Types;
 use Atmosphere\Publisher;
 use function Atmosphere\get_connection;
+use function Atmosphere\get_supported_post_types;
 use function Atmosphere\is_connected;
 
 /**
@@ -70,6 +71,23 @@ class Admin {
 
 		\register_setting(
 			'atmosphere',
+			'atmosphere_support_post_types',
+			array(
+				'type'              => 'array',
+				'description'       => 'Post types to publish to AT Protocol.',
+				'default'           => array( 'post' ),
+				'sanitize_callback' => array( Post_Types::class, 'sanitize' ),
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'string' ),
+					),
+				),
+			)
+		);
+
+		\register_setting(
+			'atmosphere',
 			'atmosphere_handle',
 			array(
 				'type'              => 'string',
@@ -112,6 +130,14 @@ class Admin {
 			'atmosphere_auto_publish',
 			\__( 'Auto-publish', 'atmosphere' ),
 			array( self::class, 'render_auto_publish_field' ),
+			'atmosphere',
+			'atmosphere_publishing'
+		);
+
+		\add_settings_field(
+			'atmosphere_support_post_types',
+			\__( 'Post types', 'atmosphere' ),
+			array( self::class, 'render_support_post_types_field' ),
 			'atmosphere',
 			'atmosphere_publishing'
 		);
@@ -244,6 +270,64 @@ class Admin {
 			<?php \esc_html_e( 'Automatically publish new posts to AT Protocol', 'atmosphere' ); ?>
 		</label>
 		<p class="description"><?php \esc_html_e( 'When enabled, posts are sent to your PDS as soon as they are published in WordPress.', 'atmosphere' ); ?></p>
+		<?php
+	}
+
+	/**
+	 * Render the post type support checkboxes.
+	 */
+	public static function render_support_post_types_field(): void {
+		$post_types = \get_post_types( array( 'public' => true ), 'objects' );
+
+		/*
+		 * The checkbox state reflects the saved option only. Native
+		 * `add_post_type_support()` opt-ins and the syncable filter are
+		 * surfaced as a note below the label so the user can see when a
+		 * post type is enabled outside this UI.
+		 */
+		$saved     = (array) \get_option( 'atmosphere_support_post_types', array( 'post' ) );
+		$saved     = \array_filter( \array_map( 'sanitize_key', $saved ) );
+		$effective = get_supported_post_types();
+		?>
+		<fieldset>
+			<legend class="screen-reader-text">
+				<?php \esc_html_e( 'Post types', 'atmosphere' ); ?>
+			</legend>
+			<?php
+			foreach ( $post_types as $post_type ) :
+				$is_saved        = \in_array( $post_type->name, $saved, true );
+				$is_effective    = \in_array( $post_type->name, $effective, true );
+				$is_external     = ! $is_saved && $is_effective;
+				$is_filtered_out = $is_saved && ! $is_effective;
+				?>
+				<p>
+					<label>
+						<input
+							type="checkbox"
+							name="atmosphere_support_post_types[]"
+							value="<?php echo \esc_attr( $post_type->name ); ?>"
+							<?php \checked( $is_saved ); ?>
+						>
+						<?php echo \esc_html( $post_type->label ); ?>
+						<code><?php echo \esc_html( $post_type->name ); ?></code>
+					</label>
+					<?php if ( $is_external ) : ?>
+						<br>
+						<span class="description">
+							<?php \esc_html_e( 'Enabled by another plugin or theme.', 'atmosphere' ); ?>
+						</span>
+					<?php elseif ( $is_filtered_out ) : ?>
+						<br>
+						<span class="description">
+							<?php \esc_html_e( 'Disabled by another plugin or theme — this post type will not be published.', 'atmosphere' ); ?>
+						</span>
+					<?php endif; ?>
+				</p>
+			<?php endforeach; ?>
+		</fieldset>
+		<p class="description">
+			<?php \esc_html_e( 'Select which post types are published to AT Protocol.', 'atmosphere' ); ?>
+		</p>
 		<?php
 	}
 
@@ -399,7 +483,7 @@ class Admin {
 			return;
 		}
 
-		foreach ( Backfill::syncable_post_types() as $post_type ) {
+		foreach ( get_supported_post_types() as $post_type ) {
 			\add_meta_box(
 				'atmosphere',
 				\__( 'ATmosphere', 'atmosphere' ),

--- a/tests/phpunit/tests/class-test-post-types.php
+++ b/tests/phpunit/tests/class-test-post-types.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Tests for the Post_Types class and the post-type helper functions.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group post-types
+ */
+
+namespace Atmosphere\Tests;
+
+use WP_UnitTestCase;
+use Atmosphere\Post_Types;
+use function Atmosphere\get_supported_post_types;
+use function Atmosphere\is_supported_post_type;
+
+/**
+ * Post type support tests.
+ */
+class Test_Post_Types extends WP_UnitTestCase {
+
+	/**
+	 * Reset state between tests.
+	 */
+	public function tear_down(): void {
+		\remove_post_type_support( 'page', 'atmosphere' );
+		\delete_option( 'atmosphere_support_post_types' );
+		\remove_all_filters( 'atmosphere_syncable_post_types' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Default option includes the `post` type.
+	 */
+	public function test_default_includes_post() {
+		$this->assertTrue( is_supported_post_type( 'post' ) );
+	}
+
+	/**
+	 * Custom option drives the supported list.
+	 */
+	public function test_option_drives_supported_list() {
+		\update_option( 'atmosphere_support_post_types', array( 'post', 'page' ) );
+
+		$supported = get_supported_post_types();
+
+		$this->assertContains( 'post', $supported );
+		$this->assertContains( 'page', $supported );
+		$this->assertTrue( is_supported_post_type( 'page' ) );
+	}
+
+	/**
+	 * Empty option means nothing is supported (unless opted in via WP API).
+	 */
+	public function test_empty_option_supports_nothing() {
+		\update_option( 'atmosphere_support_post_types', array() );
+
+		$this->assertFalse( is_supported_post_type( 'post' ) );
+		$this->assertSame( array(), get_supported_post_types() );
+	}
+
+	/**
+	 * Third parties can opt their post types in via WP's native API.
+	 */
+	public function test_third_party_add_post_type_support() {
+		\update_option( 'atmosphere_support_post_types', array() );
+		\add_post_type_support( 'page', 'atmosphere' );
+
+		$this->assertTrue( is_supported_post_type( 'page' ) );
+		$this->assertContains( 'page', get_supported_post_types() );
+	}
+
+	/**
+	 * The `atmosphere_syncable_post_types` filter still adjusts the list.
+	 */
+	public function test_filter_can_add_post_type() {
+		\add_filter(
+			'atmosphere_syncable_post_types',
+			static function ( array $types ): array {
+				$types[] = 'page';
+				return $types;
+			}
+		);
+
+		$this->assertTrue( is_supported_post_type( 'page' ) );
+	}
+
+	/**
+	 * `Post_Types::sanitize()` drops unknown / non-public post types.
+	 */
+	public function test_sanitize_filters_unknown_post_types() {
+		$result = Post_Types::sanitize( array( 'post', 'bogus_type', 'page' ) );
+
+		$this->assertSame( array( 'post', 'page' ), $result );
+	}
+
+	/**
+	 * `Post_Types::sanitize()` coerces empty input to an empty array.
+	 */
+	public function test_sanitize_handles_empty_input() {
+		$this->assertSame( array(), Post_Types::sanitize( null ) );
+		$this->assertSame( array(), Post_Types::sanitize( '' ) );
+		$this->assertSame( array(), Post_Types::sanitize( array() ) );
+	}
+
+	/**
+	 * `Post_Types::sanitize()` dedupes the result so the saved option is
+	 * a canonical list.
+	 */
+	public function test_sanitize_dedupes() {
+		$result = Post_Types::sanitize( array( 'post', 'page', 'post', 'page' ) );
+
+		$this->assertSame( array( 'post', 'page' ), $result );
+	}
+
+	/**
+	 * `Post_Types::sanitize()` drops non-strings and empties so callers
+	 * never store junk.
+	 */
+	public function test_sanitize_drops_non_strings_and_empties() {
+		$result = Post_Types::sanitize( array( 'post', '', null, 42, true, 'page' ) );
+
+		$this->assertSame( array( 'post', 'page' ), $result );
+	}
+
+	/**
+	 * Filter callbacks returning duplicates / non-strings / empties are
+	 * normalised away so callers always get a clean string[] of unique slugs.
+	 */
+	public function test_get_supported_normalises_filter_output() {
+		\add_filter(
+			'atmosphere_syncable_post_types',
+			static function (): array {
+				return array( 'post', 'post', '', null, 42, 'page' );
+			}
+		);
+
+		$result = get_supported_post_types();
+
+		$this->assertSame( array( 'post', 'page' ), \array_values( $result ) );
+	}
+}

--- a/tests/phpunit/tests/class-test-status-change.php
+++ b/tests/phpunit/tests/class-test-status-change.php
@@ -284,4 +284,90 @@ class Test_Status_Change extends WP_UnitTestCase {
 			'Disconnected state must prevent scheduling.'
 		);
 	}
+
+	/**
+	 * Unpublish of a previously-synced post with a post type no longer in
+	 * the syncable allowlist must still schedule remote cleanup. Without
+	 * this, narrowing the allowlist after publishing orphans the remote
+	 * records.
+	 */
+	public function test_unpublish_of_previously_synced_non_syncable_post_schedules_delete() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_status' => 'draft',
+				'post_type'   => 'page',
+			)
+		);
+
+		\update_post_meta( $post->ID, Post::META_TID, 'bsky-tid-123' );
+		\update_post_meta( $post->ID, Document::META_TID, 'doc-tid-456' );
+
+		$this->reset_publishing_action();
+		$this->atmosphere->on_status_change( 'draft', 'publish', $post );
+
+		$this->assertNotFalse(
+			\wp_next_scheduled( 'atmosphere_delete_post', array( $post->ID ) ),
+			'Unpublish must clean up remote records even when the post type is no longer in the syncable allowlist.'
+		);
+	}
+
+	/**
+	 * Permanent delete of a previously-synced post with a post type no
+	 * longer in the syncable allowlist must still capture TIDs and
+	 * schedule remote cleanup. Same rationale as the unpublish test
+	 * above: the allowlist governs new-publish eligibility, not cleanup.
+	 */
+	public function test_before_delete_of_previously_synced_non_syncable_post_schedules_delete_records() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_status' => 'publish',
+				'post_type'   => 'page',
+			)
+		);
+
+		\update_post_meta( $post->ID, Post::META_TID, 'bsky-tid-123' );
+		\update_post_meta( $post->ID, Document::META_TID, 'doc-tid-456' );
+
+		$this->atmosphere->on_before_delete( $post->ID );
+
+		$this->assertNotFalse(
+			\wp_next_scheduled(
+				'atmosphere_delete_records',
+				array( 'bsky-tid-123', 'doc-tid-456' )
+			),
+			'Permanent delete must schedule remote cleanup even when the post type is no longer in the syncable allowlist.'
+		);
+	}
+
+	/**
+	 * Regression guard for the split gate: narrowing the allowlist via
+	 * the `atmosphere_syncable_post_types` filter must still block a
+	 * new-publish of a post type the filter excludes. Only cleanup
+	 * paths are meant to bypass the allowlist.
+	 */
+	public function test_new_publish_respects_allowlist_even_when_filter_narrows() {
+		$narrow = static function () {
+			return array( 'page' );
+		};
+		\add_filter( 'atmosphere_syncable_post_types', $narrow );
+
+		try {
+			$post = self::factory()->post->create_and_get(
+				array(
+					'post_status' => 'publish',
+					'post_type'   => 'post',
+				)
+			);
+
+			$this->reset_publishing_action();
+			$this->atmosphere->on_status_change( 'publish', 'draft', $post );
+
+			$this->assertFalse(
+				\wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) ),
+				'New publish of a post type outside the allowlist must not be scheduled.'
+			);
+		} finally {
+			\remove_filter( 'atmosphere_syncable_post_types', $narrow );
+		}
+	}
 }


### PR DESCRIPTION
Fixes the rollback hazard where narrowing \`atmosphere_syncable_post_types\` (directly or via the \`activitypub_support_post_types\` option projected into that filter, as FOSSE's \`Post_Types\` projector does) orphans the remote AT Protocol records of posts that were already synced under the wider configuration.

## Proposed changes:

- **\`on_status_change()\`** — split the allowlist gate so it governs only the new-publish / update decisions. Unpublish now consults \`_atmosphere_bsky_tid\` / \`_atmosphere_doc_tid\` directly and schedules \`atmosphere_delete_post\` whenever either is present, regardless of whether the post type is currently in the allowlist. The \`did_action/do_action\` recursion guard moves with the scheduling block so non-syncable unpublishes without TIDs still early-return without firing it.
- **\`on_before_delete()\`** — drop the allowlist check entirely. Permanent delete is a pure cleanup path: if the post has Atmosphere publication metadata it was synced at some point, and the remote records must be removed even if the post type has since been dropped from the allowlist. A comment on the method explains the omission.

### Rationale

The bug is a gate-conflation issue. \`Backfill::syncable_post_types()\` answers "what post types is this site willing to publish to Bluesky?" — a publish-time eligibility question. Both cleanup paths were reusing it as a proxy for "was this post ever synced?", which only coincides when the allowlist never narrows. A site owner unchecking a post type on the AP side (where FOSSE's new projector surfaces that control in a way most sites already used) becomes a normal operation, not an edge case — at which point the conflation silently leaks orphaned records.

FOSSE PR Automattic/fosse#31 surfaces this path by making the allowlist editable via AP's existing checkbox UI, but the bug pre-exists in every standalone Atmosphere site that filters \`atmosphere_syncable_post_types\` in PHP. Fixing it here — not in a FOSSE-side workaround — is correct per Atmosphere's existing upstream-first positioning: post-type-agnostic correctness lives here.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Three new PHPUnit cases in \`tests/phpunit/tests/class-test-status-change.php\`:

1. \`test_unpublish_of_previously_synced_non_syncable_post_schedules_delete\` — publish→draft of a \`page\` with synthetic \`META_TID\` / \`META_TID\` (document) set; asserts \`atmosphere_delete_post\` is scheduled even though \`page\` isn't in the default allowlist.
2. \`test_before_delete_of_previously_synced_non_syncable_post_schedules_delete_records\` — \`on_before_delete\` on the same kind of post; asserts \`atmosphere_delete_records\` is scheduled with the captured TIDs.
3. \`test_new_publish_respects_allowlist_even_when_filter_narrows\` — regression guard: narrowing via \`atmosphere_syncable_post_types\` filter still blocks a new publish of a type the filter excludes, so the split gate doesn't accidentally loosen publish-time semantics.

Full suite runs clean (97/97).

## Testing instructions:

- Check out this branch, \`composer install\`, \`npm install\`, \`npm run env-start\`.
- Run \`npx wp-env run tests-cli --env-cwd="wp-content/plugins/wordpress-atmosphere" vendor/bin/phpunit --filter=Test_Status_Change\`. Expect 14/14.
- (Or \`npm run env-test\` for the full 97-case suite.)
- Manual: connect a site, publish a \`post\`, then add \`atmosphere_syncable_post_types\` filter returning \`[]\`, trash the post; confirm \`wp cron event list\` shows an \`atmosphere_delete_post\` scheduled.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Preserve remote cleanup of already-synced posts when their post type is removed from the syncable allowlist.

</details>

---

Companion references:

- Downstream trigger scenario: Automattic/fosse#31 (FOSSE's \`Post_Types\` projector)
- Linear issue: https://linear.app/a8c/issue/DOTCOM-16875