### PR TITLE
Collapse teaser-thread to a single record when the body is the entire hook

### DIFF
--- a/.github/changelog/teaser-thread-collapse-redundant-cta
+++ b/.github/changelog/teaser-thread-collapse-redundant-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Short posts under the long-form teaser-thread strategy no longer ship a redundant "continue reading" reply when the entire body already fits in a single Bluesky post. The link-back is preserved as a card on the same post.

--- a/includes/class-publisher.php
+++ b/includes/class-publisher.php
@@ -559,9 +559,16 @@ class Publisher {
 		$bsky_transformer = new Post( $post );
 		$doc_transformer  = new Document( $post );
 
+		// Pass the stored count to `build_long_form_records()` so the
+		// transformer can preserve the existing thread shape on update
+		// instead of triggering a destructive `rewrite_thread()` for
+		// shape-shrinking optimisations like the redundant-CTA collapse
+		// — that path would re-mint the root URI and orphan external
+		// engagement on the original. New posts (no stored records) get
+		// the optimised shape; live posts keep theirs forever.
 		$new_records = $bsky_transformer->is_short_form_post()
 			? array( $bsky_transformer->transform() )
-			: $bsky_transformer->build_long_form_records();
+			: $bsky_transformer->build_long_form_records( \count( $stored ) );
 
 		// In-place update: matching record counts. Strategy is not
 		// compared — a `truncate-link` (count=1) post that switches to

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -388,11 +388,14 @@ class Post extends Base {
 	 *     no embed card.
 	 *   - `'teaser-thread'`: a reply chain of hook + body chunk + CTA
 	 *     (3 records by default; falls back to `[ hook, cta ]` when the
-	 *     post body is too short for a body chunk). The terminal CTA
-	 *     entry carries an `app.bsky.embed.external` link card so the
-	 *     reader has a clear path back to the WordPress post regardless
-	 *     of which entry surfaces. Filterable via
-	 *     `atmosphere_teaser_thread_posts`.
+	 *     post body is too short for a body chunk; collapses further
+	 *     to a single record when that 2-entry fallback would just be
+	 *     `[ entire-body, "Continue reading: <permalink>" ]` — the
+	 *     CTA is redundant when the entire post body is already the
+	 *     hook). The terminal entry carries an `app.bsky.embed.external`
+	 *     link card so the reader has a clear path back to the
+	 *     WordPress post regardless of which entry surfaces. Filterable
+	 *     via `atmosphere_teaser_thread_posts`.
 	 *   - unknown values: treated as `'link-card'`.
 	 *
 	 * Empty-body guard: for `'teaser-thread'` and `'truncate-link'`,
@@ -460,8 +463,32 @@ class Post extends Base {
 					return array( $this->record_for_link_card() );
 				}
 
+				$texts = $this->build_teaser_thread();
+
+				// When the 2-entry fallback would publish the entire
+				// body as the hook followed by a "Continue reading"
+				// CTA, the CTA is redundant — there's nothing past
+				// the hook to "continue reading" to. Collapse to a
+				// single record (body text + link-card embed) so the
+				// reader gets one clean post with a card linking back
+				// to WordPress, instead of a 2-post self-reply where
+				// the reply only restates the link.
+				if ( $this->teaser_thread_two_entry_is_redundant( $texts ) ) {
+					return array(
+						$this->record_for_thread_entry(
+							(string) $texts[0],
+							true,
+							array(
+								'strategy'        => 'teaser-thread',
+								'thread_index'    => 0,
+								'is_thread_reply' => false,
+							),
+							$this->build_embed()
+						),
+					);
+				}
+
 				$records = array();
-				$texts   = $this->build_teaser_thread();
 				$last    = \count( $texts ) - 1;
 				// Attach an `app.bsky.embed.external` link card to the
 				// terminal CTA entry. Without it, even when the thread
@@ -795,6 +822,39 @@ class Post extends Base {
 		}
 
 		return \mb_strlen( $this->render_post_content_plain( $this->object ) ) >= 10;
+	}
+
+	/**
+	 * Whether a 2-entry teaser-thread output is the redundant
+	 * `[ entire-body, default CTA ]` shape.
+	 *
+	 * The default `build_teaser_thread()` falls back to `[ hook, cta ]`
+	 * when the body is exhausted by the hook. When the post has no
+	 * separate `post_excerpt` (so the hook IS the body) AND the second
+	 * entry is the default `Continue reading: <permalink>` text, the
+	 * CTA is purely redundant — the entire post body is already in the
+	 * hook above it. Callers can collapse to a single record (with a
+	 * link-card embed for the link-back) instead.
+	 *
+	 * Guards on the default CTA text rather than just `count === 2` so
+	 * filter authors who deliberately return a 2-entry shape with a
+	 * custom second entry (a related-link, a sign-off, etc.) keep their
+	 * explicit choice — only the default-fallback shape collapses.
+	 *
+	 * @param array $texts Post-filter teaser-thread output.
+	 * @return bool
+	 */
+	private function teaser_thread_two_entry_is_redundant( array $texts ): bool {
+		if ( 2 !== \count( $texts ) ) {
+			return false;
+		}
+
+		$excerpt = sanitize_text( (string) $this->object->post_excerpt );
+		if ( \mb_strlen( $excerpt ) >= 10 ) {
+			return false;
+		}
+
+		return ( $texts[1] ?? '' ) === $this->teaser_thread_cta_text();
 	}
 
 	/**

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -515,7 +515,7 @@ class Post extends Base {
 					);
 				}
 
-				$texts   = $this->build_teaser_thread();
+				$texts   = $this->build_teaser_thread( $default_texts );
 				$records = array();
 				$last    = \count( $texts ) - 1;
 				// Attach an `app.bsky.embed.external` link card to the
@@ -736,11 +736,22 @@ class Post extends Base {
 	 * Filterable via `atmosphere_teaser_thread_posts`; the filter is the
 	 * final transformation point and may return any 2..5 string entries.
 	 *
+	 * @param array|null $precomputed_default Precomputed default array
+	 *                                        from `compute_default_teaser_thread()`.
+	 *                                        Pass to avoid re-running
+	 *                                        the `render_post_content_plain`
+	 *                                        / `truncate_to_budget`
+	 *                                        pipeline when the caller
+	 *                                        already needed the default
+	 *                                        for its own decision (e.g.
+	 *                                        the redundant-CTA collapse
+	 *                                        predicate). When null,
+	 *                                        computed here.
 	 * @return string[] Text of each post in order. 2 or 3 entries by
 	 *                  default; up to 5 when overridden by filter.
 	 */
