### PR TITLE
Add atmosphere_should_sync_reply filter to suppress self-replies on teaser-thread publishes

### DIFF
--- a/.github/changelog/add-reaction-sync-should-sync-reply-filter
+++ b/.github/changelog/add-reaction-sync-should-sync-reply-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add `atmosphere_should_sync_reply` filter so consumers can suppress specific incoming replies before they become WordPress comments — primarily useful for teaser-thread publishers that don't want their own follow-up records re-ingested as self-replies.

--- a/includes/class-reaction-sync.php
+++ b/includes/class-reaction-sync.php
@@ -416,6 +416,35 @@ class Reaction_Sync {
 
 		$profile = self::resolve_author( $author['did'] ?? '' );
 
+		/**
+		 * Filters whether a reply should be synced as a WordPress comment.
+		 *
+		 * Fires after the reply's target post and parent comment have been
+		 * resolved, immediately before the comment row is inserted. Return
+		 * false to skip the insert (and the comment-meta writes that follow).
+		 *
+		 * Use case: the `teaser-thread` long-form strategy emits multiple
+		 * reply records for a single post, and `Reaction_Sync` ingests
+		 * our own records back through this path. Consumers that publish
+		 * threads can register a callback here to suppress those self-replies.
+		 *
+		 * @param bool  $should         Whether to sync this reply. Default true.
+		 * @param array $notification   Notification or synthesized own-record.
+		 * @param int   $post_id        Resolved local WP post the reply targets.
+		 * @param int   $comment_parent Resolved local parent comment ID, 0 if top-level.
+		 */
+		$should_sync = (bool) \apply_filters(
+			'atmosphere_should_sync_reply',
+			true,
+			$notification,
+			$post_id,
+			$comment_parent
+		);
+
+		if ( ! $should_sync ) {
+			return false;
+		}
+
 		return self::insert_reaction( $post_id, 'comment', $text, $comment_parent, $notification, $profile );
 	}
 

--- a/includes/class-reaction-sync.php
+++ b/includes/class-reaction-sync.php
@@ -414,19 +414,19 @@ class Reaction_Sync {
 			return false;
 		}
 
