### PR TITLE
Add publish-result actions for post and comment

### DIFF
--- a/.github/changelog/add-publish-result-actions
+++ b/.github/changelog/add-publish-result-actions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add `atmosphere_publish_post_result` and `atmosphere_publish_comment_result` actions so subscribers can react to publish success or failure (e.g., for metrics and notifications) without observing internal state.

--- a/includes/class-publisher.php
+++ b/includes/class-publisher.php
@@ -86,6 +86,10 @@ class Publisher {
 	/**
 	 * Publish a post to AT Protocol (bsky record(s) + document).
 	 *
+	 * Fires `atmosphere_publish_post_result` once with the final outcome
+	 * regardless of which internal path (short-form, long-form single,
+	 * long-form thread) produced it.
+	 *
 	 * @param \WP_Post $post WordPress post.
 	 * @return array|\WP_Error applyWrites response(s) or error.
 	 */
@@ -95,21 +99,36 @@ class Publisher {
 
 		if ( $bsky_transformer->is_short_form_post() ) {
 			// Short-form path: single record via today's transform().
-			return self::publish_single(
+			$result = self::publish_single(
 				$post,
 				$bsky_transformer->transform(),
 				$bsky_transformer,
 				$doc_transformer
 			);
+		} else {
+			$records = $bsky_transformer->build_long_form_records();
+
+			if ( 1 === \count( $records ) ) {
+				$result = self::publish_single( $post, $records[0], $bsky_transformer, $doc_transformer );
+			} else {
+				$result = self::publish_thread( $post, $records, $bsky_transformer, $doc_transformer );
+			}
 		}
 
-		$records = $bsky_transformer->build_long_form_records();
+		/**
+		 * Fires after a post publish attempt completes, with the final result.
+		 *
+		 * Subscribers can use this to react to success or failure — for
+		 * example, to instrument metrics, surface notifications, or schedule
+		 * follow-up jobs. Fires exactly once per `publish_post()` invocation
+		 * regardless of which internal path produced the result.
+		 *
+		 * @param \WP_Post        $post   The post that was published.
+		 * @param array|\WP_Error $result `applyWrites` response on success, `WP_Error` on failure.
+		 */
+		\do_action( 'atmosphere_publish_post_result', $post, $result );
 
-		if ( 1 === \count( $records ) ) {
-			return self::publish_single( $post, $records[0], $bsky_transformer, $doc_transformer );
-		}
-
-		return self::publish_thread( $post, $records, $bsky_transformer, $doc_transformer );
+		return $result;
 	}
 
 	/**
@@ -1168,6 +1187,8 @@ class Publisher {
 	/**
 	 * Publish a WordPress comment as an app.bsky.feed.post reply.
 	 *
+	 * Fires `atmosphere_publish_comment_result` once with the final outcome.
+	 *
 	 * @param \WP_Comment $comment WordPress comment.
 	 * @return array|\WP_Error applyWrites response or error.
 	 */
@@ -1187,14 +1208,24 @@ class Publisher {
 
 		$result = API::apply_writes( $writes );
 
-		if ( \is_wp_error( $result ) ) {
-			return $result;
+		if ( ! \is_wp_error( $result ) ) {
+			$stored = self::store_comment_result( (int) $comment->comment_ID, $result );
+			if ( \is_wp_error( $stored ) ) {
+				$result = $stored;
+			}
 		}
 
-		$stored = self::store_comment_result( (int) $comment->comment_ID, $result );
-		if ( \is_wp_error( $stored ) ) {
-			return $stored;
-		}
+		/**
+		 * Fires after a comment publish attempt completes, with the final result.
+		 *
+		 * Mirrors `atmosphere_publish_post_result`. Fires exactly once per
+		 * `publish_comment()` invocation regardless of whether the underlying
+		 * API call or the post-publish bookkeeping was the failure.
+		 *
+		 * @param \WP_Comment     $comment The comment that was published.
+		 * @param array|\WP_Error $result  `applyWrites` response on success, `WP_Error` on failure.
+		 */
+		\do_action( 'atmosphere_publish_comment_result', $comment, $result );
 
 		return $result;
 	}

--- a/tests/phpunit/tests/class-test-publisher.php
+++ b/tests/phpunit/tests/class-test-publisher.php
@@ -1876,7 +1876,7 @@ class Test_Publisher extends WP_UnitTestCase {
 	}
 
 	/**
-	 * publish_post fires `atmosphere_publish_post_result` exactly once
+	 * Publish_post fires `atmosphere_publish_post_result` exactly once
 	 * with the post and the final result — even when the underlying
 	 * API call fails.
 	 */
@@ -1908,7 +1908,7 @@ class Test_Publisher extends WP_UnitTestCase {
 	}
 
 	/**
-	 * publish_comment fires `atmosphere_publish_comment_result` exactly
+	 * Publish_comment fires `atmosphere_publish_comment_result` exactly
 	 * once with the comment and the final result — even when the
 	 * underlying API call fails.
 	 */

--- a/tests/phpunit/tests/class-test-publisher.php
+++ b/tests/phpunit/tests/class-test-publisher.php
@@ -1876,9 +1876,58 @@ class Test_Publisher extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Publish_post fires `atmosphere_publish_post_result` exactly once
-	 * with the post and the final result — even when the underlying
-	 * API call fails.
+	 * `publish_post()` fires `atmosphere_publish_post_result` exactly
+	 * once with the post and the final result on the success path.
+	 *
+	 * Uses `atmosphere_pre_apply_writes` to short-circuit the API call
+	 * with a valid two-record response (bsky post + site.standard.document).
+	 */
+	public function test_publish_post_result_action_fires_on_success() {
+		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+
+		\add_filter(
+			'atmosphere_pre_apply_writes',
+			static fn ( $short_circuit, $writes ) => array(
+				'results' => array_map(
+					static fn ( $write ) => array(
+						'uri' => 'at://did:plc:test/' . $write['collection'] . '/' . $write['rkey'],
+						'cid' => 'bafy-' . $write['rkey'],
+					),
+					$writes
+				),
+			),
+			10,
+			2
+		);
+
+		$captured = array();
+		\add_action(
+			'atmosphere_publish_post_result',
+			static function ( $hooked_post, $hooked_result ) use ( &$captured ) {
+				$captured[] = array(
+					'post'   => $hooked_post,
+					'result' => $hooked_result,
+				);
+			},
+			10,
+			2
+		);
+
+		$result = Publisher::publish_post( $post );
+
+		\remove_all_filters( 'atmosphere_pre_apply_writes' );
+		\remove_all_actions( 'atmosphere_publish_post_result' );
+
+		$this->assertCount( 1, $captured, 'action fired exactly once' );
+		$this->assertSame( $post->ID, $captured[0]['post']->ID );
+		$this->assertIsArray( $captured[0]['result'], 'hook receives the array result on success' );
+		$this->assertSame( $result, $captured[0]['result'], 'hook receives the same result returned to the caller' );
+	}
+
+	/**
+	 * `publish_post()` fires `atmosphere_publish_post_result` exactly
+	 * once with the post and the final result — even when the
+	 * underlying API call fails.
 	 */
 	public function test_publish_post_result_action_fires_on_failure() {
 		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
@@ -1908,9 +1957,67 @@ class Test_Publisher extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Publish_comment fires `atmosphere_publish_comment_result` exactly
-	 * once with the comment and the final result — even when the
-	 * underlying API call fails.
+	 * `publish_comment()` fires `atmosphere_publish_comment_result`
+	 * exactly once with the comment and the final result on the success
+	 * path.
+	 *
+	 * Uses `atmosphere_pre_apply_writes` to short-circuit the API call
+	 * with a valid single-record response.
+	 */
+	public function test_publish_comment_result_action_fires_on_success() {
+		$post_id    = $this->seed_root_post();
+		$user_id    = self::factory()->user->create();
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+				'user_id'          => $user_id,
+			)
+		);
+
+		\add_filter(
+			'atmosphere_pre_apply_writes',
+			static fn ( $short_circuit, $writes ) => array(
+				'results' => array_map(
+					static fn ( $write ) => array(
+						'uri' => 'at://did:plc:test/' . $write['collection'] . '/' . $write['rkey'],
+						'cid' => 'bafy-' . $write['rkey'],
+					),
+					$writes
+				),
+			),
+			10,
+			2
+		);
+
+		$captured = array();
+		\add_action(
+			'atmosphere_publish_comment_result',
+			static function ( $hooked_comment, $hooked_result ) use ( &$captured ) {
+				$captured[] = array(
+					'comment' => $hooked_comment,
+					'result'  => $hooked_result,
+				);
+			},
+			10,
+			2
+		);
+
+		$result = Publisher::publish_comment( \get_comment( $comment_id ) );
+
+		\remove_all_filters( 'atmosphere_pre_apply_writes' );
+		\remove_all_actions( 'atmosphere_publish_comment_result' );
+
+		$this->assertCount( 1, $captured, 'action fired exactly once' );
+		$this->assertSame( (int) $comment_id, (int) $captured[0]['comment']->comment_ID );
+		$this->assertIsArray( $captured[0]['result'], 'hook receives the array result on success' );
+		$this->assertSame( $result, $captured[0]['result'], 'hook receives the same result returned to the caller' );
+	}
+
+	/**
+	 * `publish_comment()` fires `atmosphere_publish_comment_result`
+	 * exactly once with the comment and the final result — even when
+	 * the underlying API call fails.
 	 */
 	public function test_publish_comment_result_action_fires_on_failure() {
 		$post_id    = $this->seed_root_post();

--- a/tests/phpunit/tests/class-test-publisher.php
+++ b/tests/phpunit/tests/class-test-publisher.php
@@ -1874,4 +1874,76 @@ class Test_Publisher extends WP_UnitTestCase {
 		$this->assertCount( 1, $this->captured_calls );
 		$this->assertCount( 4, $this->captured_calls[0]['writes'] );
 	}
+
+	/**
+	 * publish_post fires `atmosphere_publish_post_result` exactly once
+	 * with the post and the final result — even when the underlying
+	 * API call fails.
+	 */
+	public function test_publish_post_result_action_fires_on_failure() {
+		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+
+		$captured = array();
+		\add_action(
+			'atmosphere_publish_post_result',
+			static function ( $hooked_post, $hooked_result ) use ( &$captured ) {
+				$captured[] = array(
+					'post'   => $hooked_post,
+					'result' => $hooked_result,
+				);
+			},
+			10,
+			2
+		);
+
+		// No HTTP stub — the bootstrap returns WP_Error from the auth layer.
+		$result = Publisher::publish_post( $post );
+
+		\remove_all_actions( 'atmosphere_publish_post_result' );
+
+		$this->assertCount( 1, $captured, 'action fired exactly once' );
+		$this->assertSame( $post->ID, $captured[0]['post']->ID );
+		$this->assertWPError( $captured[0]['result'] );
+		$this->assertSame( $result, $captured[0]['result'], 'hook receives the same result returned to the caller' );
+	}
+
+	/**
+	 * publish_comment fires `atmosphere_publish_comment_result` exactly
+	 * once with the comment and the final result — even when the
+	 * underlying API call fails.
+	 */
+	public function test_publish_comment_result_action_fires_on_failure() {
+		$post_id    = $this->seed_root_post();
+		$user_id    = self::factory()->user->create();
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+				'user_id'          => $user_id,
+			)
+		);
+
+		$captured = array();
+		\add_action(
+			'atmosphere_publish_comment_result',
+			static function ( $hooked_comment, $hooked_result ) use ( &$captured ) {
+				$captured[] = array(
+					'comment' => $hooked_comment,
+					'result'  => $hooked_result,
+				);
+			},
+			10,
+			2
+		);
+
+		// No HTTP stub — the bootstrap returns WP_Error from the auth layer.
+		$result = Publisher::publish_comment( \get_comment( $comment_id ) );
+
+		\remove_all_actions( 'atmosphere_publish_comment_result' );
+
+		$this->assertCount( 1, $captured, 'action fired exactly once' );
+		$this->assertSame( (int) $comment_id, (int) $captured[0]['comment']->comment_ID );
+		$this->assertWPError( $captured[0]['result'] );
+		$this->assertSame( $result, $captured[0]['result'], 'hook receives the same result returned to the caller' );
+	}
 }


