### PR TITLE
Use site domain as Bluesky handle

### DIFF
--- a/.github/changelog/domain-handle-setup
+++ b/.github/changelog/domain-handle-setup
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Use your site domain as your Bluesky handle with one click from the ATmosphere settings page.

--- a/includes/class-handle.php
+++ b/includes/class-handle.php
@@ -83,4 +83,51 @@ class Handle {
 
 		return null === $path || '' === $path || '/' === $path;
 	}
+
+	/**
+	 * Compute the handle that the site would advertise.
+	 *
+	 * Reads the host portion of `home_url()`. Returns empty when the host
+	 * cannot be resolved so callers refuse to send an empty payload.
+	 *
+	 * @return string
+	 */
+	public static function get_target_handle(): string {
+		$host = \wp_parse_url( \home_url(), PHP_URL_HOST );
+
+		return \is_string( $host ) ? \strtolower( $host ) : '';
+	}
+
+	/**
+	 * Whether the confirm-handle UI should render for the given status.
+	 *
+	 * @param array<string, mixed> $status Connection status snapshot with at
+	 *                                     least `connected` and `handle`.
+	 * @return bool
+	 */
+	public static function should_offer( array $status ): bool {
+		if ( ! self::is_enabled() ) {
+			return false;
+		}
+
+		if ( ! self::is_root_install() ) {
+			return false;
+		}
+
+		$target = self::get_target_handle();
+		if ( '' === $target ) {
+			return false;
+		}
+
+		if ( empty( $status['connected'] ) ) {
+			return false;
+		}
+
+		$current = isset( $status['handle'] ) ? (string) $status['handle'] : '';
+		if ( '' !== $current && \strtolower( $current ) === $target ) {
+			return false;
+		}
+
+		return true;
+	}
 }