-	private function build_teaser_thread(): array {
-		$default = $this->compute_default_teaser_thread();
+	private function build_teaser_thread( ?array $precomputed_default = null ): array {
+		$default = $precomputed_default ?? $this->compute_default_teaser_thread();
 
 		/**
 		 * Filters the default teaser-thread post texts.
@@ -885,13 +896,23 @@ class Post extends Base {
 	 * Whether the unfiltered default teaser-thread is the redundant
 	 * `[ entire-body, "Continue reading: <permalink>" ]` shape.
 	 *
-	 * Triggers when the post has no usable `post_excerpt` (so the hook
-	 * IS the body) AND the body fits entirely in the 280-char hook
-	 * budget (so `chunk_source` is below the 10-char floor and the
-	 * default falls back to `[ hook, cta ]`). In that shape, the CTA
-	 * reply is purely redundant — there's nothing past the hook to
-	 * "continue reading" to. Callers can collapse to a single record
-	 * with the body text and a link-card embed instead.
+	 * Triggers when ALL of:
+	 *   - The post has no usable `post_excerpt` (so the hook IS the
+	 *     body, not a separate curated string).
+	 *   - The body fits entirely in the 280-char hook budget (so the
+	 *     hook is the *whole* body, not a truncated prefix — without
+	 *     this check, a 285-char body produces a hook-truncated
+	 *     `[ first 280 chars, cta ]` default whose collapse would
+	 *     silently drop the trailing 5 chars from bsky output without
+	 *     the reader having any in-text affordance to know there's
+	 *     more).
+	 *   - The default is the 2-entry fallback (so chunk_source ended
+	 *     up below the 10-char floor and the body chunk was dropped).
+	 *
+	 * In that exact shape, the CTA reply is purely redundant — the
+	 * entire post body is already in the hook above it. Callers can
+	 * collapse to a single record with the body text and a link-card
+	 * embed instead.
 	 *
 	 * Decision is made on the unfiltered default so filter authors who
 	 * legitimately want a 2-entry custom shape (custom hook + custom
@@ -910,8 +931,15 @@ class Post extends Base {
 		}
 
 		$excerpt = sanitize_text( (string) $this->object->post_excerpt );
+		if ( \mb_strlen( $excerpt ) >= 10 ) {
+			return false;
+		}
 
-		return \mb_strlen( $excerpt ) < 10;
+		// Confirm the hook IS the whole body, not a truncated prefix.
+		// 280 mirrors `compute_default_teaser_thread()`'s body-as-hook
+		// budget; for a body at or below that length the hook
+		// equals the body verbatim and `chunk_source` is empty.
+		return \mb_strlen( $this->render_post_content_plain( $this->object ) ) <= 280;
 	}
 
 	/**

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -414,10 +414,22 @@ class Post extends Base {
 	 * for the short-form path and for any legacy caller on today's
 	 * single-record contract.
 	 *
+	 * @param int $stored_count Number of bsky records currently stored
+	 *                          for this post (from `META_THREAD_RECORDS`).
+	 *                          Defaults to 0 — a fresh publish, no
+	 *                          existing state. Callers updating an
+	 *                          already-published post should pass the
+	 *                          stored count so shape-shrinking optimisations
+	 *                          (e.g. the redundant-CTA collapse) are
+	 *                          skipped when they would force a destructive
+	 *                          rewrite of an existing thread; preserving
+	 *                          the stored shape lets `Publisher::update_post`
+	 *                          take the in-place update path and keep
+	 *                          external Bluesky engagement intact.
 	 * @return array[] Bsky post records, in thread order (index 0 is
 	 *                 the root / parent of any replies).
 	 */
-	public function build_long_form_records(): array {
+	public function build_long_form_records( int $stored_count = 0 ): array {
 		/**
 		 * Filters the long-form composition strategy for this post.
 		 *
@@ -463,9 +475,7 @@ class Post extends Base {
 					return array( $this->record_for_link_card() );
 				}
 
-				$texts = $this->build_teaser_thread();
-
-				// When the 2-entry fallback would publish the entire
+				// When the unfiltered default would publish the entire
 				// body as the hook followed by a "Continue reading"
 				// CTA, the CTA is redundant — there's nothing past
 				// the hook to "continue reading" to. Collapse to a
@@ -473,10 +483,27 @@ class Post extends Base {
 				// reader gets one clean post with a card linking back
 				// to WordPress, instead of a 2-post self-reply where
 				// the reply only restates the link.
-				if ( $this->teaser_thread_two_entry_is_redundant( $texts ) ) {
+				//
+				// Backward-compat: skip the collapse when the post
+				// already has 2+ stored records. `Publisher::update_post`
+				// only takes the in-place update path when stored count
+				// matches new count; a 2→1 shape change otherwise falls
+				// through to `rewrite_thread()`, which deletes the
+				// original root URI and orphans every external Bluesky
+				// reply / like / repost on it. Preserving the stored
+				// shape costs an extra (still-redundant) reply but
+				// keeps engagement intact.
+				//
+				// Decision is made on the unfiltered default so an
+				// `atmosphere_teaser_thread_posts` filter that
+				// legitimately produces a 2-entry custom shape (custom
+				// hook + custom second post) still runs and ships as 2
+				// records.
+				$default_texts = $this->compute_default_teaser_thread();
+				if ( $stored_count < 2 && $this->default_teaser_thread_is_redundant_two_entry( $default_texts ) ) {
 					return array(
 						$this->record_for_thread_entry(
-							(string) $texts[0],
+							(string) $default_texts[0],
 							true,
 							array(
 								'strategy'        => 'teaser-thread',
@@ -488,6 +515,7 @@ class Post extends Base {
 					);
 				}
 
+				$texts   = $this->build_teaser_thread();
 				$records = array();
 				$last    = \count( $texts ) - 1;
 				// Attach an `app.bsky.embed.external` link card to the
@@ -712,40 +740,7 @@ class Post extends Base {
 	 *                  default; up to 5 when overridden by filter.
 	 */
 	private function build_teaser_thread(): array {
-		$excerpt = sanitize_text( (string) $this->object->post_excerpt );
-		$plain   = $this->render_post_content_plain( $this->object );
-
-		if ( \mb_strlen( $excerpt ) >= 10 ) {
-			$hook         = $this->truncate_to_budget( $excerpt, 300, false );
-			$chunk_source = $plain;
-		} else {
-			$hook = $this->truncate_to_budget( $plain, 280, true );
-			// Strip the hard-cap ellipsis (when present) before measuring
-			// how much of the plain body the hook consumed; the
-			// sentence/word-cut paths return clean prefixes so this is a
-			// no-op there. `mb_substr` keeps the strip char-aware —
-			// `rtrim($hook, '…')` would strip individual UTF-8 bytes from
-			// the multi-byte ellipsis sequence and can corrupt the trailing
-			// non-ASCII char before it.
-			$consumed     = '…' === \mb_substr( $hook, -1 )
-				? \mb_substr( $hook, 0, \mb_strlen( $hook ) - 1 )
-				: $hook;
-			$chunk_source = \mb_substr( $plain, \mb_strlen( $consumed ) );
-		}
-
-		// Unicode-aware leading-whitespace strip: `\ltrim` only handles
-		// ASCII whitespace, so NBSP (U+00A0) and ideographic space
-		// (U+3000) at the start of `$chunk_source` would otherwise leak
-		// into the body chunk as leading invisible whitespace. PCRE in
-		// `/u` mode returns null on invalid UTF-8; fall back to the
-		// pre-strip slice so the `mb_strlen` check below stays string-safe.
-		$stripped     = \preg_replace( '/^\s+/u', '', $chunk_source );
-		$chunk_source = \is_string( $stripped ) ? $stripped : $chunk_source;
-		$cta          = $this->teaser_thread_cta_text();
-
-		$default = \mb_strlen( $chunk_source ) >= 10
-			? array( $hook, $this->truncate_to_budget( $chunk_source, 280, true ), $cta )
-			: array( $hook, $cta );
+		$default = $this->compute_default_teaser_thread();
 
 		/**
 		 * Filters the default teaser-thread post texts.
@@ -825,36 +820,98 @@ class Post extends Base {
 	}
 
 	/**
-	 * Whether a 2-entry teaser-thread output is the redundant
-	 * `[ entire-body, default CTA ]` shape.
+	 * Compute the default teaser-thread text array, pre-filter.
 	 *
-	 * The default `build_teaser_thread()` falls back to `[ hook, cta ]`
-	 * when the body is exhausted by the hook. When the post has no
-	 * separate `post_excerpt` (so the hook IS the body) AND the second
-	 * entry is the default `Continue reading: <permalink>` text, the
-	 * CTA is purely redundant — the entire post body is already in the
-	 * hook above it. Callers can collapse to a single record (with a
-	 * link-card embed for the link-back) instead.
+	 * Extracted from `build_teaser_thread()` so callers can inspect the
+	 * unfiltered default before deciding whether to short-circuit (e.g.
+	 * the redundant-2-entry collapse in `build_long_form_records()`)
+	 * without coupling to whatever an `atmosphere_teaser_thread_posts`
+	 * filter might do.
 	 *
-	 * Guards on the default CTA text rather than just `count === 2` so
-	 * filter authors who deliberately return a 2-entry shape with a
-	 * custom second entry (a related-link, a sign-off, etc.) keep their
-	 * explicit choice — only the default-fallback shape collapses.
+	 * Hook precedence:
+	 *   1. If the post has a `post_excerpt`, use it (plain-text
+	 *      normalized, clamped to 300 chars as a safety floor).
+	 *   2. Otherwise, use the first ~280 chars of the body text,
+	 *      cut at a sentence boundary.
 	 *
-	 * @param array $texts Post-filter teaser-thread output.
+	 * Body chunk:
+	 *   - Excerpt-as-hook: chunk_source is the entire body.
+	 *   - Body-as-hook: chunk_source is what remains after the hook
+	 *     consumed its slice.
+	 *   - Dropped (output reduces to `[ hook, cta ]`) when fewer than
+	 *     10 chars of prose remain after Unicode-aware leading-whitespace
+	 *     strip.
+	 *
+	 * @return string[] 2 or 3 entries.
+	 */
+	private function compute_default_teaser_thread(): array {
+		$excerpt = sanitize_text( (string) $this->object->post_excerpt );
+		$plain   = $this->render_post_content_plain( $this->object );
+
+		if ( \mb_strlen( $excerpt ) >= 10 ) {
+			$hook         = $this->truncate_to_budget( $excerpt, 300, false );
+			$chunk_source = $plain;
+		} else {
+			$hook = $this->truncate_to_budget( $plain, 280, true );
+			// Strip the hard-cap ellipsis (when present) before measuring
+			// how much of the plain body the hook consumed; the
+			// sentence/word-cut paths return clean prefixes so this is a
+			// no-op there. `mb_substr` keeps the strip char-aware —
+			// `rtrim($hook, '…')` would strip individual UTF-8 bytes from
+			// the multi-byte ellipsis sequence and can corrupt the trailing
+			// non-ASCII char before it.
+			$consumed     = '…' === \mb_substr( $hook, -1 )
+				? \mb_substr( $hook, 0, \mb_strlen( $hook ) - 1 )
+				: $hook;
+			$chunk_source = \mb_substr( $plain, \mb_strlen( $consumed ) );
+		}
+
+		// Unicode-aware leading-whitespace strip: `\ltrim` only handles
+		// ASCII whitespace, so NBSP (U+00A0) and ideographic space
+		// (U+3000) at the start of `$chunk_source` would otherwise leak
+		// into the body chunk as leading invisible whitespace. PCRE in
+		// `/u` mode returns null on invalid UTF-8; fall back to the
+		// pre-strip slice so the `mb_strlen` check below stays string-safe.
+		$stripped     = \preg_replace( '/^\s+/u', '', $chunk_source );
+		$chunk_source = \is_string( $stripped ) ? $stripped : $chunk_source;
+		$cta          = $this->teaser_thread_cta_text();
+
+		return \mb_strlen( $chunk_source ) >= 10
+			? array( $hook, $this->truncate_to_budget( $chunk_source, 280, true ), $cta )
+			: array( $hook, $cta );
+	}
+
+	/**
+	 * Whether the unfiltered default teaser-thread is the redundant
+	 * `[ entire-body, "Continue reading: <permalink>" ]` shape.
+	 *
+	 * Triggers when the post has no usable `post_excerpt` (so the hook
+	 * IS the body) AND the body fits entirely in the 280-char hook
+	 * budget (so `chunk_source` is below the 10-char floor and the
+	 * default falls back to `[ hook, cta ]`). In that shape, the CTA
+	 * reply is purely redundant — there's nothing past the hook to
+	 * "continue reading" to. Callers can collapse to a single record
+	 * with the body text and a link-card embed instead.
+	 *
+	 * Decision is made on the unfiltered default so filter authors who
+	 * legitimately want a 2-entry custom shape (custom hook + custom
+	 * second post) still see their filter run on the un-collapsed
+	 * default and ship as 2 records.
+	 *
+	 * @param array $default_texts Precomputed default array (pass to
+	 *                             avoid recomputing — this method does
+	 *                             not call `compute_default_teaser_thread()`
+	 *                             itself).
 	 * @return bool
 	 */
-	private function teaser_thread_two_entry_is_redundant( array $texts ): bool {
-		if ( 2 !== \count( $texts ) ) {
+	private function default_teaser_thread_is_redundant_two_entry( array $default_texts ): bool {
+		if ( 2 !== \count( $default_texts ) ) {
 			return false;
 		}
 
 		$excerpt = sanitize_text( (string) $this->object->post_excerpt );
-		if ( \mb_strlen( $excerpt ) >= 10 ) {
-			return false;
-		}
 
-		return ( $texts[1] ?? '' ) === $this->teaser_thread_cta_text();
+		return \mb_strlen( $excerpt ) < 10;
 	}
 
 	/**

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -925,9 +925,12 @@ class Post extends Base {
 	 * is the indexed representation of the WP post for the Bluesky
 	 * algorithm. Non-root replies are conversational and omit tags.
 	 *
-	 * `$embed` is set only by the teaser-thread caller for the terminal
-	 * CTA entry; `reply` and `embed` are independent fields in
-	 * `app.bsky.feed.post`'s lexicon, so a record carrying both is fine.
+	 * `$embed` is set by the teaser-thread caller for the terminal CTA
+	 * entry of a multi-record thread, AND for the root of a collapsed
+	 * single-record thread (where the would-be CTA is dropped but the
+	 * link-card embed is preserved on the surviving record). `reply`
+	 * and `embed` are independent fields in `app.bsky.feed.post`'s
+	 * lexicon, so a record carrying both is fine.
 	 *
 	 * @param string     $text    Pre-composed post text.
 	 * @param bool       $is_root Whether this record is the thread root.

--- a/tests/phpunit/tests/class-test-publisher.php
+++ b/tests/phpunit/tests/class-test-publisher.php
@@ -883,10 +883,13 @@ class Test_Publisher extends WP_UnitTestCase {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_title'   => 'A Long-Form Post',
-				'post_content' => 'Body content that is enough to compose a hook from.',
-				// Body absorbs entirely into the hook → 2-entry fallback shape,
-				// keeping the publisher protocol assertions below at 2 records.
-				'post_excerpt' => '',
+				'post_content' => 'Hi.',
+				// Excerpt becomes the hook + body too short to form a
+				// chunk → 2-entry `[ excerpt, CTA ]` default. Excerpt
+				// is non-empty so the redundant-CTA collapse in
+				// `build_long_form_records()` does not fire and the
+				// publisher protocol assertions below stay at 2 records.
+				'post_excerpt' => 'A curated standalone excerpt for the test fixture.',
 			)
 		);
 
@@ -937,10 +940,13 @@ class Test_Publisher extends WP_UnitTestCase {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_title'   => 'A Long-Form Post',
-				'post_content' => 'Body content that is enough to compose a hook from.',
-				// Body absorbs entirely into the hook → 2-entry fallback shape,
-				// keeping the publisher protocol assertions below at 2 records.
-				'post_excerpt' => '',
+				'post_content' => 'Hi.',
+				// Excerpt becomes the hook + body too short to form a
+				// chunk → 2-entry `[ excerpt, CTA ]` default. Excerpt
+				// is non-empty so the redundant-CTA collapse in
+				// `build_long_form_records()` does not fire and the
+				// publisher protocol assertions below stay at 2 records.
+				'post_excerpt' => 'A curated standalone excerpt for the test fixture.',
 			)
 		);
 
@@ -971,10 +977,13 @@ class Test_Publisher extends WP_UnitTestCase {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_title'   => 'A Long-Form Post',
-				'post_content' => 'Body content that is enough to compose a hook from.',
-				// Body absorbs entirely into the hook → 2-entry fallback shape,
-				// keeping the publisher protocol assertions below at 2 records.
-				'post_excerpt' => '',
+				'post_content' => 'Hi.',
+				// Excerpt becomes the hook + body too short to form a
+				// chunk → 2-entry `[ excerpt, CTA ]` default. Excerpt
+				// is non-empty so the redundant-CTA collapse in
+				// `build_long_form_records()` does not fire and the
+				// publisher protocol assertions below stay at 2 records.
+				'post_excerpt' => 'A curated standalone excerpt for the test fixture.',
 			)
 		);
 
@@ -1165,10 +1174,13 @@ class Test_Publisher extends WP_UnitTestCase {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_title'   => 'A Long-Form Post',
-				'post_content' => 'Body content that is enough to compose a hook from.',
-				// Body absorbs entirely into the hook → 2-entry fallback shape,
-				// keeping the publisher protocol assertions below at 2 records.
-				'post_excerpt' => '',
+				'post_content' => 'Hi.',
+				// Excerpt becomes the hook + body too short to form a
+				// chunk → 2-entry `[ excerpt, CTA ]` default. Excerpt
+				// is non-empty so the redundant-CTA collapse in
+				// `build_long_form_records()` does not fire and the
+				// publisher protocol assertions below stay at 2 records.
+				'post_excerpt' => 'A curated standalone excerpt for the test fixture.',
 			)
 		);
 
@@ -1227,10 +1239,13 @@ class Test_Publisher extends WP_UnitTestCase {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_title'   => 'A Long-Form Post',
-				'post_content' => 'Body content that is enough to compose a hook from.',
-				// Body absorbs entirely into the hook → 2-entry fallback shape,
-				// keeping the publisher protocol assertions below at 2 records.
-				'post_excerpt' => '',
+				'post_content' => 'Hi.',
+				// Excerpt becomes the hook + body too short to form a
+				// chunk → 2-entry `[ excerpt, CTA ]` default. Excerpt
+				// is non-empty so the redundant-CTA collapse in
+				// `build_long_form_records()` does not fire and the
+				// publisher protocol assertions below stay at 2 records.
+				'post_excerpt' => 'A curated standalone excerpt for the test fixture.',
 			)
 		);
 
@@ -1324,10 +1339,14 @@ class Test_Publisher extends WP_UnitTestCase {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_title'   => 'A Long-Form Post',
-				'post_content' => 'Body content that is enough to compose a hook from.',
-				// Body absorbs entirely into the hook → 2-entry fallback shape,
-				// matching the stored 2-entry meta below for an in-place update.
-				'post_excerpt' => '',
+				'post_content' => 'Hi.',
+				// Excerpt becomes the hook + body too short to form a
+				// chunk → 2-entry `[ excerpt, CTA ]` default. Excerpt
+				// is non-empty so the redundant-CTA collapse in
+				// `build_long_form_records()` does not fire and the
+				// new record count matches the stored 2-entry meta
+				// below for an in-place update.
+				'post_excerpt' => 'A curated standalone excerpt for the test fixture.',
 			)
 		);
 
@@ -1396,10 +1415,13 @@ class Test_Publisher extends WP_UnitTestCase {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_title'   => 'A Long-Form Post',
-				'post_content' => 'Body content that is enough to compose a hook from.',
-				// Body absorbs entirely into the hook → 2-entry fallback shape,
-				// keeping the post-rewrite assertions below at 2 records.
-				'post_excerpt' => '',
+				'post_content' => 'Hi.',
+				// Excerpt becomes the hook + body too short to form a
+				// chunk → 2-entry `[ excerpt, CTA ]` default. Excerpt
+				// is non-empty so the redundant-CTA collapse in
+				// `build_long_form_records()` does not fire and the
+				// post-rewrite assertions below stay at 2 records.
+				'post_excerpt' => 'A curated standalone excerpt for the test fixture.',
 			)
 		);
 

--- a/tests/phpunit/tests/class-test-publisher.php
+++ b/tests/phpunit/tests/class-test-publisher.php
@@ -1408,6 +1408,83 @@ class Test_Publisher extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Backward-compat at the publisher level: a post that was published
+	 * BEFORE the redundant-CTA collapse landed has 2 stored thread
+	 * records for content (short body, empty excerpt) that would, on a
+	 * fresh publish today, collapse to a single record. Without the
+	 * `\count(\$stored)` hint passed from `update_post()` to
+	 * `build_long_form_records()`, the new shape would be 1 record vs.
+	 * the stored 2, the count mismatch would fall through to
+	 * `rewrite_thread()`, the original root URI would be deleted, and
+	 * every external Bluesky reply / like / repost would be orphaned.
+	 *
+	 * This test pins the end-to-end path: short-body fixture + 2 stored
+	 * records + teaser-thread strategy → in-place update via a single
+	 * `applyWrites` (2 bsky updates + 1 doc update), URIs preserved.
+	 */
+	public function test_update_thread_short_body_in_place_when_stored_two_records() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'A Long-Form Post',
+				// Short body + empty excerpt = exactly the shape that
+				// would trip the redundant-CTA collapse on a fresh
+				// publish. Backward-compat must keep it at 2 records.
+				'post_content' => 'A short note that absorbs into the hook.',
+				'post_excerpt' => '',
+			)
+		);
+
+		$stored = array(
+			array(
+				'uri' => 'at://did:plc:test123/app.bsky.feed.post/legacy-root',
+				'cid' => 'bafyreiblegacy-root',
+				'tid' => 'legacy-root',
+			),
+			array(
+				'uri' => 'at://did:plc:test123/app.bsky.feed.post/legacy-cta',
+				'cid' => 'bafyreiblegacy-cta',
+				'tid' => 'legacy-cta',
+			),
+		);
+		\update_post_meta( $post->ID, Post::META_THREAD_RECORDS, $stored );
+		\update_post_meta( $post->ID, Post::META_URI, $stored[0]['uri'] );
+		\update_post_meta( $post->ID, Post::META_TID, 'legacy-root' );
+		\update_post_meta( $post->ID, Post::META_CID, 'bafyreiblegacy-root' );
+		\update_post_meta( $post->ID, Document::META_URI, 'at://did:plc:test123/site.standard.document/legacy-doc' );
+		\update_post_meta( $post->ID, Document::META_TID, 'legacy-doc' );
+
+		\add_filter( 'atmosphere_long_form_composition', fn() => 'teaser-thread' );
+
+		$this->fail_call_indexes = array();
+		$this->register_capture( $post->ID );
+
+		$result = Publisher::update( $post );
+
+		$this->assertIsArray( $result );
+		$this->assertCount(
+			1,
+			$this->captured_calls,
+			'In-place update must be a single atomic applyWrites — not delete + republish.'
+		);
+
+		$writes = $this->captured_calls[0]['writes'];
+		$this->assertCount( 3, $writes, '2 bsky updates (root + reply) + 1 doc update.' );
+
+		// Each bsky write must be an `update`, not a `delete` or `create`,
+		// reusing the legacy TIDs (URIs preserved on the network side).
+		$this->assertSame( 'com.atproto.repo.applyWrites#update', $writes[0]['$type'] );
+		$this->assertSame( 'legacy-root', $writes[0]['rkey'] );
+		$this->assertSame( 'com.atproto.repo.applyWrites#update', $writes[1]['$type'] );
+		$this->assertSame( 'legacy-cta', $writes[1]['rkey'] );
+		$this->assertSame( 'site.standard.document', $writes[2]['collection'] );
+
+		// Persisted URIs are unchanged — no rewrite would have orphaned
+		// the external Bluesky engagement attached to legacy-root.
+		$this->assertSame( $stored[0]['uri'], \get_post_meta( $post->ID, Post::META_URI, true ) );
+		$this->assertSame( 'legacy-root', \get_post_meta( $post->ID, Post::META_TID, true ) );
+	}
+
+	/**
 	 * Update with a stored 1-entry link-card but a teaser-thread composition
 	 * deletes the old record + doc atomically, then publishes fresh.
 	 */

--- a/tests/phpunit/tests/transformer/class-test-post.php
+++ b/tests/phpunit/tests/transformer/class-test-post.php
@@ -874,13 +874,15 @@ class Test_Post extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Short post: when the hook absorbs the entire body, the body chunk is
-	 * dropped rather than padded with empty text. The CTA stays terminal
-	 * and still carries the link-card embed.
+	 * Short post with no excerpt: the 2-entry `[ body, default CTA ]`
+	 * fallback collapses to a single record with the body as text and a
+	 * link-card embed. The CTA reply is dropped because it's redundant
+	 * — there's nothing past the hook to "continue reading" to. The
+	 * link-back is preserved via the embed card on the same record.
 	 *
 	 * @covers ::build_long_form_records
 	 */
-	public function test_build_long_form_records_teaser_thread_short_body_falls_back_to_two_entries() {
+	public function test_build_long_form_records_teaser_thread_short_body_collapses_to_single_record() {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_title'   => 'Titled',
@@ -893,14 +895,75 @@ class Test_Post extends WP_UnitTestCase {
 
 		$records = ( new Post( $post ) )->build_long_form_records();
 
-		$this->assertCount( 2, $records );
+		$this->assertCount( 1, $records );
 		$this->assertSame( 'A single short sentence.', $records[0]['text'] );
-		$this->assertMatchesRegularExpression( '~^Continue reading: ~', $records[1]['text'] );
 
-		// Embed attaches to the terminal entry: "last entry," not "index 2".
+		// Link-back lives on the embed of the same record now, not on a
+		// separate CTA reply.
+		$this->assertArrayHasKey( 'embed', $records[0] );
+		$this->assertSame( 'app.bsky.embed.external', $records[0]['embed']['$type'] );
+		$this->assertSame( \get_permalink( $post ), $records[0]['embed']['external']['uri'] );
+	}
+
+	/**
+	 * Excerpt-as-hook with a body too short to compose a chunk: the
+	 * 2-entry `[ excerpt, CTA ]` fallback stays — the excerpt and the
+	 * body are separate strings, so the CTA still carries the
+	 * link-back to where the body lives. Only collapse when the hook
+	 * IS the body.
+	 *
+	 * @covers ::build_long_form_records
+	 */
+	public function test_build_long_form_records_teaser_thread_excerpt_with_short_body_stays_two_entries() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'Titled',
+				// 3-char body so chunk_source < 10 char floor → 2-entry fallback.
+				'post_content' => 'Hi.',
+				'post_excerpt' => 'A curated excerpt of decent length.',
+			)
+		);
+
+		\add_filter( 'atmosphere_long_form_composition', fn() => 'teaser-thread' );
+
+		$records = ( new Post( $post ) )->build_long_form_records();
+
+		$this->assertCount( 2, $records );
+		$this->assertSame( 'A curated excerpt of decent length.', $records[0]['text'] );
+		$this->assertMatchesRegularExpression( '~^Continue reading: ~', $records[1]['text'] );
 		$this->assertArrayNotHasKey( 'embed', $records[0] );
 		$this->assertArrayHasKey( 'embed', $records[1] );
-		$this->assertSame( 'app.bsky.embed.external', $records[1]['embed']['$type'] );
+	}
+
+	/**
+	 * Filter override that returns a 2-entry shape with a custom
+	 * (non-default) second entry is preserved — only the default
+	 * `[ body, default CTA ]` shape collapses. Filter authors who
+	 * deliberately ship a custom 2-post thread keep their explicit
+	 * choice.
+	 *
+	 * @covers ::build_long_form_records
+	 */
+	public function test_build_long_form_records_teaser_thread_filter_two_entries_custom_cta_does_not_collapse() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'Titled',
+				'post_content' => 'A single short sentence.',
+				'post_excerpt' => '',
+			)
+		);
+
+		\add_filter( 'atmosphere_long_form_composition', fn() => 'teaser-thread' );
+		\add_filter(
+			'atmosphere_teaser_thread_posts',
+			fn() => array( 'Custom hook', 'Custom second post' )
+		);
+
+		$records = ( new Post( $post ) )->build_long_form_records();
+
+		$this->assertCount( 2, $records );
+		$this->assertSame( 'Custom hook', $records[0]['text'] );
+		$this->assertSame( 'Custom second post', $records[1]['text'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/transformer/class-test-post.php
+++ b/tests/phpunit/tests/transformer/class-test-post.php
@@ -906,6 +906,43 @@ class Test_Post extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Body slightly over the 280-char hook budget with a tail too
+	 * short to form a body chunk: the 2-entry `[ truncated-hook, CTA ]`
+	 * default stays — the hook is NOT the whole body (the trailing
+	 * chars never made it in), so the CTA reply still adds value as
+	 * the only in-text affordance to "there's more in the source." The
+	 * collapse predicate must NOT fire here even though the default is
+	 * 2-entry and there's no excerpt.
+	 *
+	 * @covers ::build_long_form_records
+	 */
+	public function test_build_long_form_records_teaser_thread_truncated_hook_short_tail_does_not_collapse() {
+		// 285-char body: hook truncates to ~280 (sentence-bounded),
+		// chunk_source is the leftover ~5 chars, < 10 floor → 2-entry
+		// fallback `[ truncated-hook, CTA ]`. Hook is NOT the entire
+		// body, so the predicate must short-circuit on body length.
+		$body = \str_repeat( 'word ', 56 ) . '. tail';
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'Titled',
+				'post_content' => $body,
+				'post_excerpt' => '',
+			)
+		);
+
+		\add_filter( 'atmosphere_long_form_composition', fn() => 'teaser-thread' );
+
+		$records = ( new Post( $post ) )->build_long_form_records();
+
+		// 2-entry shape preserved; collapse did not fire.
+		$this->assertCount( 2, $records );
+		$this->assertMatchesRegularExpression( '~^Continue reading: ~', $records[1]['text'] );
+		$this->assertArrayNotHasKey( 'embed', $records[0] );
+		$this->assertArrayHasKey( 'embed', $records[1] );
+	}
+
+	/**
 	 * Excerpt-as-hook with a body too short to compose a chunk: the
 	 * 2-entry `[ excerpt, CTA ]` fallback stays — the excerpt and the
 	 * body are separate strings, so the CTA still carries the

--- a/tests/phpunit/tests/transformer/class-test-post.php
+++ b/tests/phpunit/tests/transformer/class-test-post.php
@@ -936,20 +936,60 @@ class Test_Post extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Filter override that returns a 2-entry shape with a custom
-	 * (non-default) second entry is preserved — only the default
-	 * `[ body, default CTA ]` shape collapses. Filter authors who
-	 * deliberately ship a custom 2-post thread keep their explicit
-	 * choice.
+	 * Collapse decision is made on the unfiltered default — when the
+	 * default would be the redundant `[ body, default CTA ]` shape, the
+	 * `atmosphere_teaser_thread_posts` filter is never reached and the
+	 * output is always a single record. A filter that wants to ship a
+	 * 2-entry custom thread can only do so when the post has enough
+	 * body (or an excerpt) to produce a non-redundant default shape;
+	 * otherwise the collapse pre-empts the filter.
+	 *
+	 * This pins the design choice: the filter operates on the
+	 * un-collapsed default shape only.
 	 *
 	 * @covers ::build_long_form_records
 	 */
-	public function test_build_long_form_records_teaser_thread_filter_two_entries_custom_cta_does_not_collapse() {
+	public function test_build_long_form_records_teaser_thread_short_body_collapse_pre_empts_filter() {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_title'   => 'Titled',
 				'post_content' => 'A single short sentence.',
 				'post_excerpt' => '',
+			)
+		);
+
+		$filter_ran = false;
+		\add_filter( 'atmosphere_long_form_composition', fn() => 'teaser-thread' );
+		\add_filter(
+			'atmosphere_teaser_thread_posts',
+			static function () use ( &$filter_ran ) {
+				$filter_ran = true;
+				return array( 'Custom hook', 'Custom second post' );
+			}
+		);
+
+		$records = ( new Post( $post ) )->build_long_form_records();
+
+		$this->assertCount( 1, $records );
+		$this->assertFalse( $filter_ran, 'Filter should not run when collapse fires on the default.' );
+	}
+
+	/**
+	 * Filter override DOES run when the post has a non-redundant
+	 * default (here, a usable excerpt forces the 3-entry shape) — the
+	 * filter can then return any 2..5 entries and that ships verbatim.
+	 *
+	 * @covers ::build_long_form_records
+	 */
+	public function test_build_long_form_records_teaser_thread_filter_runs_when_default_is_not_redundant() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'Titled',
+				// Excerpt becomes the hook → default is 3-entry
+				// (not the redundant 2-entry shape) → no collapse
+				// → filter runs.
+				'post_content' => 'Body content with enough prose to compose a hook from.',
+				'post_excerpt' => 'Curated excerpt.',
 			)
 		);
 
