### PR TITLE
Choose which post types publish to AT Protocol

### DIFF
--- a/.github/changelog/add-post-type-support
+++ b/.github/changelog/add-post-type-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Choose which post types are published to AT Protocol from the ATmosphere settings page. Plugins and themes can also opt their custom post types in directly with `add_post_type_support( 'your_type', 'atmosphere' )`.

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -98,7 +98,7 @@ class Atmosphere {
 			return;
 		}
 
-		if ( ! \in_array( $post->post_type, Backfill::syncable_post_types(), true ) ) {
+		if ( ! is_supported_post_type( $post->post_type ) ) {
 			return;
 		}
 
@@ -220,7 +220,7 @@ class Atmosphere {
 			return;
 		}
 
-		if ( ! \in_array( $post->post_type, Backfill::syncable_post_types(), true ) ) {
+		if ( ! is_supported_post_type( $post->post_type ) ) {
 			\status_header( 404 );
 			exit;
 		}
@@ -261,16 +261,14 @@ class Atmosphere {
 		}
 
 		/*
-		 * Publish-time decisions respect the allowlist so sites only sync
-		 * the post types they've opted into. Unpublish is a cleanup path
-		 * for records that were already synced, so narrowing the allowlist
-		 * later must not orphan those remote records: unpublish defers to
-		 * publication metadata (TIDs on the post) instead of the current
-		 * allowlist.
+		 * Publish-time decisions respect the supported list so sites
+		 * only sync the post types they've opted into. Unpublish is a
+		 * cleanup path for records that were already synced, so
+		 * narrowing support later must not orphan those remote records:
+		 * unpublish defers to publication metadata (TIDs on the post)
+		 * instead of the current support list.
 		 */
-		if ( ( $is_new_publish || $is_update )
-			&& ! \in_array( $post->post_type, Backfill::syncable_post_types(), true )
-		) {
+		if ( ( $is_new_publish || $is_update ) && ! is_supported_post_type( $post->post_type ) ) {
 			return;
 		}
 
@@ -325,12 +323,12 @@ class Atmosphere {
 		}
 
 		/*
-		 * No allowlist check here. Permanent delete is a cleanup path: if
+		 * No support check here. Permanent delete is a cleanup path: if
 		 * the post has Atmosphere publication metadata it was synced at
 		 * some point, and the remote records must be removed even if the
-		 * post type has since been dropped from the syncable allowlist.
-		 * Gating this on the current allowlist would orphan already-
-		 * published records whenever a site narrows its configuration.
+		 * post type has since been removed from the supported list.
+		 * Gating this on current support would orphan already-published
+		 * records whenever a site narrows its configuration.
 		 */
 		$bsky_tid = \get_post_meta( $post_id, Transformer\Post::META_TID, true );
 		$doc_tid  = \get_post_meta( $post_id, Transformer\Document::META_TID, true );

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -366,11 +366,19 @@ class Atmosphere {
 	 * Register async action hooks (called by WP-Cron).
 	 */
 	public static function register_async_hooks(): void {
+		/*
+		 * Publish/update cron callbacks re-check post-type support.
+		 * A user (or downstream filter) can disable a post type after a
+		 * cron event was queued, and we must not still publish it.
+		 *
+		 * The delete callback intentionally skips this check so cleanup
+		 * still runs after support is removed.
+		 */
 		\add_action(
 			'atmosphere_publish_post',
 			static function ( int $post_id ): void {
 				$post = \get_post( $post_id );
-				if ( $post && 'publish' === $post->post_status ) {
+				if ( $post && 'publish' === $post->post_status && is_supported_post_type( $post->post_type ) ) {
 					Publisher::publish( $post );
 				}
 			}
@@ -380,7 +388,7 @@ class Atmosphere {
 			'atmosphere_update_post',
 			static function ( int $post_id ): void {
 				$post = \get_post( $post_id );
-				if ( $post && 'publish' === $post->post_status ) {
+				if ( $post && 'publish' === $post->post_status && is_supported_post_type( $post->post_type ) ) {
 					Publisher::update( $post );
 				}
 			}

--- a/includes/class-backfill.php
+++ b/includes/class-backfill.php
@@ -113,12 +113,14 @@ class Backfill {
 			\wp_send_json_error( 'No post IDs provided.' );
 		}
 
-		$results = array();
+		// Resolve supported post types once for the whole batch.
+		$supported = get_supported_post_types();
+		$results   = array();
 
 		foreach ( $post_ids as $post_id ) {
 			$post = \get_post( $post_id );
 
-			if ( ! $post || 'publish' !== $post->post_status || ! is_supported_post_type( $post->post_type ) ) {
+			if ( ! $post || 'publish' !== $post->post_status || ! \in_array( $post->post_type, $supported, true ) ) {
 				$results[] = array(
 					'id'      => $post_id,
 					'success' => false,

--- a/includes/class-backfill.php
+++ b/includes/class-backfill.php
@@ -39,6 +39,20 @@ class Backfill {
 
 		$post_types = get_supported_post_types();
 
+		/*
+		 * Short-circuit when no post types are enabled. Passing an empty
+		 * array to get_posts() falls back to the default `post` query,
+		 * which would surface posts that nothing is configured to sync.
+		 */
+		if ( empty( $post_types ) ) {
+			\wp_send_json_success(
+				array(
+					'total'    => 0,
+					'post_ids' => array(),
+				)
+			);
+		}
+
 		/**
 		 * Filters the maximum number of posts to backfill.
 		 *
@@ -104,7 +118,7 @@ class Backfill {
 		foreach ( $post_ids as $post_id ) {
 			$post = \get_post( $post_id );
 
-			if ( ! $post || 'publish' !== $post->post_status ) {
+			if ( ! $post || 'publish' !== $post->post_status || ! is_supported_post_type( $post->post_type ) ) {
 				$results[] = array(
 					'id'      => $post_id,
 					'success' => false,

--- a/includes/class-backfill.php
+++ b/includes/class-backfill.php
@@ -37,7 +37,7 @@ class Backfill {
 
 		\check_ajax_referer( 'atmosphere_backfill', 'nonce' );
 
-		$post_types = self::syncable_post_types();
+		$post_types = get_supported_post_types();
 
 		/**
 		 * Filters the maximum number of posts to backfill.
@@ -132,19 +132,5 @@ class Backfill {
 		}
 
 		\wp_send_json_success( array( 'results' => $results ) );
-	}
-
-	/**
-	 * Get the post types eligible for syncing.
-	 *
-	 * @return string[]
-	 */
-	public static function syncable_post_types(): array {
-		/**
-		 * Filters the post types that can be synced to AT Protocol.
-		 *
-		 * @param string[] $post_types Post type slugs.
-		 */
-		return \apply_filters( 'atmosphere_syncable_post_types', array( 'post' ) );
 	}
 }

--- a/includes/class-post-types.php
+++ b/includes/class-post-types.php
@@ -26,7 +26,7 @@ class Post_Types {
 		$configured = (array) \get_option( 'atmosphere_support_post_types', array( 'post' ) );
 		$native     = \get_post_types_by_support( 'atmosphere' );
 
-		$post_types = \array_values( \array_unique( \array_merge( $configured, $native ) ) );
+		$post_types = \array_merge( $configured, $native );
 
 		/**
 		 * Filters the post types that support ATmosphere publishing.
@@ -36,7 +36,14 @@ class Post_Types {
 		 *
 		 * @param string[] $post_types Post type slugs.
 		 */
-		return \apply_filters( 'atmosphere_syncable_post_types', $post_types );
+		$post_types = (array) \apply_filters( 'atmosphere_syncable_post_types', $post_types );
+
+		// Normalise: drop empties / non-strings, dedupe, re-index.
+		$post_types = \array_filter( $post_types, '\is_string' );
+		$post_types = \array_map( 'sanitize_key', $post_types );
+		$post_types = \array_filter( $post_types );
+
+		return \array_values( \array_unique( $post_types ) );
 	}
 
 	/**

--- a/includes/class-post-types.php
+++ b/includes/class-post-types.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Post type support resolution and sanitization.
+ *
+ * @package Atmosphere
+ */
+
+namespace Atmosphere;
+
+\defined( 'ABSPATH' ) || exit;
+
+/**
+ * Post Types class.
+ */
+class Post_Types {
+
+	/**
+	 * Resolve the full set of supported post types.
+	 *
+	 * Combines the configured option with anything third parties opted
+	 * in via `\add_post_type_support( $post_type, 'atmosphere' )`.
+	 *
+	 * @return string[]
+	 */
+	public static function get_supported(): array {
+		$configured = (array) \get_option( 'atmosphere_support_post_types', array( 'post' ) );
+		$native     = \get_post_types_by_support( 'atmosphere' );
+
+		$post_types = \array_values( \array_unique( \array_merge( $configured, $native ) ) );
+
+		/**
+		 * Filters the post types that support ATmosphere publishing.
+		 *
+		 * Runs after the option and native `add_post_type_support()`
+		 * opt-ins are merged, so plugins can add or remove either source.
+		 *
+		 * @param string[] $post_types Post type slugs.
+		 */
+		return \apply_filters( 'atmosphere_syncable_post_types', $post_types );
+	}
+
+	/**
+	 * Whether a post type is supported.
+	 *
+	 * @param string $post_type Post type slug.
+	 * @return bool
+	 */
+	public static function supports( string $post_type ): bool {
+		return \in_array( $post_type, self::get_supported(), true );
+	}
+
+	/**
+	 * Sanitize the option on save.
+	 *
+	 * Drops unknown or non-public post types and coerces empty input
+	 * (e.g. all checkboxes unchecked) to an empty array.
+	 *
+	 * @param mixed $value Submitted value.
+	 * @return string[]
+	 */
+	public static function sanitize( $value ): array {
+		if ( empty( $value ) ) {
+			return array();
+		}
+
+		$allowed = \get_post_types( array( 'public' => true ) );
+		$value   = \array_map( 'sanitize_text_field', (array) $value );
+
+		return \array_values( \array_intersect( $value, $allowed ) );
+	}
+}

--- a/includes/class-post-types.php
+++ b/includes/class-post-types.php
@@ -59,8 +59,9 @@ class Post_Types {
 	/**
 	 * Sanitize the option on save.
 	 *
-	 * Drops unknown or non-public post types and coerces empty input
-	 * (e.g. all checkboxes unchecked) to an empty array.
+	 * Normalises input to a clean string[] of unique public post type
+	 * slugs. Coerces empty input (e.g. all checkboxes unchecked) to an
+	 * empty array.
 	 *
 	 * @param mixed $value Submitted value.
 	 * @return string[]
@@ -71,8 +72,11 @@ class Post_Types {
 		}
 
 		$allowed = \get_post_types( array( 'public' => true ) );
-		$value   = \array_map( 'sanitize_text_field', (array) $value );
 
-		return \array_values( \array_intersect( $value, $allowed ) );
+		$value = \array_filter( (array) $value, '\is_string' );
+		$value = \array_map( 'sanitize_key', $value );
+		$value = \array_filter( $value );
+
+		return \array_values( \array_unique( \array_intersect( $value, $allowed ) ) );
 	}
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -128,3 +128,22 @@ function get_did(): string {
 function get_pds_endpoint(): string {
 	return get_connection()['pds_endpoint'] ?? '';
 }
+
+/**
+ * Get post types that publish to AT Protocol.
+ *
+ * @return string[] Post type slugs.
+ */
+function get_supported_post_types(): array {
+	return Post_Types::get_supported();
+}
+
+/**
+ * Whether a post type publishes to AT Protocol.
+ *
+ * @param string $post_type Post type slug.
+ * @return bool
+ */
+function is_supported_post_type( string $post_type ): bool {
+	return Post_Types::supports( $post_type );
+}

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -9,10 +9,11 @@ namespace Atmosphere\WP_Admin;
 
 \defined( 'ABSPATH' ) || exit;
 
-use Atmosphere\Backfill;
 use Atmosphere\OAuth\Client;
+use Atmosphere\Post_Types;
 use Atmosphere\Publisher;
 use function Atmosphere\get_connection;
+use function Atmosphere\get_supported_post_types;
 use function Atmosphere\is_connected;
 
 /**
@@ -70,6 +71,23 @@ class Admin {
 
 		\register_setting(
 			'atmosphere',
+			'atmosphere_support_post_types',
+			array(
+				'type'              => 'array',
+				'description'       => 'Post types to publish to AT Protocol.',
+				'default'           => array( 'post' ),
+				'sanitize_callback' => array( Post_Types::class, 'sanitize' ),
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'string' ),
+					),
+				),
+			)
+		);
+
+		\register_setting(
+			'atmosphere',
 			'atmosphere_handle',
 			array(
 				'type'              => 'string',
@@ -112,6 +130,14 @@ class Admin {
 			'atmosphere_auto_publish',
 			\__( 'Auto-publish', 'atmosphere' ),
 			array( self::class, 'render_auto_publish_field' ),
+			'atmosphere',
+			'atmosphere_publishing'
+		);
+
+		\add_settings_field(
+			'atmosphere_support_post_types',
+			\__( 'Post types', 'atmosphere' ),
+			array( self::class, 'render_support_post_types_field' ),
 			'atmosphere',
 			'atmosphere_publishing'
 		);
@@ -244,6 +270,38 @@ class Admin {
 			<?php \esc_html_e( 'Automatically publish new posts to AT Protocol', 'atmosphere' ); ?>
 		</label>
 		<p class="description"><?php \esc_html_e( 'When enabled, posts are sent to your PDS as soon as they are published in WordPress.', 'atmosphere' ); ?></p>
+		<?php
+	}
+
+	/**
+	 * Render the post type support checkboxes.
+	 */
+	public static function render_support_post_types_field(): void {
+		$post_types = \get_post_types( array( 'public' => true ), 'objects' );
+		$enabled    = get_supported_post_types();
+		?>
+		<fieldset>
+			<legend class="screen-reader-text">
+				<?php \esc_html_e( 'Post types', 'atmosphere' ); ?>
+			</legend>
+			<?php foreach ( $post_types as $post_type ) : ?>
+				<p>
+					<label>
+						<input
+							type="checkbox"
+							name="atmosphere_support_post_types[]"
+							value="<?php echo \esc_attr( $post_type->name ); ?>"
+							<?php \checked( \in_array( $post_type->name, $enabled, true ) ); ?>
+						>
+						<?php echo \esc_html( $post_type->label ); ?>
+						<code><?php echo \esc_html( $post_type->name ); ?></code>
+					</label>
+				</p>
+			<?php endforeach; ?>
+		</fieldset>
+		<p class="description">
+			<?php \esc_html_e( 'Select which post types are published to AT Protocol.', 'atmosphere' ); ?>
+		</p>
 		<?php
 	}
 
@@ -399,7 +457,7 @@ class Admin {
 			return;
 		}
 
-		foreach ( Backfill::syncable_post_types() as $post_type ) {
+		foreach ( get_supported_post_types() as $post_type ) {
 			\add_meta_box(
 				'atmosphere',
 				\__( 'ATmosphere', 'atmosphere' ),

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -278,24 +278,43 @@ class Admin {
 	 */
 	public static function render_support_post_types_field(): void {
 		$post_types = \get_post_types( array( 'public' => true ), 'objects' );
-		$enabled    = get_supported_post_types();
+
+		/*
+		 * The checkbox state reflects the saved option only. Native
+		 * `add_post_type_support()` opt-ins and the syncable filter are
+		 * surfaced as a note below the label so the user can see when a
+		 * post type is enabled outside this UI.
+		 */
+		$saved     = (array) \get_option( 'atmosphere_support_post_types', array( 'post' ) );
+		$saved     = \array_filter( \array_map( 'sanitize_key', $saved ) );
+		$effective = get_supported_post_types();
 		?>
 		<fieldset>
 			<legend class="screen-reader-text">
 				<?php \esc_html_e( 'Post types', 'atmosphere' ); ?>
 			</legend>
-			<?php foreach ( $post_types as $post_type ) : ?>
+			<?php
+			foreach ( $post_types as $post_type ) :
+				$is_saved    = \in_array( $post_type->name, $saved, true );
+				$is_external = ! $is_saved && \in_array( $post_type->name, $effective, true );
+				?>
 				<p>
 					<label>
 						<input
 							type="checkbox"
 							name="atmosphere_support_post_types[]"
 							value="<?php echo \esc_attr( $post_type->name ); ?>"
-							<?php \checked( \in_array( $post_type->name, $enabled, true ) ); ?>
+							<?php \checked( $is_saved ); ?>
 						>
 						<?php echo \esc_html( $post_type->label ); ?>
 						<code><?php echo \esc_html( $post_type->name ); ?></code>
 					</label>
+					<?php if ( $is_external ) : ?>
+						<br>
+						<span class="description">
+							<?php \esc_html_e( 'Enabled by another plugin or theme.', 'atmosphere' ); ?>
+						</span>
+					<?php endif; ?>
 				</p>
 			<?php endforeach; ?>
 		</fieldset>

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -295,8 +295,10 @@ class Admin {
 			</legend>
 			<?php
 			foreach ( $post_types as $post_type ) :
-				$is_saved    = \in_array( $post_type->name, $saved, true );
-				$is_external = ! $is_saved && \in_array( $post_type->name, $effective, true );
+				$is_saved        = \in_array( $post_type->name, $saved, true );
+				$is_effective    = \in_array( $post_type->name, $effective, true );
+				$is_external     = ! $is_saved && $is_effective;
+				$is_filtered_out = $is_saved && ! $is_effective;
 				?>
 				<p>
 					<label>
@@ -313,6 +315,11 @@ class Admin {
 						<br>
 						<span class="description">
 							<?php \esc_html_e( 'Enabled by another plugin or theme.', 'atmosphere' ); ?>
+						</span>
+					<?php elseif ( $is_filtered_out ) : ?>
+						<br>
+						<span class="description">
+							<?php \esc_html_e( 'Disabled by another plugin or theme — this post type will not be published.', 'atmosphere' ); ?>
 						</span>
 					<?php endif; ?>
 				</p>

--- a/tests/phpunit/tests/class-test-post-types.php
+++ b/tests/phpunit/tests/class-test-post-types.php
@@ -103,4 +103,21 @@ class Test_Post_Types extends WP_UnitTestCase {
 		$this->assertSame( array(), Post_Types::sanitize( '' ) );
 		$this->assertSame( array(), Post_Types::sanitize( array() ) );
 	}
+
+	/**
+	 * Filter callbacks returning duplicates / non-strings / empties are
+	 * normalised away so callers always get a clean string[] of unique slugs.
+	 */
+	public function test_get_supported_normalises_filter_output() {
+		\add_filter(
+			'atmosphere_syncable_post_types',
+			static function (): array {
+				return array( 'post', 'post', '', null, 42, 'page' );
+			}
+		);
+
+		$result = get_supported_post_types();
+
+		$this->assertSame( array( 'post', 'page' ), \array_values( $result ) );
+	}
 }

--- a/tests/phpunit/tests/class-test-post-types.php
+++ b/tests/phpunit/tests/class-test-post-types.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Tests for the Post_Types class and the post-type helper functions.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group post-types
+ */
+
+namespace Atmosphere\Tests;
+
+use WP_UnitTestCase;
+use Atmosphere\Post_Types;
+use function Atmosphere\get_supported_post_types;
+use function Atmosphere\is_supported_post_type;
+
+/**
+ * Post type support tests.
+ */
+class Test_Post_Types extends WP_UnitTestCase {
+
+	/**
+	 * Reset state between tests.
+	 */
+	public function tear_down(): void {
+		\remove_post_type_support( 'page', 'atmosphere' );
+		\delete_option( 'atmosphere_support_post_types' );
+		\remove_all_filters( 'atmosphere_syncable_post_types' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Default option includes the `post` type.
+	 */
+	public function test_default_includes_post() {
+		$this->assertTrue( is_supported_post_type( 'post' ) );
+	}
+
+	/**
+	 * Custom option drives the supported list.
+	 */
+	public function test_option_drives_supported_list() {
+		\update_option( 'atmosphere_support_post_types', array( 'post', 'page' ) );
+
+		$supported = get_supported_post_types();
+
+		$this->assertContains( 'post', $supported );
+		$this->assertContains( 'page', $supported );
+		$this->assertTrue( is_supported_post_type( 'page' ) );
+	}
+
+	/**
+	 * Empty option means nothing is supported (unless opted in via WP API).
+	 */
+	public function test_empty_option_supports_nothing() {
+		\update_option( 'atmosphere_support_post_types', array() );
+
+		$this->assertFalse( is_supported_post_type( 'post' ) );
+		$this->assertSame( array(), get_supported_post_types() );
+	}
+
+	/**
+	 * Third parties can opt their post types in via WP's native API.
+	 */
+	public function test_third_party_add_post_type_support() {
+		\update_option( 'atmosphere_support_post_types', array() );
+		\add_post_type_support( 'page', 'atmosphere' );
+
+		$this->assertTrue( is_supported_post_type( 'page' ) );
+		$this->assertContains( 'page', get_supported_post_types() );
+	}
+
+	/**
+	 * The `atmosphere_syncable_post_types` filter still adjusts the list.
+	 */
+	public function test_filter_can_add_post_type() {
+		\add_filter(
+			'atmosphere_syncable_post_types',
+			static function ( array $types ): array {
+				$types[] = 'page';
+				return $types;
+			}
+		);
+
+		$this->assertTrue( is_supported_post_type( 'page' ) );
+	}
+
+	/**
+	 * `Post_Types::sanitize()` drops unknown / non-public post types.
+	 */
+	public function test_sanitize_filters_unknown_post_types() {
+		$result = Post_Types::sanitize( array( 'post', 'bogus_type', 'page' ) );
+
+		$this->assertSame( array( 'post', 'page' ), $result );
+	}
+
+	/**
+	 * `Post_Types::sanitize()` coerces empty input to an empty array.
+	 */
+	public function test_sanitize_handles_empty_input() {
+		$this->assertSame( array(), Post_Types::sanitize( null ) );
+		$this->assertSame( array(), Post_Types::sanitize( '' ) );
+		$this->assertSame( array(), Post_Types::sanitize( array() ) );
+	}
+}

--- a/tests/phpunit/tests/class-test-post-types.php
+++ b/tests/phpunit/tests/class-test-post-types.php
@@ -105,6 +105,26 @@ class Test_Post_Types extends WP_UnitTestCase {
 	}
 
 	/**
+	 * `Post_Types::sanitize()` dedupes the result so the saved option is
+	 * a canonical list.
+	 */
+	public function test_sanitize_dedupes() {
+		$result = Post_Types::sanitize( array( 'post', 'page', 'post', 'page' ) );
+
+		$this->assertSame( array( 'post', 'page' ), $result );
+	}
+
+	/**
+	 * `Post_Types::sanitize()` drops non-strings and empties so callers
+	 * never store junk.
+	 */
+	public function test_sanitize_drops_non_strings_and_empties() {
+		$result = Post_Types::sanitize( array( 'post', '', null, 42, true, 'page' ) );
+
+		$this->assertSame( array( 'post', 'page' ), $result );
+	}
+
+	/**
 	 * Filter callbacks returning duplicates / non-strings / empties are
 	 * normalised away so callers always get a clean string[] of unique slugs.
 	 */


### PR DESCRIPTION
## Proposed changes

- New **Post types** field in *Settings → ATmosphere* with a checkbox per public post type. Stored as `atmosphere_support_post_types` (default `['post']`).
- Plugins and themes can opt their custom post types in via the WordPress-canonical `\add_post_type_support( 'book', 'atmosphere' )` — picked up automatically.
- Replaces `Backfill::syncable_post_types()` with `Atmosphere\Post_Types` + bridge functions `Atmosphere\get_supported_post_types()` and `Atmosphere\is_supported_post_type()`.
- `atmosphere_syncable_post_types` filter preserved; now runs after the option and native opt-ins are merged so callers can add or remove from either source.

### Other information

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions

1. Visit *Settings → ATmosphere*. Confirm a new **Post types** field appears in the Publishing section with a checkbox per public post type. **Posts** is checked by default.
2. Check **Pages**, save, edit any page. The ATmosphere meta box should appear.
3. Uncheck everything, save, and confirm no meta box renders on any post-edit screen.
4. In a small test plugin, add `add_post_type_support( 'book', 'atmosphere' );` for a custom `book` CPT — confirm `Atmosphere\get_supported_post_types()` includes it even when the option is empty.
5. `composer lint` and `npm run env-test` should pass.