--- a/includes/class-handle.php
+++ b/includes/class-handle.php
@@ -76,12 +76,39 @@ class Handle {
 	 * feature must skip them — Bluesky's PDS would reject the handle change
 	 * because it cannot fetch `/.well-known/atproto-did` at the host root.
 	 *
+	 * Also rejects split installs where `home_url` is at the host root but
+	 * `site_url` lives in a subdirectory (e.g. `WP_HOME=https://example.com`,
+	 * `WP_SITEURL=https://example.com/wp`). The `.well-known/atproto-did`
+	 * rewrite resolves through WordPress's request parser rooted at
+	 * `site_url`, so the verification fetch would 404 even though `home_url`
+	 * looks correct — and the PDS would have already accepted the new
+	 * handle by the time we found out.
+	 *
 	 * @return bool
 	 */
 	public static function is_root_install(): bool {
-		$path = \wp_parse_url( \home_url(), PHP_URL_PATH );
+		$home = \wp_parse_url( \home_url() );
+		$site = \wp_parse_url( \site_url() );
 
-		return null === $path || '' === $path || '/' === $path;
+		if ( ! \is_array( $home ) || ! \is_array( $site ) ) {
+			return false;
+		}
+
+		$home_path = isset( $home['path'] ) ? (string) $home['path'] : '';
+		$site_path = isset( $site['path'] ) ? (string) $site['path'] : '';
+
+		if ( '' !== $home_path && '/' !== $home_path ) {
+			return false;
+		}
+
+		if ( '' !== $site_path && '/' !== $site_path ) {
+			return false;
+		}
+
+		$home_host = isset( $home['host'] ) ? \strtolower( (string) $home['host'] ) : '';
+		$site_host = isset( $site['host'] ) ? \strtolower( (string) $site['host'] ) : '';
+
+		return '' !== $home_host && $home_host === $site_host;
 	}
 
 	/**
@@ -101,19 +128,30 @@ class Handle {
 	/**
 	 * Replace the connected user's Bluesky handle with the site host.
 	 *
-	 * Caller MUST have verified capability + nonce before invoking. The
-	 * method does not check those preconditions: it snapshots the current
-	 * handle (so disconnect can revert), invokes
-	 * `com.atproto.identity.updateHandle` via Atmosphere's DPoP client,
-	 * and posts a settings notice describing the outcome.
+	 * Fail-safe default: short-circuits when the current user lacks
+	 * `manage_options`. Callers in admin contexts (e.g.
+	 * {@see \Atmosphere\WP_Admin\Admin::handle_set_domain_handle()}) still
+	 * verify nonce themselves; the cap gate here is belt-and-braces so a
+	 * future caller (cron, REST, WP-CLI) cannot accidentally trigger an
+	 * `updateHandle` against the user's connected account without an
+	 * explicit cap-bearing context.
+	 *
+	 * On success: snapshots the current handle (so disconnect can revert),
+	 * invokes `com.atproto.identity.updateHandle` via Atmosphere's DPoP
+	 * client, and posts a settings notice describing the outcome.
 	 *
 	 * @return true|\WP_Error|null Null when the feature is disabled, the
-	 *                              install is ineligible, the connection
-	 *                              handle already matches the site host,
-	 *                              or no host can be derived. True on
-	 *                              success. WP_Error on failure.
+	 *                              install is ineligible, the current user
+	 *                              lacks the required capability, the
+	 *                              connection handle already matches the
+	 *                              site host, or no host can be derived.
+	 *                              True on success. WP_Error on failure.
 	 */
 	public static function set_handle(): true|\WP_Error|null {
+		if ( ! \current_user_can( 'manage_options' ) ) {
+			return null;
+		}
+
 		if ( ! self::is_enabled() || ! self::is_root_install() ) {
 			return null;
 		}
@@ -217,6 +255,14 @@ class Handle {
 
 		\delete_option( self::OPTION_PREVIOUS_HANDLE );
 
+		/*
+		 * Mirror the restored handle into atmosphere_connection. On the
+		 * standard disconnect path Client::disconnect() drops the option
+		 * moments later, so this write is wasted there — but keeping it
+		 * decouples Handle from disconnect ordering, so any future caller
+		 * (e.g. a manual revert action that does not also disconnect) gets
+		 * a consistent local snapshot.
+		 */
 		self::sync_connection_handle( $previous );
 
 		self::add_settings_notice(

--- a/includes/class-handle.php
+++ b/includes/class-handle.php
@@ -99,6 +99,150 @@ class Handle {
 	}
 
 	/**
+	 * Replace the connected user's Bluesky handle with the site host.
+	 *
+	 * Caller MUST have verified capability + nonce before invoking. The
+	 * method does not check those preconditions: it snapshots the current
+	 * handle (so disconnect can revert), invokes
+	 * `com.atproto.identity.updateHandle` via Atmosphere's DPoP client,
+	 * and posts a settings notice describing the outcome.
+	 *
+	 * @return true|\WP_Error|null Null when the feature is disabled, the
+	 *                              install is ineligible, the connection
+	 *                              handle already matches the site host,
+	 *                              or no host can be derived. True on
+	 *                              success. WP_Error on failure.
+	 */
+	public static function set_handle(): true|\WP_Error|null {
+		if ( ! self::is_enabled() || ! self::is_root_install() ) {
+			return null;
+		}
+
+		$target = self::get_target_handle();
+		if ( '' === $target ) {
+			return null;
+		}
+
+		if ( ! is_connected() ) {
+			self::add_settings_notice(
+				\__( 'Connect to Bluesky before setting your domain handle.', 'atmosphere' ),
+				'error'
+			);
+			return new \WP_Error(
+				'atmosphere_not_connected',
+				\__( 'Not connected to Bluesky.', 'atmosphere' )
+			);
+		}
+
+		$connection = get_connection();
+		$current    = isset( $connection['handle'] ) ? \strtolower( (string) $connection['handle'] ) : '';
+
+		if ( $current === $target ) {
+			return null;
+		}
+
+		if ( '' !== $current ) {
+			/*
+			 * Snapshot the current handle BEFORE the XRPC call. If the call
+			 * succeeds, the snapshot is what we revert to on disconnect. If it
+			 * fails, the PDS handle is unchanged, so the snapshot still equals
+			 * the user's actual handle and a later revert call is a safe no-op.
+			 */
+			\update_option( self::OPTION_PREVIOUS_HANDLE, $current, false );
+		}
+
+		$result = self::call_update_handle( $target );
+
+		if ( \is_wp_error( $result ) ) {
+			self::add_settings_notice(
+				\sprintf(
+					/* translators: 1: target handle (the site domain); 2: error message from the PDS. */
+					\__( 'Could not set %1$s as your Bluesky handle: %2$s', 'atmosphere' ),
+					$target,
+					$result->get_error_message()
+				),
+				'error'
+			);
+			return $result;
+		}
+
+		self::add_settings_notice(
+			\sprintf(
+				/* translators: %s: the handle the site set itself to (e.g. example.com). */
+				\__( 'Your Bluesky handle is now %s.', 'atmosphere' ),
+				$target
+			),
+			'success'
+		);
+
+		return true;
+	}
+
+	/**
+	 * Issue the `com.atproto.identity.updateHandle` call.
+	 *
+	 * Runs the `atmosphere_pre_update_handle` short-circuit filter first so
+	 * tests and integrations can observe / mock the call without going
+	 * through the DPoP layer (which would otherwise require real encrypted
+	 * keys to even build a request).
+	 *
+	 * @param string $handle Handle to set on the connected account.
+	 * @return true|\WP_Error
+	 */
+	private static function call_update_handle( string $handle ): true|\WP_Error {
+		/**
+		 * Short-circuits the `com.atproto.identity.updateHandle` call.
+		 *
+		 * Return `true` to fake success, a `WP_Error` to fake failure, or
+		 * `null` (the default) to fall through to the real PDS request.
+		 *
+		 * @param null|true|\WP_Error $short_circuit Short-circuit value.
+		 * @param string              $handle        Handle that would be set.
+		 */
+		$short_circuit = \apply_filters( self::FILTER_PRE_UPDATE, null, $handle );
+
+		if ( true === $short_circuit ) {
+			return true;
+		}
+
+		if ( \is_wp_error( $short_circuit ) ) {
+			return $short_circuit;
+		}
+
+		if ( null !== $short_circuit ) {
+			return new \WP_Error(
+				'atmosphere_invalid_pre_update_handle_return',
+				\__( 'atmosphere_pre_update_handle must return null, true, or a WP_Error.', 'atmosphere' )
+			);
+		}
+
+		$response = API::post(
+			'/xrpc/com.atproto.identity.updateHandle',
+			array( 'handle' => $handle )
+		);
+
+		if ( \is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Persist a settings notice under the Atmosphere group.
+	 *
+	 * Stores via the `settings_errors` transient so the message survives
+	 * the `wp_safe_redirect` admin-post handlers issue. Does not redirect.
+	 *
+	 * @param string $message Translated message to surface.
+	 * @param string $type    Notice type (`success`, `error`, `warning`, `info`).
+	 */
+	private static function add_settings_notice( string $message, string $type ): void {
+		\add_settings_error( self::NOTICE_SETTING, 'atmosphere_domain_handle', $message, $type );
+		\set_transient( 'settings_errors', \get_settings_errors(), 30 );
+	}
+
+	/**
 	 * Whether the confirm-handle UI should render for the given status.
 	 *
 	 * @param array<string, mixed> $status Connection status snapshot with at

--- a/includes/class-handle.php
+++ b/includes/class-handle.php
@@ -50,4 +50,37 @@ class Handle {
 	 * @var string
 	 */
 	public const OPTION_PREVIOUS_HANDLE = 'atmosphere_previous_handle';
+
+	/**
+	 * Whether the entire feature is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled(): bool {
+		/**
+		 * Filter whether the domain-handle feature is enabled.
+		 *
+		 * Filter to false to fully disable: the Settings panel suppresses
+		 * the confirm button, and disconnect does not attempt to revert.
+		 *
+		 * @param bool $enabled Default true.
+		 */
+		return (bool) \apply_filters( self::FILTER_ENABLED, true );
+	}
+
+	/**
+	 * Whether the site is at the root of its domain.
+	 *
+	 * Subdirectory installs (e.g. `https://example.com/blog/`) cannot serve
+	 * the AT Protocol verification endpoint at the domain root, so the
+	 * feature must skip them — Bluesky's PDS would reject the handle change
+	 * because it cannot fetch `/.well-known/atproto-did` at the host root.
+	 *
+	 * @return bool
+	 */
+	public static function is_root_install(): bool {
+		$path = \wp_parse_url( \home_url(), PHP_URL_PATH );
+
+		return null === $path || '' === $path || '/' === $path;
+	}
 }

--- a/includes/class-handle.php
+++ b/includes/class-handle.php
@@ -179,6 +179,55 @@ class Handle {
 	}
 
 	/**
+	 * Attempt to revert to the previously snapshotted handle.
+	 *
+	 * No-op when the feature is disabled or there is nothing to revert.
+	 * Caller (the disconnect flow) MUST invoke this BEFORE
+	 * `\Atmosphere\OAuth\Client::disconnect()` so the access token is still
+	 * valid for the call.
+	 *
+	 * @return true|\WP_Error|null Null when no revert was attempted.
+	 */
+	public static function maybe_revert_on_disconnect(): true|\WP_Error|null {
+		if ( ! self::is_enabled() ) {
+			return null;
+		}
+
+		$previous = (string) \get_option( self::OPTION_PREVIOUS_HANDLE, '' );
+		if ( '' === $previous ) {
+			return null;
+		}
+
+		$result = self::call_update_handle( $previous );
+
+		if ( \is_wp_error( $result ) ) {
+			self::add_settings_notice(
+				\sprintf(
+					/* translators: 1: previous handle to restore; 2: error message from the PDS. */
+					\__( 'Could not restore your previous Bluesky handle (%1$s): %2$s', 'atmosphere' ),
+					$previous,
+					$result->get_error_message()
+				),
+				'warning'
+			);
+			return $result;
+		}
+
+		\delete_option( self::OPTION_PREVIOUS_HANDLE );
+
+		self::add_settings_notice(
+			\sprintf(
+				/* translators: %s: the handle that was restored (e.g. alice.bsky.social). */
+				\__( 'Restored your previous Bluesky handle: %s.', 'atmosphere' ),
+				$previous
+			),
+			'info'
+		);
+
+		return true;
+	}
+
+	/**
 	 * Issue the `com.atproto.identity.updateHandle` call.
 	 *
 	 * Runs the `atmosphere_pre_update_handle` short-circuit filter first so

--- a/includes/class-handle.php
+++ b/includes/class-handle.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Domain-handle service: replace the connected Bluesky handle with the site host.
+ *
+ * @package Atmosphere
+ */
+
+namespace Atmosphere;
+
+\defined( 'ABSPATH' ) || exit;
+
+/**
+ * Coordinates the "use my domain as my Bluesky handle" feature.
+ *
+ * Calls `com.atproto.identity.updateHandle` on the connected PDS so the
+ * site's host (e.g. `example.com`) becomes the public AT Protocol handle.
+ * Bluesky verifies the change against `/.well-known/atproto-did`, which
+ * `Atmosphere::serve_wellknown_atproto_did()` already serves.
+ *
+ * Changing a handle is destructive — the previous handle stops resolving
+ * — so the call ALWAYS requires explicit user confirmation. There is no
+ * automatic mode.
+ */
+class Handle {
+
+	/**
+	 * Filter name for the feature kill-switch.
+	 *
+	 * @var string
+	 */
+	public const FILTER_ENABLED = 'atmosphere_domain_handle_enabled';
+
+	/**
+	 * Filter name for short-circuiting the actual `updateHandle` call.
+	 *
+	 * @var string
+	 */
+	public const FILTER_PRE_UPDATE = 'atmosphere_pre_update_handle';
+
+	/**
+	 * Settings-error slug used when surfacing notices.
+	 *
+	 * @var string
+	 */
+	public const NOTICE_SETTING = 'atmosphere';
+
+	/**
+	 * Option storing the previous handle so disconnect can revert.
+	 *
+	 * @var string
+	 */
+	public const OPTION_PREVIOUS_HANDLE = 'atmosphere_previous_handle';
+}

--- a/includes/class-handle.php
+++ b/includes/class-handle.php
@@ -166,6 +166,8 @@ class Handle {
 			return $result;
 		}
 
+		self::sync_connection_handle( $target );
+
 		self::add_settings_notice(
 			\sprintf(
 				/* translators: %s: the handle the site set itself to (e.g. example.com). */
@@ -214,6 +216,8 @@ class Handle {
 		}
 
 		\delete_option( self::OPTION_PREVIOUS_HANDLE );
+
+		self::sync_connection_handle( $previous );
 
 		self::add_settings_notice(
 			\sprintf(
@@ -275,6 +279,26 @@ class Handle {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Mirror a successful PDS handle change into the local connection option.
+	 *
+	 * The PDS is now serving the new handle, but `atmosphere_connection`
+	 * still holds the value captured at OAuth time. Without this update
+	 * the Settings page shows the stale handle and {@see self::should_offer()}
+	 * keeps offering the panel because `current !== target`.
+	 *
+	 * @param string $handle New handle to record locally.
+	 */
+	private static function sync_connection_handle( string $handle ): void {
+		$connection = get_connection();
+		if ( empty( $connection ) ) {
+			return;
+		}
+
+		$connection['handle'] = $handle;
+		\update_option( 'atmosphere_connection', $connection );
 	}
 
 	/**

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -663,6 +663,14 @@ class Admin {
 		 */
 		Handle::maybe_revert_on_disconnect();
 
+		/*
+		 * Clear the snapshot regardless of revert outcome so it cannot be
+		 * revived by a future reconnect to a different account. Once the
+		 * OAuth token is gone there is no way to retry a failed revert
+		 * anyway, so the snapshot is dead weight after this point.
+		 */
+		\delete_option( Handle::OPTION_PREVIOUS_HANDLE );
+
 		Client::disconnect();
 
 		\add_settings_error(

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -10,6 +10,7 @@ namespace Atmosphere\WP_Admin;
 \defined( 'ABSPATH' ) || exit;
 
 use Atmosphere\Atmosphere;
+use Atmosphere\Handle;
 use Atmosphere\OAuth\Client;
 use Atmosphere\Post_Types;
 use Atmosphere\Publisher;
@@ -32,6 +33,7 @@ class Admin {
 		\add_action( 'admin_enqueue_scripts', array( self::class, 'enqueue_assets' ) );
 
 		\add_action( 'admin_post_atmosphere_disconnect', array( self::class, 'handle_disconnect' ) );
+		\add_action( 'admin_post_atmosphere_set_domain_handle', array( self::class, 'handle_set_domain_handle' ) );
 
 		// Meta box on syncable post types.
 		\add_action( 'add_meta_boxes', array( self::class, 'add_meta_box' ) );
@@ -219,6 +221,76 @@ class Admin {
 				</td>
 			</tr>
 		</table>
+		<?php
+		self::render_domain_handle_panel( $connection );
+	}
+
+	/**
+	 * Render the "use my domain as my Bluesky handle" confirm panel.
+	 *
+	 * Shows the current handle alongside the target so the user
+	 * understands the trade — clicking the button replaces their handle
+	 * and the previous one stops resolving.
+	 *
+	 * @param array<string, mixed> $connection Connection snapshot.
+	 */
+	public static function render_domain_handle_panel( array $connection ): void {
+		$status = array(
+			'connected' => true,
+			'handle'    => $connection['handle'] ?? '',
+		);
+
+		if ( ! Handle::should_offer( $status ) ) {
+			return;
+		}
+
+		$current = (string) ( $connection['handle'] ?? '' );
+		$target  = Handle::get_target_handle();
+		?>
+		<div class="atmosphere-domain-handle-panel">
+			<h3><?php \esc_html_e( 'Use your domain as your Bluesky handle', 'atmosphere' ); ?></h3>
+			<p>
+				<?php
+				if ( '' !== $current ) {
+					echo \esc_html(
+						\sprintf(
+							/* translators: 1: current Bluesky handle (e.g. alice.bsky.social); 2: target handle = site host (e.g. example.com). */
+							\__( 'Your current Bluesky handle is %1$s. Click the button below to replace it with %2$s.', 'atmosphere' ),
+							$current,
+							$target
+						)
+					);
+				} else {
+					echo \esc_html(
+						\sprintf(
+							/* translators: %s: target handle = site host (e.g. example.com). */
+							\__( 'Click the button below to set your Bluesky handle to %s.', 'atmosphere' ),
+							$target
+						)
+					);
+				}
+				?>
+			</p>
+			<p class="description">
+				<?php \esc_html_e( 'Heads up: replacing your handle is destructive. Your previous handle will stop resolving immediately, and links to it will break. Bluesky verifies the new handle through this site automatically.', 'atmosphere' ); ?>
+			</p>
+			<form method="post" action="<?php echo \esc_url( \admin_url( 'admin-post.php' ) ); ?>">
+				<input type="hidden" name="action" value="atmosphere_set_domain_handle" />
+				<?php \wp_nonce_field( 'atmosphere_set_domain_handle' ); ?>
+				<?php
+				\submit_button(
+					\sprintf(
+						/* translators: %s: target handle = site host (e.g. example.com). */
+						\__( 'Use %s as my Bluesky handle', 'atmosphere' ),
+						$target
+					),
+					'secondary',
+					'submit',
+					false
+				);
+				?>
+			</form>
+		</div>
 		<?php
 	}
 
@@ -548,6 +620,26 @@ class Admin {
 		\set_transient( 'settings_errors', \get_settings_errors(), 30 );
 
 		\wp_safe_redirect( \admin_url( 'options-general.php?page=atmosphere&connected=1' ) );
+		exit;
+	}
+
+	/**
+	 * Handle the explicit "use my domain as my Bluesky handle" submission.
+	 *
+	 * Verifies capability + nonce, defers to {@see Handle::set_handle()} for
+	 * the actual call, then redirects back to the Settings page with a notice
+	 * already populated by Handle.
+	 */
+	public static function handle_set_domain_handle(): void {
+		if ( ! \current_user_can( 'manage_options' ) ) {
+			\wp_die( \esc_html__( 'You do not have permission to do this.', 'atmosphere' ) );
+		}
+
+		\check_admin_referer( 'atmosphere_set_domain_handle' );
+
+		Handle::set_handle();
+
+		\wp_safe_redirect( \admin_url( 'options-general.php?page=atmosphere' ) );
 		exit;
 	}
 

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -653,6 +653,16 @@ class Admin {
 
 		\check_admin_referer( 'atmosphere_disconnect', 'atmosphere_nonce' );
 
+		/*
+		 * Best-effort handle revert BEFORE the disconnect drops the OAuth
+		 * token: if the site previously set the handle to its domain, restore
+		 * the snapshotted previous handle while the access token is still
+		 * valid. The call posts a notice on the way out; disconnect proceeds
+		 * regardless of result so a token-revoked or network-failed revert
+		 * can't trap the user in a connected state.
+		 */
+		Handle::maybe_revert_on_disconnect();
+
 		Client::disconnect();
 
 		\add_settings_error(

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -176,6 +176,27 @@ class Admin {
 			'atmosphere',
 			'atmosphere_publishing'
 		);
+
+		/*
+		 * Register the domain-handle confirm row only when the offer is
+		 * meaningful (root install, feature enabled, current handle differs
+		 * from the site host). Skipping registration is the cleanest way to
+		 * suppress the row entirely without rendering an empty <tr>.
+		 */
+		if ( Handle::should_offer(
+			array(
+				'connected' => true,
+				'handle'    => get_connection()['handle'] ?? '',
+			)
+		) ) {
+			\add_settings_field(
+				'atmosphere_set_domain_handle',
+				\__( 'Domain handle', 'atmosphere' ),
+				array( self::class, 'render_domain_handle_field' ),
+				'atmosphere',
+				'atmosphere_connection'
+			);
+		}
 	}
 
 	/**
@@ -222,75 +243,62 @@ class Admin {
 			</tr>
 		</table>
 		<?php
-		self::render_domain_handle_panel( $connection );
 	}
 
 	/**
-	 * Render the "use my domain as my Bluesky handle" confirm panel.
+	 * Render the "use my domain as my Bluesky handle" confirm field.
 	 *
-	 * Shows the current handle alongside the target so the user
-	 * understands the trade — clicking the button replaces their handle
-	 * and the previous one stops resolving.
-	 *
-	 * @param array<string, mixed> $connection Connection snapshot.
+	 * Registered conditionally on the `atmosphere_connection` section
+	 * via {@see self::register_settings()}; only enqueued when
+	 * {@see Handle::should_offer()} agrees the offer is meaningful.
 	 */
-	public static function render_domain_handle_panel( array $connection ): void {
-		$status = array(
-			'connected' => true,
-			'handle'    => $connection['handle'] ?? '',
-		);
-
-		if ( ! Handle::should_offer( $status ) ) {
-			return;
-		}
-
-		$current = (string) ( $connection['handle'] ?? '' );
+	public static function render_domain_handle_field(): void {
+		$current = (string) ( get_connection()['handle'] ?? '' );
 		$target  = Handle::get_target_handle();
+		$action  = \wp_nonce_url(
+			\admin_url( 'admin-post.php?action=atmosphere_set_domain_handle' ),
+			'atmosphere_set_domain_handle',
+			'atmosphere_nonce'
+		);
 		?>
-		<div class="atmosphere-domain-handle-panel">
-			<h3><?php \esc_html_e( 'Use your domain as your Bluesky handle', 'atmosphere' ); ?></h3>
-			<p>
+		<p>
+			<?php
+			if ( '' !== $current ) {
+				echo \esc_html(
+					\sprintf(
+						/* translators: 1: current Bluesky handle (e.g. alice.bsky.social); 2: target handle = site host (e.g. example.com). */
+						\__( 'Your current Bluesky handle is %1$s. Click the button below to replace it with %2$s.', 'atmosphere' ),
+						$current,
+						$target
+					)
+				);
+			} else {
+				echo \esc_html(
+					\sprintf(
+						/* translators: %s: target handle = site host (e.g. example.com). */
+						\__( 'Click the button below to set your Bluesky handle to %s.', 'atmosphere' ),
+						$target
+					)
+				);
+			}
+			?>
+		</p>
+		<p>
+			<a href="<?php echo \esc_url( $action ); ?>" class="button">
 				<?php
-				if ( '' !== $current ) {
-					echo \esc_html(
-						\sprintf(
-							/* translators: 1: current Bluesky handle (e.g. alice.bsky.social); 2: target handle = site host (e.g. example.com). */
-							\__( 'Your current Bluesky handle is %1$s. Click the button below to replace it with %2$s.', 'atmosphere' ),
-							$current,
-							$target
-						)
-					);
-				} else {
-					echo \esc_html(
-						\sprintf(
-							/* translators: %s: target handle = site host (e.g. example.com). */
-							\__( 'Click the button below to set your Bluesky handle to %s.', 'atmosphere' ),
-							$target
-						)
-					);
-				}
-				?>
-			</p>
-			<p class="description">
-				<?php \esc_html_e( 'Heads up: replacing your handle is destructive. Your previous handle will stop resolving immediately, and links to it will break. Bluesky verifies the new handle through this site automatically.', 'atmosphere' ); ?>
-			</p>
-			<form method="post" action="<?php echo \esc_url( \admin_url( 'admin-post.php' ) ); ?>">
-				<input type="hidden" name="action" value="atmosphere_set_domain_handle" />
-				<?php \wp_nonce_field( 'atmosphere_set_domain_handle' ); ?>
-				<?php
-				\submit_button(
+				echo \esc_html(
 					\sprintf(
 						/* translators: %s: target handle = site host (e.g. example.com). */
 						\__( 'Use %s as my Bluesky handle', 'atmosphere' ),
 						$target
-					),
-					'secondary',
-					'submit',
-					false
+					)
 				);
 				?>
-			</form>
-		</div>
+			</a>
+		</p>
+		<p class="description">
+			<?php \esc_html_e( 'Heads up: replacing your handle is destructive. Your previous handle will stop resolving immediately, and links to it will break. Bluesky verifies the new handle through this site automatically.', 'atmosphere' ); ?>
+		</p>
 		<?php
 	}
 
@@ -635,7 +643,7 @@ class Admin {
 			\wp_die( \esc_html__( 'You do not have permission to do this.', 'atmosphere' ) );
 		}
 
-		\check_admin_referer( 'atmosphere_set_domain_handle' );
+		\check_admin_referer( 'atmosphere_set_domain_handle', 'atmosphere_nonce' );
 
 		Handle::set_handle();
 

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -253,13 +253,9 @@ class Admin {
 	 * {@see Handle::should_offer()} agrees the offer is meaningful.
 	 */
 	public static function render_domain_handle_field(): void {
-		$current = (string) ( get_connection()['handle'] ?? '' );
-		$target  = Handle::get_target_handle();
-		$action  = \wp_nonce_url(
-			\admin_url( 'admin-post.php?action=atmosphere_set_domain_handle' ),
-			'atmosphere_set_domain_handle',
-			'atmosphere_nonce'
-		);
+		$current  = (string) ( get_connection()['handle'] ?? '' );
+		$target   = Handle::get_target_handle();
+		$post_url = \admin_url( 'admin-post.php?action=atmosphere_set_domain_handle' );
 		?>
 		<p>
 			<?php
@@ -284,7 +280,26 @@ class Admin {
 			?>
 		</p>
 		<p>
-			<a href="<?php echo \esc_url( $action ); ?>" class="button">
+			<?php
+			/*
+			 * The settings page wraps every field in a single outer
+			 * <form action="options.php" method="post">. A nested form
+			 * would be invalid HTML, so the submit button overrides the
+			 * outer form's destination via formaction/formmethod when —
+			 * and only when — this button is the one clicked. The Save
+			 * button at the bottom of the settings page still posts to
+			 * options.php as normal. This keeps the nonce in the request
+			 * body instead of leaking it through the URL / Referer
+			 * header / link prefetching, which an <a> with
+			 * wp_nonce_url() would do.
+			 */
+			\wp_nonce_field( 'atmosphere_set_domain_handle', 'atmosphere_nonce', false );
+			?>
+			<button
+				type="submit"
+				formaction="<?php echo \esc_url( $post_url ); ?>"
+				formmethod="post"
+				class="button">
 				<?php
 				echo \esc_html(
 					\sprintf(
@@ -294,7 +309,7 @@ class Admin {
 					)
 				);
 				?>
-			</a>
+			</button>
 		</p>
 		<p class="description">
 			<?php \esc_html_e( 'Heads up: replacing your handle is destructive. Your previous handle will stop resolving immediately, and links to it will break. Bluesky verifies the new handle through this site automatically.', 'atmosphere' ); ?>

--- a/tests/phpunit/tests/class-test-admin-handle.php
+++ b/tests/phpunit/tests/class-test-admin-handle.php
@@ -148,14 +148,15 @@ class Test_Admin_Handle extends WP_UnitTestCase {
 	public function test_redirects_to_settings_page_on_success(): void {
 		$this->become_admin();
 
-		$nonce                        = \wp_create_nonce( 'atmosphere_set_domain_handle' );
-		$_POST['atmosphere_nonce']    = $nonce;
+		$nonce = \wp_create_nonce( 'atmosphere_set_domain_handle' );
+
 		/*
 		 * In real requests PHP populates $_REQUEST from $_POST/$_GET on
 		 * script start; in tests we mutate the superglobals directly, so
 		 * mirror the value into $_REQUEST too — that is what
 		 * check_admin_referer() actually reads.
 		 */
+		$_POST['atmosphere_nonce']    = $nonce;
 		$_REQUEST['atmosphere_nonce'] = $nonce;
 
 		/*

--- a/tests/phpunit/tests/class-test-admin-handle.php
+++ b/tests/phpunit/tests/class-test-admin-handle.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Integration tests for the domain-handle admin-post handler.
+ *
+ * Covers the two security gates on `Admin::handle_set_domain_handle`
+ * (capability + nonce) and the happy-path redirect. The Handle service
+ * itself has unit coverage in {@see Test_Handle}; this file pins the
+ * front-door contract between an admin POST and the XRPC call.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group handle
+ */
+
+namespace Atmosphere\Tests;
+
+use Atmosphere\Handle;
+use Atmosphere\WP_Admin\Admin;
+use WP_UnitTestCase;
+use WPDieException;
+
+/**
+ * Admin domain-handle handler tests.
+ */
+class Test_Admin_Handle extends WP_UnitTestCase {
+
+	/**
+	 * Filters registered during a test that must be removed in tearDown.
+	 *
+	 * @var array<int, array{0: string, 1: callable, 2: int}>
+	 */
+	private array $tracked_filters = array();
+
+	/**
+	 * Reset request superglobals and current user.
+	 */
+	public function tear_down(): void {
+		foreach ( $this->tracked_filters as $entry ) {
+			\remove_filter( $entry[0], $entry[1], $entry[2] );
+		}
+		$this->tracked_filters = array();
+
+		$_REQUEST = array();
+		$_POST    = array();
+		$_GET     = array();
+
+		\wp_set_current_user( 0 );
+		\delete_option( 'atmosphere_connection' );
+		\delete_option( Handle::OPTION_PREVIOUS_HANDLE );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Register a filter and remember it for tearDown removal.
+	 *
+	 * @param string   $hook     Hook name.
+	 * @param callable $callback Callback.
+	 * @param int      $priority Priority.
+	 */
+	private function add_filter_tracked( string $hook, callable $callback, int $priority = 10 ): void {
+		\add_filter( $hook, $callback, $priority );
+		$this->tracked_filters[] = array( $hook, $callback, $priority );
+	}
+
+	/**
+	 * Become an administrator — grants `manage_options`.
+	 */
+	private function become_admin(): void {
+		$admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		\wp_set_current_user( $admin );
+	}
+
+	/**
+	 * Test that the handler dies when the current user lacks `manage_options`.
+	 */
+	public function test_dies_without_manage_options_cap(): void {
+		\wp_set_current_user( 0 );
+
+		$this->expectException( WPDieException::class );
+
+		Admin::handle_set_domain_handle();
+	}
+
+	/**
+	 * Test that the handler dies when no valid nonce is present, and that
+	 * the underlying `Handle::set_handle()` flow never runs.
+	 */
+	public function test_dies_on_missing_nonce_and_skips_handle_call(): void {
+		$this->become_admin();
+
+		$called = 0;
+		$spy    = static function ( $value ) use ( &$called ) {
+			++$called;
+			return $value;
+		};
+		$this->add_filter_tracked( Handle::FILTER_PRE_UPDATE, $spy );
+
+		try {
+			Admin::handle_set_domain_handle();
+			$this->fail( 'Expected wp_die() from check_admin_referer.' );
+		} catch ( WPDieException $e ) {
+			// Expected.
+			unset( $e );
+		}
+
+		$this->assertSame( 0, $called, 'Handle::set_handle() must not run when the nonce check fails.' );
+	}
+
+	/**
+	 * Test that the handler redirects to the Atmosphere settings page when
+	 * both the capability and nonce gates pass.
+	 */
+	public function test_redirects_to_settings_page_on_success(): void {
+		$this->become_admin();
+
+		$_REQUEST['atmosphere_nonce'] = \wp_create_nonce( 'atmosphere_set_domain_handle' );
+
+		/*
+		 * Short-circuit `wp_redirect` so the handler's `exit` is preempted
+		 * by an exception we can catch — without this the test would halt
+		 * the entire PHPUnit run.
+		 */
+		$captured = null;
+		$catcher  = static function ( $location ) use ( &$captured ) {
+			$captured = $location;
+			throw new WPDieException( 'redirect_intercepted' );
+		};
+		$this->add_filter_tracked( 'wp_redirect', $catcher );
+
+		try {
+			Admin::handle_set_domain_handle();
+			$this->fail( 'Expected redirect to be intercepted.' );
+		} catch ( WPDieException $e ) {
+			$this->assertSame( 'redirect_intercepted', $e->getMessage() );
+		}
+
+		$this->assertIsString( $captured );
+		$this->assertStringContainsString( 'page=atmosphere', $captured );
+	}
+}

--- a/tests/phpunit/tests/class-test-admin-handle.php
+++ b/tests/phpunit/tests/class-test-admin-handle.php
@@ -72,6 +72,30 @@ class Test_Admin_Handle extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Set up an eligible state where {@see Handle::set_handle()} would
+	 * reach the {@see Handle::FILTER_PRE_UPDATE} short-circuit if
+	 * called: root-install URLs and a connected, non-matching handle.
+	 *
+	 * Without this scaffolding, a `FILTER_PRE_UPDATE` spy can't tell the
+	 * difference between "the handler skipped Handle::set_handle()" and
+	 * "Handle::set_handle() ran but bailed early at !is_connected()".
+	 */
+	private function make_handle_call_observable(): void {
+		$home = static fn() => 'https://example.com';
+		$this->add_filter_tracked( 'home_url', $home );
+		$this->add_filter_tracked( 'site_url', $home );
+
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'handle'       => 'alice.bsky.social',
+				'did'          => 'did:plc:test',
+				'access_token' => 'tok',
+			)
+		);
+	}
+
+	/**
 	 * Test that the handler dies when the current user lacks `manage_options`.
 	 */
 	public function test_dies_without_manage_options_cap(): void {
@@ -85,9 +109,15 @@ class Test_Admin_Handle extends WP_UnitTestCase {
 	/**
 	 * Test that the handler dies when no valid nonce is present, and that
 	 * the underlying `Handle::set_handle()` flow never runs.
+	 *
+	 * Sets up an otherwise-eligible state (root install + connected,
+	 * non-matching handle) so the FILTER_PRE_UPDATE spy is meaningful:
+	 * if `Handle::set_handle()` *were* incorrectly reached, the filter
+	 * would fire and `$called` would be 1.
 	 */
 	public function test_dies_on_missing_nonce_and_skips_handle_call(): void {
 		$this->become_admin();
+		$this->make_handle_call_observable();
 
 		$called = 0;
 		$spy    = static function ( $value ) use ( &$called ) {
@@ -110,11 +140,23 @@ class Test_Admin_Handle extends WP_UnitTestCase {
 	/**
 	 * Test that the handler redirects to the Atmosphere settings page when
 	 * both the capability and nonce gates pass.
+	 *
+	 * The browser-side panel posts to admin-post.php via a form, so the
+	 * nonce is delivered in `$_POST` rather than the URL — the test
+	 * mirrors that.
 	 */
 	public function test_redirects_to_settings_page_on_success(): void {
 		$this->become_admin();
 
-		$_REQUEST['atmosphere_nonce'] = \wp_create_nonce( 'atmosphere_set_domain_handle' );
+		$nonce                        = \wp_create_nonce( 'atmosphere_set_domain_handle' );
+		$_POST['atmosphere_nonce']    = $nonce;
+		/*
+		 * In real requests PHP populates $_REQUEST from $_POST/$_GET on
+		 * script start; in tests we mutate the superglobals directly, so
+		 * mirror the value into $_REQUEST too — that is what
+		 * check_admin_referer() actually reads.
+		 */
+		$_REQUEST['atmosphere_nonce'] = $nonce;
 
 		/*
 		 * Short-circuit `wp_redirect` so the handler's `exit` is preempted

--- a/tests/phpunit/tests/class-test-handle.php
+++ b/tests/phpunit/tests/class-test-handle.php
@@ -18,6 +18,70 @@ use WP_UnitTestCase;
 class Test_Handle extends WP_UnitTestCase {
 
 	/**
+	 * Closures registered during a test that must be removed in tearDown.
+	 *
+	 * Stored as `[ [ $hook, $callable, $priority ], ... ]` so tests can
+	 * register filters via {@see self::add_filter_tracked()} without having
+	 * to remember to detach each one. Targeted removal avoids the
+	 * shotgun blast of `remove_all_filters()`, which strips core's own
+	 * registrations (multisite, `wp_force_ssl_admin`, etc.) too.
+	 *
+	 * @var array<int, array{0: string, 1: callable, 2: int}>
+	 */
+	private array $tracked_filters = array();
+
+	/**
+	 * Set up an admin user so {@see Handle::set_handle()} clears its cap gate.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		\wp_set_current_user( $admin );
+	}
+
+	/**
+	 * Detach any filters registered via {@see self::add_filter_tracked()}.
+	 */
+	public function tear_down(): void {
+		foreach ( $this->tracked_filters as $entry ) {
+			\remove_filter( $entry[0], $entry[1], $entry[2] );
+		}
+		$this->tracked_filters = array();
+
+		\delete_option( 'atmosphere_connection' );
+		\delete_option( Handle::OPTION_PREVIOUS_HANDLE );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Register a filter and remember it for tearDown removal.
+	 *
+	 * @param string   $hook     Hook name.
+	 * @param callable $callback Callback.
+	 * @param int      $priority Priority.
+	 */
+	private function add_filter_tracked( string $hook, callable $callback, int $priority = 10 ): void {
+		\add_filter( $hook, $callback, $priority );
+		$this->tracked_filters[] = array( $hook, $callback, $priority );
+	}
+
+	/**
+	 * Force home_url() and site_url() to resolve to the same URL.
+	 *
+	 * Most tests want a clean root install where both URLs share host and
+	 * path, so this helper installs both filters in one call.
+	 *
+	 * @param string $url URL to return for both.
+	 */
+	private function force_urls( string $url ): void {
+		$callback = static fn() => $url;
+		$this->add_filter_tracked( 'home_url', $callback );
+		$this->add_filter_tracked( 'site_url', $callback );
+	}
+
+	/**
 	 * Test that public constants hold the expected string values.
 	 */
 	public function test_constants(): void {
@@ -38,61 +102,75 @@ class Test_Handle extends WP_UnitTestCase {
 	 * Test that is_enabled can be disabled via filter.
 	 */
 	public function test_is_enabled_filter_can_disable(): void {
-		\add_filter( Handle::FILTER_ENABLED, '__return_false' );
+		$this->add_filter_tracked( Handle::FILTER_ENABLED, '__return_false' );
 		$this->assertFalse( Handle::is_enabled() );
-		\remove_filter( Handle::FILTER_ENABLED, '__return_false' );
 	}
 
 	/**
 	 * Test that is_root_install returns true for a root domain.
 	 */
 	public function test_is_root_install_for_root(): void {
-		\add_filter( 'home_url', static fn() => 'https://example.com' );
+		$this->force_urls( 'https://example.com' );
 		$this->assertTrue( Handle::is_root_install() );
-		\remove_all_filters( 'home_url' );
 	}
 
 	/**
 	 * Test that is_root_install returns true for a root domain with trailing slash.
 	 */
 	public function test_is_root_install_for_root_with_trailing_slash(): void {
-		\add_filter( 'home_url', static fn() => 'https://example.com/' );
+		$this->force_urls( 'https://example.com/' );
 		$this->assertTrue( Handle::is_root_install() );
-		\remove_all_filters( 'home_url' );
 	}
 
 	/**
 	 * Test that is_root_install returns false for a subdirectory install.
 	 */
 	public function test_is_root_install_false_for_subdirectory(): void {
-		\add_filter( 'home_url', static fn() => 'https://example.com/blog' );
+		$this->force_urls( 'https://example.com/blog' );
 		$this->assertFalse( Handle::is_root_install() );
-		\remove_all_filters( 'home_url' );
+	}
+
+	/**
+	 * Test that is_root_install returns false when home_url is at the host
+	 * root but site_url is in a subdirectory — the rewrite parser is
+	 * rooted at site_url and would not resolve `/.well-known/atproto-did`.
+	 */
+	public function test_is_root_install_false_for_split_install(): void {
+		$this->add_filter_tracked( 'home_url', static fn() => 'https://example.com' );
+		$this->add_filter_tracked( 'site_url', static fn() => 'https://example.com/wp' );
+		$this->assertFalse( Handle::is_root_install() );
+	}
+
+	/**
+	 * Test that is_root_install returns false when home and site disagree on host.
+	 */
+	public function test_is_root_install_false_for_host_mismatch(): void {
+		$this->add_filter_tracked( 'home_url', static fn() => 'https://example.com' );
+		$this->add_filter_tracked( 'site_url', static fn() => 'https://other.example' );
+		$this->assertFalse( Handle::is_root_install() );
 	}
 
 	/**
 	 * Test that get_target_handle lowercases the host.
 	 */
 	public function test_get_target_handle_lowercases_host(): void {
-		\add_filter( 'home_url', static fn() => 'https://Example.COM' );
+		$this->add_filter_tracked( 'home_url', static fn() => 'https://Example.COM' );
 		$this->assertSame( 'example.com', Handle::get_target_handle() );
-		\remove_all_filters( 'home_url' );
 	}
 
 	/**
 	 * Test that get_target_handle returns empty string when host is missing.
 	 */
 	public function test_get_target_handle_returns_empty_when_host_missing(): void {
-		\add_filter( 'home_url', static fn() => '/relative/path' );
+		$this->add_filter_tracked( 'home_url', static fn() => '/relative/path' );
 		$this->assertSame( '', Handle::get_target_handle() );
-		\remove_all_filters( 'home_url' );
 	}
 
 	/**
 	 * Test that should_offer returns false when the feature is disabled.
 	 */
 	public function test_should_offer_false_when_disabled(): void {
-		\add_filter( Handle::FILTER_ENABLED, '__return_false' );
+		$this->add_filter_tracked( Handle::FILTER_ENABLED, '__return_false' );
 		$this->assertFalse(
 			Handle::should_offer(
 				array(
@@ -101,14 +179,13 @@ class Test_Handle extends WP_UnitTestCase {
 				)
 			)
 		);
-		\remove_filter( Handle::FILTER_ENABLED, '__return_false' );
 	}
 
 	/**
 	 * Test that should_offer returns false for a subdirectory install.
 	 */
 	public function test_should_offer_false_for_subdir_install(): void {
-		\add_filter( 'home_url', static fn() => 'https://example.com/blog' );
+		$this->force_urls( 'https://example.com/blog' );
 		$this->assertFalse(
 			Handle::should_offer(
 				array(
@@ -117,23 +194,21 @@ class Test_Handle extends WP_UnitTestCase {
 				)
 			)
 		);
-		\remove_all_filters( 'home_url' );
 	}
 
 	/**
 	 * Test that should_offer returns false when not connected.
 	 */
 	public function test_should_offer_false_when_not_connected(): void {
-		\add_filter( 'home_url', static fn() => 'https://example.com' );
+		$this->force_urls( 'https://example.com' );
 		$this->assertFalse( Handle::should_offer( array( 'connected' => false ) ) );
-		\remove_all_filters( 'home_url' );
 	}
 
 	/**
 	 * Test that should_offer returns false when the handle already matches the domain.
 	 */
 	public function test_should_offer_false_when_handle_already_matches(): void {
-		\add_filter( 'home_url', static fn() => 'https://example.com' );
+		$this->force_urls( 'https://example.com' );
 		$this->assertFalse(
 			Handle::should_offer(
 				array(
@@ -150,14 +225,13 @@ class Test_Handle extends WP_UnitTestCase {
 				)
 			)
 		);
-		\remove_all_filters( 'home_url' );
 	}
 
 	/**
 	 * Test that should_offer returns true when all conditions are met.
 	 */
 	public function test_should_offer_true_when_eligible(): void {
-		\add_filter( 'home_url', static fn() => 'https://example.com' );
+		$this->force_urls( 'https://example.com' );
 		$this->assertTrue(
 			Handle::should_offer(
 				array(
@@ -166,44 +240,63 @@ class Test_Handle extends WP_UnitTestCase {
 				)
 			)
 		);
-		\remove_all_filters( 'home_url' );
+	}
+
+	/**
+	 * Test that set_handle returns null when the current user lacks manage_options.
+	 */
+	public function test_set_handle_returns_null_when_user_lacks_cap(): void {
+		\wp_set_current_user( 0 );
+		$this->force_urls( 'https://example.com' );
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'handle'       => 'alice.bsky.social',
+				'did'          => 'did:plc:test',
+				'access_token' => 'tok',
+			)
+		);
+		$this->add_filter_tracked( Handle::FILTER_PRE_UPDATE, static fn() => true );
+
+		$this->assertNull( Handle::set_handle() );
+		$this->assertSame(
+			'alice.bsky.social',
+			\get_option( 'atmosphere_connection' )['handle']
+		);
 	}
 
 	/**
 	 * Test that set_handle returns null when the feature is disabled.
 	 */
 	public function test_set_handle_returns_null_when_disabled(): void {
-		\add_filter( Handle::FILTER_ENABLED, '__return_false' );
+		$this->add_filter_tracked( Handle::FILTER_ENABLED, '__return_false' );
 		$this->assertNull( Handle::set_handle() );
-		\remove_filter( Handle::FILTER_ENABLED, '__return_false' );
 	}
 
 	/**
 	 * Test that set_handle returns null for a subdirectory install.
 	 */
 	public function test_set_handle_returns_null_for_subdir_install(): void {
-		\add_filter( 'home_url', static fn() => 'https://example.com/blog' );
+		$this->force_urls( 'https://example.com/blog' );
 		$this->assertNull( Handle::set_handle() );
-		\remove_all_filters( 'home_url' );
 	}
 
 	/**
 	 * Test that set_handle returns WP_Error when not connected.
 	 */
 	public function test_set_handle_errors_when_not_connected(): void {
-		\add_filter( 'home_url', static fn() => 'https://example.com' );
+		$this->force_urls( 'https://example.com' );
 		\delete_option( 'atmosphere_connection' );
 		$result = Handle::set_handle();
 		$this->assertWPError( $result );
 		$this->assertSame( 'atmosphere_not_connected', $result->get_error_code() );
-		\remove_all_filters( 'home_url' );
 	}
 
 	/**
 	 * Test that set_handle returns null when the handle already matches.
 	 */
 	public function test_set_handle_returns_null_when_already_matching(): void {
-		\add_filter( 'home_url', static fn() => 'https://example.com' );
+		$this->force_urls( 'https://example.com' );
 		\update_option(
 			'atmosphere_connection',
 			array(
@@ -213,15 +306,13 @@ class Test_Handle extends WP_UnitTestCase {
 			)
 		);
 		$this->assertNull( Handle::set_handle() );
-		\delete_option( 'atmosphere_connection' );
-		\remove_all_filters( 'home_url' );
 	}
 
 	/**
 	 * Test that set_handle succeeds via the short-circuit filter.
 	 */
 	public function test_set_handle_succeeds_via_short_circuit_filter(): void {
-		\add_filter( 'home_url', static fn() => 'https://example.com' );
+		$this->force_urls( 'https://example.com' );
 		\update_option(
 			'atmosphere_connection',
 			array(
@@ -230,25 +321,20 @@ class Test_Handle extends WP_UnitTestCase {
 				'access_token' => 'tok',
 			)
 		);
-		\add_filter( Handle::FILTER_PRE_UPDATE, static fn() => true );
+		$this->add_filter_tracked( Handle::FILTER_PRE_UPDATE, static fn() => true );
 
 		$result = Handle::set_handle();
 
 		$this->assertTrue( $result );
 		$this->assertSame( 'alice.bsky.social', \get_option( Handle::OPTION_PREVIOUS_HANDLE ) );
 		$this->assertSame( 'example.com', \get_option( 'atmosphere_connection' )['handle'] );
-
-		\remove_all_filters( Handle::FILTER_PRE_UPDATE );
-		\remove_all_filters( 'home_url' );
-		\delete_option( 'atmosphere_connection' );
-		\delete_option( Handle::OPTION_PREVIOUS_HANDLE );
 	}
 
 	/**
 	 * Test that set_handle propagates a WP_Error from the short-circuit filter.
 	 */
 	public function test_set_handle_propagates_short_circuit_wp_error(): void {
-		\add_filter( 'home_url', static fn() => 'https://example.com' );
+		$this->force_urls( 'https://example.com' );
 		\update_option(
 			'atmosphere_connection',
 			array(
@@ -258,34 +344,27 @@ class Test_Handle extends WP_UnitTestCase {
 			)
 		);
 		$err = new \WP_Error( 'rate_limited', 'slow down' );
-		\add_filter( Handle::FILTER_PRE_UPDATE, static fn() => $err );
+		$this->add_filter_tracked( Handle::FILTER_PRE_UPDATE, static fn() => $err );
 
 		$result = Handle::set_handle();
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'rate_limited', $result->get_error_code() );
 		$this->assertSame( 'alice.bsky.social', \get_option( 'atmosphere_connection' )['handle'] );
-
-		\remove_all_filters( Handle::FILTER_PRE_UPDATE );
-		\remove_all_filters( 'home_url' );
-		\delete_option( 'atmosphere_connection' );
-		\delete_option( Handle::OPTION_PREVIOUS_HANDLE );
 	}
 
 	/**
 	 * Test that maybe_revert_on_disconnect returns null when the feature is disabled.
 	 */
 	public function test_revert_returns_null_when_disabled(): void {
-		\add_filter( Handle::FILTER_ENABLED, '__return_false' );
+		$this->add_filter_tracked( Handle::FILTER_ENABLED, '__return_false' );
 		$this->assertNull( Handle::maybe_revert_on_disconnect() );
-		\remove_filter( Handle::FILTER_ENABLED, '__return_false' );
 	}
 
 	/**
 	 * Test that maybe_revert_on_disconnect returns null when no previous handle is stored.
 	 */
 	public function test_revert_returns_null_when_no_previous_handle(): void {
-		\delete_option( Handle::OPTION_PREVIOUS_HANDLE );
 		$this->assertNull( Handle::maybe_revert_on_disconnect() );
 	}
 
@@ -303,16 +382,13 @@ class Test_Handle extends WP_UnitTestCase {
 				'access_token' => 'tok',
 			)
 		);
-		\add_filter( Handle::FILTER_PRE_UPDATE, static fn() => true );
+		$this->add_filter_tracked( Handle::FILTER_PRE_UPDATE, static fn() => true );
 
 		$result = Handle::maybe_revert_on_disconnect();
 
 		$this->assertTrue( $result );
 		$this->assertFalse( \get_option( Handle::OPTION_PREVIOUS_HANDLE ) );
 		$this->assertSame( 'alice.bsky.social', \get_option( 'atmosphere_connection' )['handle'] );
-
-		\remove_all_filters( Handle::FILTER_PRE_UPDATE );
-		\delete_option( 'atmosphere_connection' );
 	}
 
 	/**
@@ -321,14 +397,11 @@ class Test_Handle extends WP_UnitTestCase {
 	public function test_revert_keeps_option_on_failure(): void {
 		\update_option( Handle::OPTION_PREVIOUS_HANDLE, 'alice.bsky.social' );
 		$err = new \WP_Error( 'fail', 'nope' );
-		\add_filter( Handle::FILTER_PRE_UPDATE, static fn() => $err );
+		$this->add_filter_tracked( Handle::FILTER_PRE_UPDATE, static fn() => $err );
 
 		$result = Handle::maybe_revert_on_disconnect();
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'alice.bsky.social', \get_option( Handle::OPTION_PREVIOUS_HANDLE ) );
-
-		\remove_all_filters( Handle::FILTER_PRE_UPDATE );
-		\delete_option( Handle::OPTION_PREVIOUS_HANDLE );
 	}
 }

--- a/tests/phpunit/tests/class-test-handle.php
+++ b/tests/phpunit/tests/class-test-handle.php
@@ -168,4 +168,105 @@ class Test_Handle extends WP_UnitTestCase {
 		);
 		\remove_all_filters( 'home_url' );
 	}
+
+	/**
+	 * Test that set_handle returns null when the feature is disabled.
+	 */
+	public function test_set_handle_returns_null_when_disabled(): void {
+		\add_filter( Handle::FILTER_ENABLED, '__return_false' );
+		$this->assertNull( Handle::set_handle() );
+		\remove_filter( Handle::FILTER_ENABLED, '__return_false' );
+	}
+
+	/**
+	 * Test that set_handle returns null for a subdirectory install.
+	 */
+	public function test_set_handle_returns_null_for_subdir_install(): void {
+		\add_filter( 'home_url', static fn() => 'https://example.com/blog' );
+		$this->assertNull( Handle::set_handle() );
+		\remove_all_filters( 'home_url' );
+	}
+
+	/**
+	 * Test that set_handle returns WP_Error when not connected.
+	 */
+	public function test_set_handle_errors_when_not_connected(): void {
+		\add_filter( 'home_url', static fn() => 'https://example.com' );
+		\delete_option( 'atmosphere_connection' );
+		$result = Handle::set_handle();
+		$this->assertWPError( $result );
+		$this->assertSame( 'atmosphere_not_connected', $result->get_error_code() );
+		\remove_all_filters( 'home_url' );
+	}
+
+	/**
+	 * Test that set_handle returns null when the handle already matches.
+	 */
+	public function test_set_handle_returns_null_when_already_matching(): void {
+		\add_filter( 'home_url', static fn() => 'https://example.com' );
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'handle'       => 'example.com',
+				'did'          => 'did:plc:test',
+				'access_token' => 'tok',
+			)
+		);
+		$this->assertNull( Handle::set_handle() );
+		\delete_option( 'atmosphere_connection' );
+		\remove_all_filters( 'home_url' );
+	}
+
+	/**
+	 * Test that set_handle succeeds via the short-circuit filter.
+	 */
+	public function test_set_handle_succeeds_via_short_circuit_filter(): void {
+		\add_filter( 'home_url', static fn() => 'https://example.com' );
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'handle'       => 'alice.bsky.social',
+				'did'          => 'did:plc:test',
+				'access_token' => 'tok',
+			)
+		);
+		\add_filter( Handle::FILTER_PRE_UPDATE, static fn() => true );
+
+		$result = Handle::set_handle();
+
+		$this->assertTrue( $result );
+		$this->assertSame( 'alice.bsky.social', \get_option( Handle::OPTION_PREVIOUS_HANDLE ) );
+
+		\remove_all_filters( Handle::FILTER_PRE_UPDATE );
+		\remove_all_filters( 'home_url' );
+		\delete_option( 'atmosphere_connection' );
+		\delete_option( Handle::OPTION_PREVIOUS_HANDLE );
+	}
+
+	/**
+	 * Test that set_handle propagates a WP_Error from the short-circuit filter.
+	 */
+	public function test_set_handle_propagates_short_circuit_wp_error(): void {
+		\add_filter( 'home_url', static fn() => 'https://example.com' );
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'handle'       => 'alice.bsky.social',
+				'did'          => 'did:plc:test',
+				'access_token' => 'tok',
+			)
+		);
+		$err = new \WP_Error( 'rate_limited', 'slow down' );
+		\add_filter( Handle::FILTER_PRE_UPDATE, static fn() => $err );
+
+		$result = Handle::set_handle();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'rate_limited', $result->get_error_code() );
+
+		\remove_all_filters( Handle::FILTER_PRE_UPDATE );
+		\remove_all_filters( 'home_url' );
+		\delete_option( 'atmosphere_connection' );
+		\delete_option( Handle::OPTION_PREVIOUS_HANDLE );
+	}
 }

--- a/tests/phpunit/tests/class-test-handle.php
+++ b/tests/phpunit/tests/class-test-handle.php
@@ -26,4 +26,47 @@ class Test_Handle extends WP_UnitTestCase {
 		$this->assertSame( 'atmosphere_previous_handle', Handle::OPTION_PREVIOUS_HANDLE );
 		$this->assertSame( 'atmosphere', Handle::NOTICE_SETTING );
 	}
+
+	/**
+	 * Test that is_enabled returns true by default.
+	 */
+	public function test_is_enabled_default_true(): void {
+		$this->assertTrue( Handle::is_enabled() );
+	}
+
+	/**
+	 * Test that is_enabled can be disabled via filter.
+	 */
+	public function test_is_enabled_filter_can_disable(): void {
+		\add_filter( Handle::FILTER_ENABLED, '__return_false' );
+		$this->assertFalse( Handle::is_enabled() );
+		\remove_filter( Handle::FILTER_ENABLED, '__return_false' );
+	}
+
+	/**
+	 * Test that is_root_install returns true for a root domain.
+	 */
+	public function test_is_root_install_for_root(): void {
+		\add_filter( 'home_url', static fn() => 'https://example.com' );
+		$this->assertTrue( Handle::is_root_install() );
+		\remove_all_filters( 'home_url' );
+	}
+
+	/**
+	 * Test that is_root_install returns true for a root domain with trailing slash.
+	 */
+	public function test_is_root_install_for_root_with_trailing_slash(): void {
+		\add_filter( 'home_url', static fn() => 'https://example.com/' );
+		$this->assertTrue( Handle::is_root_install() );
+		\remove_all_filters( 'home_url' );
+	}
+
+	/**
+	 * Test that is_root_install returns false for a subdirectory install.
+	 */
+	public function test_is_root_install_false_for_subdirectory(): void {
+		\add_filter( 'home_url', static fn() => 'https://example.com/blog' );
+		$this->assertFalse( Handle::is_root_install() );
+		\remove_all_filters( 'home_url' );
+	}
 }

--- a/tests/phpunit/tests/class-test-handle.php
+++ b/tests/phpunit/tests/class-test-handle.php
@@ -236,6 +236,7 @@ class Test_Handle extends WP_UnitTestCase {
 
 		$this->assertTrue( $result );
 		$this->assertSame( 'alice.bsky.social', \get_option( Handle::OPTION_PREVIOUS_HANDLE ) );
+		$this->assertSame( 'example.com', \get_option( 'atmosphere_connection' )['handle'] );
 
 		\remove_all_filters( Handle::FILTER_PRE_UPDATE );
 		\remove_all_filters( 'home_url' );
@@ -263,6 +264,7 @@ class Test_Handle extends WP_UnitTestCase {
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'rate_limited', $result->get_error_code() );
+		$this->assertSame( 'alice.bsky.social', \get_option( 'atmosphere_connection' )['handle'] );
 
 		\remove_all_filters( Handle::FILTER_PRE_UPDATE );
 		\remove_all_filters( 'home_url' );
@@ -288,18 +290,29 @@ class Test_Handle extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that maybe_revert_on_disconnect clears the option on success.
+	 * Test that maybe_revert_on_disconnect clears the option on success
+	 * and mirrors the restored handle into the connection option.
 	 */
 	public function test_revert_clears_option_on_success(): void {
 		\update_option( Handle::OPTION_PREVIOUS_HANDLE, 'alice.bsky.social' );
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'handle'       => 'example.com',
+				'did'          => 'did:plc:test',
+				'access_token' => 'tok',
+			)
+		);
 		\add_filter( Handle::FILTER_PRE_UPDATE, static fn() => true );
 
 		$result = Handle::maybe_revert_on_disconnect();
 
 		$this->assertTrue( $result );
 		$this->assertFalse( \get_option( Handle::OPTION_PREVIOUS_HANDLE ) );
+		$this->assertSame( 'alice.bsky.social', \get_option( 'atmosphere_connection' )['handle'] );
 
 		\remove_all_filters( Handle::FILTER_PRE_UPDATE );
+		\delete_option( 'atmosphere_connection' );
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-handle.php
+++ b/tests/phpunit/tests/class-test-handle.php
@@ -69,4 +69,103 @@ class Test_Handle extends WP_UnitTestCase {
 		$this->assertFalse( Handle::is_root_install() );
 		\remove_all_filters( 'home_url' );
 	}
+
+	/**
+	 * Test that get_target_handle lowercases the host.
+	 */
+	public function test_get_target_handle_lowercases_host(): void {
+		\add_filter( 'home_url', static fn() => 'https://Example.COM' );
+		$this->assertSame( 'example.com', Handle::get_target_handle() );
+		\remove_all_filters( 'home_url' );
+	}
+
+	/**
+	 * Test that get_target_handle returns empty string when host is missing.
+	 */
+	public function test_get_target_handle_returns_empty_when_host_missing(): void {
+		\add_filter( 'home_url', static fn() => '/relative/path' );
+		$this->assertSame( '', Handle::get_target_handle() );
+		\remove_all_filters( 'home_url' );
+	}
+
+	/**
+	 * Test that should_offer returns false when the feature is disabled.
+	 */
+	public function test_should_offer_false_when_disabled(): void {
+		\add_filter( Handle::FILTER_ENABLED, '__return_false' );
+		$this->assertFalse(
+			Handle::should_offer(
+				array(
+					'connected' => true,
+					'handle'    => 'alice.bsky.social',
+				)
+			)
+		);
+		\remove_filter( Handle::FILTER_ENABLED, '__return_false' );
+	}
+
+	/**
+	 * Test that should_offer returns false for a subdirectory install.
+	 */
+	public function test_should_offer_false_for_subdir_install(): void {
+		\add_filter( 'home_url', static fn() => 'https://example.com/blog' );
+		$this->assertFalse(
+			Handle::should_offer(
+				array(
+					'connected' => true,
+					'handle'    => 'alice.bsky.social',
+				)
+			)
+		);
+		\remove_all_filters( 'home_url' );
+	}
+
+	/**
+	 * Test that should_offer returns false when not connected.
+	 */
+	public function test_should_offer_false_when_not_connected(): void {
+		\add_filter( 'home_url', static fn() => 'https://example.com' );
+		$this->assertFalse( Handle::should_offer( array( 'connected' => false ) ) );
+		\remove_all_filters( 'home_url' );
+	}
+
+	/**
+	 * Test that should_offer returns false when the handle already matches the domain.
+	 */
+	public function test_should_offer_false_when_handle_already_matches(): void {
+		\add_filter( 'home_url', static fn() => 'https://example.com' );
+		$this->assertFalse(
+			Handle::should_offer(
+				array(
+					'connected' => true,
+					'handle'    => 'example.com',
+				)
+			)
+		);
+		$this->assertFalse(
+			Handle::should_offer(
+				array(
+					'connected' => true,
+					'handle'    => 'EXAMPLE.com',
+				)
+			)
+		);
+		\remove_all_filters( 'home_url' );
+	}
+
+	/**
+	 * Test that should_offer returns true when all conditions are met.
+	 */
+	public function test_should_offer_true_when_eligible(): void {
+		\add_filter( 'home_url', static fn() => 'https://example.com' );
+		$this->assertTrue(
+			Handle::should_offer(
+				array(
+					'connected' => true,
+					'handle'    => 'alice.bsky.social',
+				)
+			)
+		);
+		\remove_all_filters( 'home_url' );
+	}
 }

--- a/tests/phpunit/tests/class-test-handle.php
+++ b/tests/phpunit/tests/class-test-handle.php
@@ -269,4 +269,53 @@ class Test_Handle extends WP_UnitTestCase {
 		\delete_option( 'atmosphere_connection' );
 		\delete_option( Handle::OPTION_PREVIOUS_HANDLE );
 	}
+
+	/**
+	 * Test that maybe_revert_on_disconnect returns null when the feature is disabled.
+	 */
+	public function test_revert_returns_null_when_disabled(): void {
+		\add_filter( Handle::FILTER_ENABLED, '__return_false' );
+		$this->assertNull( Handle::maybe_revert_on_disconnect() );
+		\remove_filter( Handle::FILTER_ENABLED, '__return_false' );
+	}
+
+	/**
+	 * Test that maybe_revert_on_disconnect returns null when no previous handle is stored.
+	 */
+	public function test_revert_returns_null_when_no_previous_handle(): void {
+		\delete_option( Handle::OPTION_PREVIOUS_HANDLE );
+		$this->assertNull( Handle::maybe_revert_on_disconnect() );
+	}
+
+	/**
+	 * Test that maybe_revert_on_disconnect clears the option on success.
+	 */
+	public function test_revert_clears_option_on_success(): void {
+		\update_option( Handle::OPTION_PREVIOUS_HANDLE, 'alice.bsky.social' );
+		\add_filter( Handle::FILTER_PRE_UPDATE, static fn() => true );
+
+		$result = Handle::maybe_revert_on_disconnect();
+
+		$this->assertTrue( $result );
+		$this->assertFalse( \get_option( Handle::OPTION_PREVIOUS_HANDLE ) );
+
+		\remove_all_filters( Handle::FILTER_PRE_UPDATE );
+	}
+
+	/**
+	 * Test that maybe_revert_on_disconnect keeps the option on failure.
+	 */
+	public function test_revert_keeps_option_on_failure(): void {
+		\update_option( Handle::OPTION_PREVIOUS_HANDLE, 'alice.bsky.social' );
+		$err = new \WP_Error( 'fail', 'nope' );
+		\add_filter( Handle::FILTER_PRE_UPDATE, static fn() => $err );
+
+		$result = Handle::maybe_revert_on_disconnect();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'alice.bsky.social', \get_option( Handle::OPTION_PREVIOUS_HANDLE ) );
+
+		\remove_all_filters( Handle::FILTER_PRE_UPDATE );
+		\delete_option( Handle::OPTION_PREVIOUS_HANDLE );
+	}
 }

--- a/tests/phpunit/tests/class-test-handle.php
+++ b/tests/phpunit/tests/class-test-handle.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Tests for the domain-handle service.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group handle
+ */
+
+namespace Atmosphere\Tests;
+
+use Atmosphere\Handle;
+use WP_UnitTestCase;
+
+/**
+ * Domain-handle tests.
+ */
+class Test_Handle extends WP_UnitTestCase {
+
+	/**
+	 * Test that public constants hold the expected string values.
+	 */
+	public function test_constants(): void {
+		$this->assertSame( 'atmosphere_domain_handle_enabled', Handle::FILTER_ENABLED );
+		$this->assertSame( 'atmosphere_pre_update_handle', Handle::FILTER_PRE_UPDATE );
+		$this->assertSame( 'atmosphere_previous_handle', Handle::OPTION_PREVIOUS_HANDLE );
+		$this->assertSame( 'atmosphere', Handle::NOTICE_SETTING );
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -23,6 +23,7 @@ delete_option( 'atmosphere_connection' );
 delete_option( 'atmosphere_publication_tid' );
 delete_option( 'atmosphere_publication_uri' );
 delete_option( 'atmosphere_auto_publish' );
+delete_option( 'atmosphere_previous_handle' );
 
 // Remove scheduled events via the canonical helper.
 clear_scheduled_hooks();


### PR DESCRIPTION
Fixes #

## Proposed changes:

* Add a new `Atmosphere\Handle` service that calls `com.atproto.identity.updateHandle` to set the site's hostname as the connected Bluesky handle. Snapshots the previous handle to `atmosphere_previous_handle` so disconnect can revert.
* Render a confirm panel inside the connected-state Settings section. Only offered when the site is at the host root, the user is connected, and the current handle differs from the site host. Hidden via the `atmosphere_domain_handle_enabled` filter.
* Wire `admin_post_atmosphere_set_domain_handle` to verify capability + nonce, dispatch `Handle::set_handle()`, and redirect back to the settings page with a notice already populated by `Handle`.
* Best-effort revert in the disconnect handler: call `Handle::maybe_revert_on_disconnect()` BEFORE `Client::disconnect()` so the OAuth token is still valid for the XRPC call. Clear the snapshot afterward so it cannot be revived by a future reconnect to a different account.
* Bind snapshot lifetime to the connection: also delete `atmosphere_previous_handle` in `uninstall.php`.

Ports the domain-handle service from [FOSSE PR #97](https://github.com/Automattic/fosse/pull/97). Builds on the `identity:handle` OAuth scope added in #53.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

23 PHPUnit tests in `tests/phpunit/tests/class-test-handle.php` cover eligibility gating, the short-circuit filter (`atmosphere_pre_update_handle`), success / WP_Error propagation, and the revert flow. The XRPC layer is exercised through the short-circuit filter so tests do not require DPoP keys.

## Testing instructions:

1. On a site at host root (not a subdirectory install), connect a Bluesky account whose handle is something like `alice.bsky.social`.
2. Visit Settings → ATmosphere. Confirm the new "Use your domain as your Bluesky handle" panel renders with the destructive-warning copy and a button labelled "Use \<site host> as my Bluesky handle".
3. Click the button. The XRPC call goes to your PDS; on success a notice "Your Bluesky handle is now \<host>." appears.
4. Verify on bsky.app or via `com.atproto.identity.resolveHandle` that the handle changed.
5. Click Disconnect. Confirm the previous handle is restored ("Restored your previous Bluesky handle: alice.bsky.social.") before the disconnect notice.
6. On a subdirectory install (`example.com/blog`), confirm the panel does NOT render.
7. With `add_filter( 'atmosphere_domain_handle_enabled', '__return_false' )`, confirm the panel does NOT render and disconnect does NOT attempt revert.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Minor

#### Type

-   [x] Added - for new features

#### Message

Use your site domain as your Bluesky handle with one click from the ATmosphere settings page.

</details>