### PR TITLE
Add auto-port wp-env test startup

### DIFF
--- a/.github/changelog/auto-port-wp-env-tests
+++ b/.github/changelog/auto-port-wp-env-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improve the development test setup so automated tests can run while another local WordPress environment is already using the default ports.

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
 	"license": "GPL-2.0-or-later",
 	"private": true,
 	"scripts": {
-		"env-start": "wp-env start",
+		"env-start": "wp-env start --auto-port",
 		"env-stop": "wp-env stop",
+		"preenv-test": "wp-env start --auto-port",
 		"env-test": "wp-env run tests-cli --env-cwd=\"wp-content/plugins/wordpress-atmosphere\" vendor/bin/phpunit",
 		"release": "node bin/release.js"
 	},
 	"devDependencies": {
-		"@wordpress/env": "^11.2.0"
+		"@wordpress/env": "^11.4.0"
 	}
 }


### PR DESCRIPTION
## Proposed changes:

Pass `--auto-port` to `wp-env start` for both regular local development (`npm run env-start`) and the test runner (`npm run env-test`, via a new `preenv-test` step), and bump `@wordpress/env` to `^11.4.0` so the flag is available.

### Why

`wp-env` defaults to a fixed set of ports (8884 for dev, 8889 for tests). If anything else is already listening on those ports — most commonly another `wp-env` instance for a different plugin or theme — `wp-env start` fails outright and `npm run env-test` can't bring its container up. That makes it impossible to run the ATmosphere test suite without first stopping whatever else you have running.

`--auto-port` tells `wp-env` to probe for the next available port and bind to that instead, so the environment comes up cleanly regardless of what else is on those defaults. The dev URL and test container just shift to whatever port is free.

### Tradeoffs

`--auto-port` isn't appropriate everywhere. If you have tooling, bookmarks, browser sessions, or scripts that hardcode `http://localhost:8884`, those will break when the port floats. For workflows like that, keep using fixed ports.

For day-to-day local development and for running the test suite — neither of which depends on a stable URL — letting `wp-env` pick a free port removes a real friction point and is the better default.

### Other information:

- [ ] Have you written new tests for your changes, if applicable? — N/A, tooling change.

## Testing instructions:

* Run `composer lint`.
* Run `npm run env-test` and confirm tests pass.
* With another `wp-env` instance already bound to the default ports, run `npm run env-test` and confirm `wp-env` starts on alternate ports before PHPUnit runs (instead of failing).

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Added - for new features
- [x] Changed - for changes in existing functionality
- [ ] Deprecated - for soon-to-be removed features
- [ ] Removed - for now removed features
- [ ] Fixed - for any bug fixes
- [ ] Security - in case of vulnerabilities

#### Message

Improve the development test setup so automated tests can run while another local WordPress environment is already using the default ports.

</details>