### PR TITLE
Align License header with the GPL-2.0 URI

### DIFF
--- a/atmosphere.php
+++ b/atmosphere.php
@@ -6,7 +6,7 @@
  * Version: unreleased
  * Author: Automattic
  * Author URI: https://automattic.com
- * License: GPL-2.0-or-later
+ * License: GPL-2.0
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: atmosphere
  * Requires PHP: 8.2

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 6.2
 Tested up to: 7.0
 Requires PHP: 8.2
 Stable tag: unreleased
-License: GPL-2.0-or-later
+License: GPL-2.0
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Publish WordPress posts to AT Protocol (Bluesky and standard.site) via native OAuth.


### PR DESCRIPTION
## Proposed changes:

The `License URI` in both `atmosphere.php` and `readme.txt` points to https://www.gnu.org/licenses/gpl-2.0.html — the canonical GPL v2 license text. Update the `License` declaration from `GPL-2.0-or-later` to `GPL-2.0` so the SPDX identifier matches the URI it links to.

Replaces #36 (which addressed the same mismatch by updating the URI to SPDX's "or later" page; this PR aligns the declaration with the URI instead).

### Other information:

- [x] Skip Changelog (metadata fix only).

## Testing instructions:

* Verify `License: GPL-2.0` appears in both `atmosphere.php` (header docblock) and `readme.txt`.
* Verify `License URI` continues to point to https://www.gnu.org/licenses/gpl-2.0.html in both files.