@@ -964,6 +1004,36 @@ class Test_Post extends WP_UnitTestCase {
 		$this->assertCount( 2, $records );
 		$this->assertSame( 'Custom hook', $records[0]['text'] );
 		$this->assertSame( 'Custom second post', $records[1]['text'] );
+	}
+
+	/**
+	 * Backward-compat: when the post already has 2+ stored bsky records
+	 * (passed via the `$stored_count` hint), the collapse is skipped so
+	 * `Publisher::update_post` can take the in-place update path
+	 * instead of falling through to a destructive `rewrite_thread()`
+	 * that would re-mint the root URI and orphan external engagement.
+	 *
+	 * @covers ::build_long_form_records
+	 */
+	public function test_build_long_form_records_teaser_thread_short_body_does_not_collapse_when_stored_count_two() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'Titled',
+				'post_content' => 'A single short sentence.',
+				'post_excerpt' => '',
+			)
+		);
+
+		\add_filter( 'atmosphere_long_form_composition', fn() => 'teaser-thread' );
+
+		$records = ( new Post( $post ) )->build_long_form_records( 2 );
+
+		// Old shape preserved: hook + CTA, embed on terminal.
+		$this->assertCount( 2, $records );
+		$this->assertSame( 'A single short sentence.', $records[0]['text'] );
+		$this->assertMatchesRegularExpression( '~^Continue reading: ~', $records[1]['text'] );
+		$this->assertArrayNotHasKey( 'embed', $records[0] );
+		$this->assertArrayHasKey( 'embed', $records[1] );
 	}
 
 	/**
@@ -1261,7 +1331,11 @@ class Test_Post extends WP_UnitTestCase {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_title'   => 'Titled',
-				'post_content' => 'Read about #testing sensors in this detailed write-up on instrumentation.',
+				// Body long enough that the default is 3-entry (hook +
+				// body chunk + CTA), so the redundant-2-entry collapse
+				// in build_long_form_records() does not fire and the
+				// CTA record exists for the link-facet assertion below.
+				'post_content' => 'Read about #testing sensors in this detailed write-up on instrumentation. ' . \str_repeat( 'Additional analysis follows here. ', 12 ),
 				// Force body-path hook; factory auto-fills "Post excerpt NNN" otherwise.
 				'post_excerpt' => '',
 			)
@@ -1283,8 +1357,11 @@ class Test_Post extends WP_UnitTestCase {
 		}
 		$this->assertTrue( $hook_has_tag, 'Hook text should have a #testing tag facet.' );
 
+		// CTA is the terminal record, not necessarily index 1 — the
+		// thread can be 2 or 3 entries depending on body length.
+		$terminal     = $records[ \count( $records ) - 1 ];
 		$cta_has_link = false;
-		foreach ( $records[1]['facets'] ?? array() as $facet ) {
+		foreach ( $terminal['facets'] ?? array() as $facet ) {
 			foreach ( $facet['features'] as $feature ) {
 				if ( 'app.bsky.richtext.facet#link' === ( $feature['$type'] ?? '' ) ) {
 					$cta_has_link = true;


### PR DESCRIPTION
## Proposed changes

When the teaser-thread strategy's default would publish only `[ entire-body, "Continue reading: <permalink>" ]`, the CTA reply is redundant — there's nothing past the hook to "continue reading" to. Collapse to a single record (body text + link-card embed) so the reader gets one clean post; the link-back is preserved on the same record's embed card.

### Real-world example

Test post at `https://bsky.app/profile/bktest2026.bsky.social/post/3ml4torlpect2`: title + body "this is a test." (15 chars). Currently ships as a 2-post self-reply. After this PR: ships as a single post.

### Design after review iteration

1. **Collapse decision is made on the unfiltered default.** The `atmosphere_teaser_thread_posts` filter only runs when the default would NOT collapse. This avoids silently dropping the second entry for filter authors who edited only the hook (or whose 2-entry shape happens to match the redundant fallback by coincidence).

2. **Backward-compat for existing live threads via a stored-count hint.** `build_long_form_records()` now takes an optional `int $stored_count = 0`. `Publisher::update_post()` passes the stored count so the collapse is skipped when it would force a destructive `rewrite_thread()` that re-mints the root URI and orphans external Bluesky engagement (replies, likes, reposts). New posts still get the optimised single-record shape; live 2-record posts keep their existing shape forever.

### Migration semantics

- **New posts** under `teaser-thread` with short body (no `post_excerpt`, body fits in one record): publish as a single record. No CTA reply.
- **Existing 2-record posts**: keep publishing as 2 records on every subsequent update. No engagement loss. The "redundant CTA reply" stays for those posts indefinitely — fixing it retroactively would require re-minting the root URI, which is the bigger evil.
- **Filter authors** wanting a 2-entry custom shape: works for any post with a usable `post_excerpt` (>= 10 chars) or a body long enough to produce a body chunk. Short-body posts with empty excerpts always collapse before the filter runs.

The filter author behavior (point 1) is intentional and pinned by `test_build_long_form_records_teaser_thread_short_body_collapse_pre_empts_filter`.

The backward-compat behavior (point 2) is pinned by `test_build_long_form_records_teaser_thread_short_body_does_not_collapse_when_stored_count_two`.

### Other information

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions

1. Site running `atmosphere_long_form_composition` returning `'teaser-thread'`. (FOSSE sites do this by default; standalone Atmosphere sites need a `mu-plugin` filter.)
2. Publish a normal post type with a title and a short body (under ~280 chars) and **no** `post_excerpt`. Example: title "Test", body "this is a test."
3. Verify on bsky.app: a single post with the body as text and a link-card pointing back to the WP post — no "Continue reading" reply.
4. Publish a longer post (body > 300 chars) and verify the 3-entry teaser thread (hook + body chunk + CTA) still works as before.
5. Publish a short body WITH a usable `post_excerpt` and verify the 2-entry `[ excerpt, CTA ]` shape (excerpt and body are different content; the CTA still adds value).
6. Backward-compat check: a post that was previously published as a 2-record thread (you'll need to test this against trunk before this PR's changes land, edit it after, verify the URI is preserved). Or, simulate by setting `META_THREAD_RECORDS` to a 2-entry array on a freshly-created post, calling `Publisher::update_post()`, and verifying the in-place update path is taken (1 atomic apply_writes call, no delete-and-republish).

### Changelog

`.github/changelog/teaser-thread-collapse-redundant-cta` (Significance: patch, Type: fixed).