### PR DESCRIPTION
## Proposed changes:

Add `atmosphere_publish_post_result` and `atmosphere_publish_comment_result` actions that fire once per `Publisher::publish_post()` / `publish_comment()` invocation with the final result.

```php
do_action( 'atmosphere_publish_post_result', \$post, \$result );
do_action( 'atmosphere_publish_comment_result', \$comment, \$result );
```

Both actions fire on every path, including failure — `\$result` is either the `applyWrites` response array on success or a `WP_Error` on failure.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

The cron handlers in `class-atmosphere.php` that call these methods today log errors with `log_cron_error()` but otherwise drop them. The new hooks give downstream subscribers (metrics, notifications, follow-up jobs) a clean signal without having to observe internal state or wrap the public Publisher API.

## Why this matters

The FOSSE plugin (which bundles Atmosphere) needs a stable observation point for publish success/failure so it can emit a `fosse_publish_result` Tracks event with `network: 'bluesky'`, `status: success|failure`, and an `error_category` derived from the `WP_Error` code. Today Atmosphere has no such hook — the only existing publish-related action is `atmosphere_publishing` in `class-atmosphere.php:335`, which fires *before* `wp_schedule_single_event` and therefore before the actual cron handler has run, so there is no result available at that point. Without this hook, FOSSE can only emit a placeholder "I'm about to try" event with no real success/failure data.

This is the upstream half of Phase 4 of the FOSSE metrics rollout (`DOTCOM-17031`). The FOSSE-side subscriber lands separately.

## Testing instructions:

- `composer test` — two new tests in `tests/phpunit/tests/class-test-publisher.php` assert each action fires exactly once with the same result that gets returned to the caller. Both run against the failure (no-stub) path which the existing test bootstrap supports out of the box.
- Manual: install a fork that calls `add_action( 'atmosphere_publish_post_result', ... )` and verify the hook fires from a post publish whether the underlying `apply_writes` succeeds or fails.

## Out of scope

- A matching `atmosphere_update_post_result` / `atmosphere_delete_post_result` / `atmosphere_update_comment_result` / `atmosphere_delete_comment_result` set. The corresponding `Publisher::update_*` / `delete_*` methods are good candidates for the same pattern; happy to send a follow-up PR if there is appetite.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

\`\`\`
Significance: minor
Type: added

Add atmosphere_publish_post_result and atmosphere_publish_comment_result actions so subscribers can react to publish success or failure (e.g., for metrics and notifications) without observing internal state.
\`\`\`