-		$profile = self::resolve_author( $author['did'] ?? '' );
-
 		/**
 		 * Filters whether a reply should be synced as a WordPress comment.
 		 *
 		 * Fires after the reply's target post and parent comment have been
-		 * resolved, immediately before the comment row is inserted. Return
-		 * false to skip the insert (and the comment-meta writes that follow).
+		 * resolved, immediately before any work that depends on the reply
+		 * being kept (author profile resolution, comment row insert,
+		 * comment-meta writes). Return false to skip the insert.
 		 *
-		 * Use case: the `teaser-thread` long-form strategy emits multiple
-		 * reply records for a single post, and `Reaction_Sync` ingests
-		 * our own records back through this path. Consumers that publish
-		 * threads can register a callback here to suppress those self-replies.
+		 * Use case: consumers publishing multi-record threads from their
+		 * own DID may want to skip the round-tripped self-replies that
+		 * `Reaction_Sync` would otherwise ingest as comments. The filter
+		 * is intentionally policy-free upstream so consumers can express
+		 * whatever discriminator fits their publishing strategy.
 		 *
 		 * @param bool  $should         Whether to sync this reply. Default true.
 		 * @param array $notification   Notification or synthesized own-record.
@@ -444,6 +444,8 @@ class Reaction_Sync {
 		if ( ! $should_sync ) {
 			return false;
 		}
+
+		$profile = self::resolve_author( $author['did'] ?? '' );
 
 		return self::insert_reaction( $post_id, 'comment', $text, $comment_parent, $notification, $profile );
 	}

--- a/tests/phpunit/tests/class-test-reaction-sync.php
+++ b/tests/phpunit/tests/class-test-reaction-sync.php
@@ -372,9 +372,11 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 			),
 		);
 
-		$result = $method->invoke( null, $notification );
-
-		\remove_filter( 'atmosphere_should_sync_reply', $filter, 10 );
+		try {
+			$result = $method->invoke( null, $notification );
+		} finally {
+			\remove_filter( 'atmosphere_should_sync_reply', $filter, 10 );
+		}
 
 		$this->assertFalse( $result );
 		$this->assertTrue( $captured['should'] );
@@ -479,9 +481,11 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 			),
 		);
 
-		$method->invoke( null, $notification );
-
-		\remove_filter( 'atmosphere_should_sync_reply', $filter, 10 );
+		try {
+			$method->invoke( null, $notification );
+		} finally {
+			\remove_filter( 'atmosphere_should_sync_reply', $filter, 10 );
+		}
 
 		$this->assertSame( $post_id, $captured['post_id'] );
 		$this->assertSame( $parent_comment_id, $captured['comment_parent'] );
@@ -521,9 +525,11 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 			),
 		);
 
-		$result = $method->invoke( null, $notification );
-
-		\remove_filter( 'atmosphere_should_sync_reply', $filter );
+		try {
+			$result = $method->invoke( null, $notification );
+		} finally {
+			\remove_filter( 'atmosphere_should_sync_reply', $filter );
+		}
 
 		$this->assertFalse( $result );
 		$this->assertSame( array(), \get_comments( array( 'post_id' => $post_id ) ) );

--- a/tests/phpunit/tests/class-test-reaction-sync.php
+++ b/tests/phpunit/tests/class-test-reaction-sync.php
@@ -389,17 +389,21 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 
 	/**
 	 * Test that the default filter value is true — no callback registered
-	 * means existing behavior (comment is inserted as before).
+	 * means existing behavior (comment is inserted as before). Mirrors
+	 * the contract assertions of test_process_reply_creates_comment so a
+	 * future regression that changes what insert_reaction writes is
+	 * caught here too.
 	 */
 	public function test_process_reply_defaults_to_syncing() {
-		$post_id  = self::factory()->post->create();
-		$post_uri = 'at://did:plc:me/app.bsky.feed.post/defaultsync';
+		$post_id   = self::factory()->post->create();
+		$post_uri  = 'at://did:plc:me/app.bsky.feed.post/defaultsync';
+		$reply_uri = 'at://did:plc:friend/app.bsky.feed.post/friendreply';
 		\update_post_meta( $post_id, BskyPost::META_URI, $post_uri );
 
 		$method = new \ReflectionMethod( Reaction_Sync::class, 'process_reply' );
 
 		$notification = array(
-			'uri'    => 'at://did:plc:friend/app.bsky.feed.post/friendreply',
+			'uri'    => $reply_uri,
 			'cid'    => 'bafyreifriend',
 			'record' => array(
 				'text'      => 'Nice one.',
@@ -419,6 +423,123 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 
 		$this->assertIsInt( $comment_id );
 		$this->assertGreaterThan( 0, $comment_id );
+
+		$comment = \get_comment( $comment_id );
+
+		$this->assertSame( 'Nice one.', $comment->comment_content );
+		$this->assertSame( 'comment', $comment->comment_type );
+		$this->assertSame( (string) $post_id, $comment->comment_post_ID );
+		$this->assertSame( '0', $comment->comment_parent );
+		$this->assertSame( 'atproto', \get_comment_meta( $comment_id, 'protocol', true ) );
+		$this->assertSame( $reply_uri, \get_comment_meta( $comment_id, 'source_id', true ) );
+		$this->assertSame( 'did:plc:friend', \get_comment_meta( $comment_id, '_atmosphere_author_did', true ) );
+	}
+
+	/**
+	 * Test that the filter receives the resolved nested-parent comment ID
+	 * (not 0) when the reply targets an existing synced comment instead
+	 * of the post itself. Locks in the contract that $comment_parent is
+	 * the resolved local ID, not the AT-URI of the parent record.
+	 */
+	public function test_process_reply_filter_receives_nested_parent_id() {
+		$post_id  = self::factory()->post->create();
+		$post_uri = 'at://did:plc:me/app.bsky.feed.post/parentpost';
+		\update_post_meta( $post_id, BskyPost::META_URI, $post_uri );
+
+		$parent_comment_id = self::factory()->comment->create( array( 'comment_post_ID' => $post_id ) );
+		$parent_reply_uri  = 'at://did:plc:first/app.bsky.feed.post/firstreply';
+		\update_comment_meta( $parent_comment_id, 'source_id', $parent_reply_uri );
+
+		$captured = array();
+		$filter   = function ( $should, $notification, $resolved_post_id, $comment_parent ) use ( &$captured ) {
+			$captured = array(
+				'post_id'        => $resolved_post_id,
+				'comment_parent' => $comment_parent,
+			);
+			return $should;
+		};
+		\add_filter( 'atmosphere_should_sync_reply', $filter, 10, 4 );
+
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'process_reply' );
+
+		$notification = array(
+			'uri'    => 'at://did:plc:second/app.bsky.feed.post/nestedreply',
+			'cid'    => 'bafyreinested',
+			'record' => array(
+				'text'      => 'Replying to the reply.',
+				'createdAt' => '2026-03-21T12:00:00.000Z',
+				'reply'     => array(
+					'parent' => array( 'uri' => $parent_reply_uri ),
+					'root'   => array( 'uri' => $post_uri ),
+				),
+			),
+			'author' => array(
+				'did'    => 'did:plc:second',
+				'handle' => 'second.bsky.social',
+			),
+		);
+
+		$method->invoke( null, $notification );
+
+		\remove_filter( 'atmosphere_should_sync_reply', $filter, 10 );
+
+		$this->assertSame( $post_id, $captured['post_id'] );
+		$this->assertSame( $parent_comment_id, $captured['comment_parent'] );
+	}
+
+	/**
+	 * Filter return values are cast via `(bool)` before deciding whether
+	 * to insert. Lock in that null, 0, and '' suppress; truthy non-bool
+	 * values allow the sync. Protects the cast against accidental removal.
+	 *
+	 * @dataProvider data_filter_falsy_returns
+	 * @param mixed $falsy_return Value the callback returns.
+	 */
+	public function test_process_reply_treats_falsy_filter_returns_as_suppression( $falsy_return ) {
+		$post_id  = self::factory()->post->create();
+		$post_uri = 'at://did:plc:me/app.bsky.feed.post/cast-' . \uniqid();
+		\update_post_meta( $post_id, BskyPost::META_URI, $post_uri );
+
+		$filter = static fn() => $falsy_return;
+		\add_filter( 'atmosphere_should_sync_reply', $filter );
+
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'process_reply' );
+
+		$notification = array(
+			'uri'    => 'at://did:plc:friend/app.bsky.feed.post/falsy-' . \uniqid(),
+			'cid'    => 'bafyreicast',
+			'record' => array(
+				'text'  => 'Should be suppressed.',
+				'reply' => array(
+					'parent' => array( 'uri' => $post_uri ),
+					'root'   => array( 'uri' => $post_uri ),
+				),
+			),
+			'author' => array(
+				'did'    => 'did:plc:friend',
+				'handle' => 'friend.bsky.social',
+			),
+		);
+
+		$result = $method->invoke( null, $notification );
+
+		\remove_filter( 'atmosphere_should_sync_reply', $filter );
+
+		$this->assertFalse( $result );
+		$this->assertSame( array(), \get_comments( array( 'post_id' => $post_id ) ) );
+	}
+
+	/**
+	 * Data provider for falsy `atmosphere_should_sync_reply` returns.
+	 *
+	 * @return array<string, array{0: mixed}>
+	 */
+	public function data_filter_falsy_returns(): array {
+		return array(
+			'null'         => array( null ),
+			'zero'         => array( 0 ),
+			'empty string' => array( '' ),
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-reaction-sync.php
+++ b/tests/phpunit/tests/class-test-reaction-sync.php
@@ -331,6 +331,97 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that a registered `atmosphere_should_sync_reply` callback can
+	 * suppress the comment insert. The filter receives the notification,
+	 * resolved post ID, and resolved parent-comment ID.
+	 */
+	public function test_process_reply_respects_should_sync_filter() {
+		$post_id  = self::factory()->post->create();
+		$post_uri = 'at://did:plc:me/app.bsky.feed.post/filterable';
+		\update_post_meta( $post_id, BskyPost::META_URI, $post_uri );
+
+		$captured = array();
+		$filter   = function ( $should, $notification, $resolved_post_id, $comment_parent ) use ( &$captured ) {
+			$captured = array(
+				'should'         => $should,
+				'notification'   => $notification,
+				'post_id'        => $resolved_post_id,
+				'comment_parent' => $comment_parent,
+			);
+			return false;
+		};
+		\add_filter( 'atmosphere_should_sync_reply', $filter, 10, 4 );
+
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'process_reply' );
+
+		$reply_uri    = 'at://did:plc:me/app.bsky.feed.post/chunk2';
+		$notification = array(
+			'uri'    => $reply_uri,
+			'cid'    => 'bafyreichunk',
+			'record' => array(
+				'text'      => 'Continued thought…',
+				'createdAt' => '2026-03-21T12:00:00.000Z',
+				'reply'     => array(
+					'parent' => array( 'uri' => $post_uri ),
+					'root'   => array( 'uri' => $post_uri ),
+				),
+			),
+			'author' => array(
+				'did'    => 'did:plc:me',
+				'handle' => 'me.example.com',
+			),
+		);
+
+		$result = $method->invoke( null, $notification );
+
+		\remove_filter( 'atmosphere_should_sync_reply', $filter, 10 );
+
+		$this->assertFalse( $result );
+		$this->assertTrue( $captured['should'] );
+		$this->assertSame( $reply_uri, $captured['notification']['uri'] );
+		$this->assertSame( $post_id, $captured['post_id'] );
+		$this->assertSame( 0, $captured['comment_parent'] );
+
+		// No comment was written.
+		$comments = \get_comments( array( 'post_id' => $post_id ) );
+		$this->assertSame( array(), $comments );
+	}
+
+	/**
+	 * Test that the default filter value is true — no callback registered
+	 * means existing behavior (comment is inserted as before).
+	 */
+	public function test_process_reply_defaults_to_syncing() {
+		$post_id  = self::factory()->post->create();
+		$post_uri = 'at://did:plc:me/app.bsky.feed.post/defaultsync';
+		\update_post_meta( $post_id, BskyPost::META_URI, $post_uri );
+
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'process_reply' );
+
+		$notification = array(
+			'uri'    => 'at://did:plc:friend/app.bsky.feed.post/friendreply',
+			'cid'    => 'bafyreifriend',
+			'record' => array(
+				'text'      => 'Nice one.',
+				'createdAt' => '2026-03-21T12:00:00.000Z',
+				'reply'     => array(
+					'parent' => array( 'uri' => $post_uri ),
+					'root'   => array( 'uri' => $post_uri ),
+				),
+			),
+			'author' => array(
+				'did'    => 'did:plc:friend',
+				'handle' => 'friend.bsky.social',
+			),
+		);
+
+		$comment_id = $method->invoke( null, $notification );
+
+		$this->assertIsInt( $comment_id );
+		$this->assertGreaterThan( 0, $comment_id );
+	}
+
+	/**
 	 * Test that process_like creates a like comment.
 	 */
 	public function test_process_like_creates_comment() {


### PR DESCRIPTION
## Proposed changes

Adds an `atmosphere_should_sync_reply` filter inside `Reaction_Sync::process_reply()`, fired after the target post and parent comment are resolved but before the comment row is inserted. Default `true` preserves existing behavior; consumers can return `false` to suppress a specific reply.

### Why

When the `teaser-thread` long-form strategy publishes a post, the result on Bluesky is a root record plus N follow-up reply records. `Reaction_Sync` (`atmosphere_sync_reactions` cron) walks the user's own records via `listRecords` and dispatches each record through `process_own_record()`. Each follow-up chunk has `value.reply` set, which routes it to `process_reply()`. The `META_URI_INDEX` fallback in `find_post_by_bsky_uri()` exists precisely so likes/reposts targeting a reply chunk still resolve to the originating post — which also means each chunk URI resolves and the chunk gets inserted as a WordPress comment.

Net effect on a 3-chunk teaser-thread post: 2 spurious comments per publish (author talking to themself), plus any downstream notifications the host platform fires for incoming comments.

### Why a filter and not a unilateral change

The discriminator is universal — any consumer of `wordpress-atmosphere` that publishes via `teaser-thread` will see this — so the upstream-friendly version is the hook. The discriminator is also small: a record's URI is in the post's `META_URI_INDEX` iff `Publisher` wrote it during a publish, so a callback that checks own DID + URI-in-index is sufficient.

If you'd prefer ATmosphere itself to register a default callback when `atmosphere_long_form_composition === 'teaser-thread'` (so every consumer gets this behavior out of the box and no plugin-side wiring is needed), happy to add that here — left out of this PR so the change stays minimal and you can decide the policy. The same discriminator works either way.

## Testing instructions

* `composer test` (or `npm run env-test`) — 272 tests, 869 assertions pass locally.
* Two new tests in `tests/phpunit/tests/class-test-reaction-sync.php`:
  * `test_process_reply_respects_should_sync_filter` — callback returning `false` suppresses the insert, captures the expected filter args (notification, resolved post ID, resolved comment-parent ID).
  * `test_process_reply_defaults_to_syncing` — no callback registered still inserts the comment, confirming default behavior is unchanged.

### Manual check (optional)

1. Publish a long-form post with `atmosphere_long_form_composition = 'teaser-thread'`.
2. Run `atmosphere_sync_reactions` cron.
3. Without the filter: N-1 spurious comments appear on the post.
4. With a callback returning `false` for own-DID + URI-in-`META_URI_INDEX`: zero spurious comments; external replies still sync as today.

### Changelog entry

A `.github/changelog/add-reaction-sync-should-sync-reply-filter` entry is included in this PR (minor / added).

-   [ ] Automatically create a changelog entry from the details below.