### PR TITLE
Refresh docs, skills, and agents for upcoming launch

### DIFF
--- a/.agents/skills/code-style/SKILL.md
+++ b/.agents/skills/code-style/SKILL.md
@@ -5,67 +5,34 @@ description: PHP coding standards and WordPress patterns for ATmosphere plugin. 
 
 # ATmosphere PHP Conventions
 
-Plugin-specific conventions and architectural patterns.
+Quick-reference for everyday work. Full reference: [`docs/php-coding-standards.md`](../../../docs/php-coding-standards.md) and [`docs/php-class-structure.md`](../../../docs/php-class-structure.md).
 
-## Quick Reference
+## Non-Negotiables
 
-### File Naming
-```
-class-{name}.php         # Regular classes.
-```
+- **Text domain:** always `'atmosphere'`.
+- **Tabs for indentation**, spaces inside parentheses, `array()` (not `[]`).
+- **Backslash-prefix** WordPress and PHP global functions in namespaced code: `\get_option()`, `\add_action()`, `\apply_filters()`, `\strlen()`.
+- **Use** imports for cross-namespace references — never inline `\Atmosphere\OAuth\Client`.
+- **Yoda conditions** for value-vs-variable comparisons: `if ( 'value' === $variable )`.
+- **`unreleased`** for `@since` / `@deprecated` tags on new code — the release script rewrites them.
 
-### Namespace Pattern
-```php
-namespace Atmosphere;
-namespace Atmosphere\OAuth;
-namespace Atmosphere\Transformer;
-namespace Atmosphere\WP_Admin;
-```
-
-### Text Domain
-Always use `'atmosphere'` for translations:
-```php
-\__( 'Text', 'atmosphere' );
-\esc_html_e( 'Text', 'atmosphere' );
-```
-
-### WordPress Global Functions
-When in a namespace, always escape WordPress and PHP global functions with backslash:
-```php
-\get_option(), \add_action(), \is_wp_error(), \strlen(), \time()
-```
-
-### Cross-Namespace References
-Use `use` imports — never inline `\Namespace\Class`:
-```php
-use Atmosphere\OAuth\Client;
-use function Atmosphere\get_did;
-use function Atmosphere\is_connected;
-```
-
-## Directory Structure
+## File and Class Layout
 
 ```
 includes/
-├── class-*.php              # Core classes.
-├── functions.php            # Helper functions.
-├── oauth/                   # OAuth flow classes.
-├── transformer/             # AT Protocol record transformers.
-└── wp-admin/                # Admin functionality.
-
-templates/                   # PHP template files.
-assets/                      # CSS and JS.
-tests/phpunit/               # PHPUnit tests.
+├── class-*.php              # Atmosphere, API, Publisher, Backfill, Handle, Post_Types, Reaction_Sync, Autoloader.
+├── functions.php
+├── content-parser/          # Content_Parser interface for site.standard.document.
+├── oauth/                   # Client, DPoP, Encryption, Nonce_Storage, Resolver.
+├── transformer/             # Post, Document, Publication, Comment, Facet, TID (extend Base).
+└── wp-admin/                # Admin UI.
+integrations/                # Plugin-specific content-parser integrations.
 ```
 
-## Architectural Patterns
+After adding or renaming a class file: `composer dump-autoload`.
 
-### Transformers
-Convert WordPress content into AT Protocol records.
+## Transformer Pattern
 
-**Base class:** `includes/transformer/class-base.php`
-
-**Pattern:**
 ```php
 namespace Atmosphere\Transformer;
 
@@ -79,65 +46,60 @@ class Custom extends Base {
     }
 
     public function get_rkey(): string {
-        // Return or generate TID.
+        // Reserve or return the TID; persist to META_TID so it survives retries.
     }
 }
 ```
 
-**Examples:**
-- `includes/transformer/class-post.php` — app.bsky.feed.post.
-- `includes/transformer/class-document.php` — site.standard.document.
-- `includes/transformer/class-publication.php` — site.standard.publication.
+Always reserve the rkey via meta in `get_rkey()` — that meta key is the marker `Publisher::update_post()` uses to distinguish "never published" from "publish attempt failed mid-flight."
 
-### OAuth Classes
-Handle the full PKCE + DPoP + PAR native OAuth flow.
+## Hook Quick-Reference
 
-- `includes/oauth/class-resolver.php` — Handle → DID → PDS → Auth Server chain.
-- `includes/oauth/class-client.php` — OAuth lifecycle (authorize, callback, refresh).
-- `includes/oauth/class-dpop.php` — ES256 DPoP proof generation.
-- `includes/oauth/class-encryption.php` — libsodium token encryption.
+**Transform filters:** `atmosphere_transform_bsky_post`, `atmosphere_transform_comment`, `atmosphere_transform_document`, `atmosphere_transform_publication`.
 
-### API Client
-`includes/class-api.php` — DPoP-authenticated PDS requests with automatic nonce retry.
+**Content / composition:** `atmosphere_content_parser`, `atmosphere_document_content`, `atmosphere_long_form_composition`, `atmosphere_teaser_thread_posts`.
 
-### Publisher
-`includes/class-publisher.php` — Atomic batch applyWrites for both bsky post + document.
+**Gating:** `atmosphere_syncable_post_types`, `atmosphere_should_publish_comment`, `atmosphere_should_sync_reply`, `atmosphere_backfill_limit`, `atmosphere_oauth_redirect_uri`, `atmosphere_client_metadata`.
 
-## Hook Patterns
+**Actions:** `atmosphere_publishing`, `atmosphere_publish_post_result`, `atmosphere_publish_comment_result`, `atmosphere_update_skipped_unsynced_post`, `atmosphere_long_form_strategy_downgraded`, `atmosphere_reaction_synced`.
 
-**Filters:**
-```php
-\apply_filters( 'atmosphere_transform_bsky_post', $record, $post );
-\apply_filters( 'atmosphere_transform_document', $record, $post );
-\apply_filters( 'atmosphere_transform_publication', $record );
-\apply_filters( 'atmosphere_client_metadata', $metadata );
-\apply_filters( 'atmosphere_syncable_post_types', array( 'post' ) );
-```
+**Test-only:** `atmosphere_pre_apply_writes` — Publisher fixture uses this to short-circuit `apply_writes` before the HTTP layer.
 
-## Cron Lifecycle — three-way symmetry
+Full signatures and docblocks: [`docs/php-coding-standards.md → Hook Patterns`](../../../docs/php-coding-standards.md#hook-patterns).
 
-Every plugin-owned `wp_schedule_*` hook MUST also be in `Atmosphere\get_cron_hooks()` (`includes/functions.php`). That single list drives:
+## Cron Lifecycle — Three-Way Symmetry
+
+Every plugin-owned `wp_schedule_*` hook MUST appear in `Atmosphere\get_cron_hooks()` (`includes/functions.php`). That list drives:
 
 - `Atmosphere\deactivate()` (`atmosphere.php`)
-- `Atmosphere\OAuth\Client::disconnect()` (`includes/oauth/class-client.php`)
+- `Atmosphere\OAuth\Client::disconnect()`
 - `uninstall.php`
 
 When adding a new cron hook:
 
-1. Add the hook name to `get_cron_hooks()` — do not duplicate the literal in deactivate / disconnect / uninstall.
-2. If the hook handler issues PDS writes without re-checking `is_connected()` (e.g. `atmosphere_delete_records`, `atmosphere_delete_comment_record`), the symmetry is load-bearing: a queued event from a previous connection would otherwise fire against a different repo on reconnect.
-3. If the handler stores or sweeps commentmeta / postmeta keys, mirror those keys in `uninstall.php`.
+1. Add it to `get_cron_hooks()` — never duplicate the literal in deactivate / disconnect / uninstall.
+2. If the handler issues PDS writes without re-checking `is_connected()`, the symmetry is load-bearing: a queued event from a previous connection would otherwise fire against a different repo on reconnect.
+3. If the handler stores or sweeps post/comment meta keys, mirror those keys in `uninstall.php`.
 
-This pattern was extracted in PR #32; see review by @kraftbj for the cross-install risk that motivated it.
+This pattern was extracted in PR #32 (review by @kraftbj). Full rationale: [`docs/php-coding-standards.md → Cron-Specific Rules`](../../../docs/php-coding-standards.md#cron-specific-rules).
 
-## Cron Handler Errors — never swallow `WP_Error`
+## Cron Handler Errors — Never Swallow `WP_Error`
 
-Cron handlers in `register_async_hooks()` MUST surface `Publisher::*` errors via `error_log()` (typically through `log_cron_error()`). `wp_schedule_single_event` does not retry, so a silent drop loses the only signal operators have for transient PDS failures, expired refresh tokens, or DPoP nonce drift.
+Cron handlers in `register_async_hooks()` MUST surface `Publisher::*` errors via `error_log()` — typically through `log_cron_error()`. `wp_schedule_single_event` does not retry, so a silent drop loses the only signal operators have for transient PDS failures, expired refresh tokens, or DPoP nonce drift.
 
 When the handler operates on records the caller has already lost local state for (e.g. `atmosphere_delete_comment_record` after the WP comment row is gone), include the TID/identifier in the log line so the orphan is recoverable manually.
 
-## Inflight-state Races
+## Inflight-State Races
 
-When a cron handler writes meta both *before* an `apply_writes` call (e.g. `Comment::get_rkey()` persists META_TID) and *after* (e.g. `store_comment_result()` writes META_URI), and a concurrent state change can short-circuit the cleanup gates that key off the *post-call* meta, the handler MUST re-check eligibility after the call returns and roll back if needed.
+When a cron handler writes meta both *before* an `apply_writes` call (e.g. `Comment::get_rkey()` persists `META_TID`) and *after* (e.g. `store_comment_result()` writes `META_URI`), and a concurrent state change can short-circuit the cleanup gates that key off the *post-call* meta, the handler MUST re-check eligibility after the call returns and roll back if needed.
 
 Concrete pattern: `atmosphere_publish_comment` → `reconcile_comment_after_publish()`. Re-fetch the WP object, re-run the eligibility gate, schedule the orphan-cleanup cron (not direct delete) so transient PDS failures retry through the standard channel.
+
+## When to Read the Full Docs
+
+- **Naming conventions** (classes / methods / files / hooks) — [`docs/php-coding-standards.md → Naming Conventions`](../../../docs/php-coding-standards.md#naming-conventions).
+- **Security** (escaping, sanitization, nonces, capability checks) — [`docs/php-coding-standards.md → Security Practices`](../../../docs/php-coding-standards.md#security-practices).
+- **Error handling** (returning, checking, aggregating `WP_Error`) — [`docs/php-coding-standards.md → Error Handling`](../../../docs/php-coding-standards.md#error-handling).
+- **Performance** (caching, capped collections, batching) — [`docs/php-coding-standards.md → Performance Considerations`](../../../docs/php-coding-standards.md#performance-considerations).
+- **Documentation standards** (DocBlock format, `@since` policy, inline comment style) — [`docs/php-coding-standards.md → Documentation Standards`](../../../docs/php-coding-standards.md#documentation-standards).
+- **Class structure** (where new classes go, namespace hierarchy, integration patterns) — [`docs/php-class-structure.md`](../../../docs/php-class-structure.md).

--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -5,90 +5,72 @@ description: Development workflows for WordPress ATmosphere plugin including wp-
 
 # ATmosphere Development Cycle
 
-Quick reference for common development workflows.
+Quick reference for everyday workflows. Full reference: [`docs/development-environment.md`](../../../docs/development-environment.md).
 
-## Quick Reference
+## Core Commands
 
-### Environment Management
 ```bash
-npm run env-start    # Start WordPress at http://localhost:8884.
-npm run env-stop     # Stop WordPress environment.
+# Environment.
+npm run env-start            # WordPress at http://localhost:8884.
+npm run env-stop
+
+# Tests.
+npm run env-test                            # All PHP tests.
+npm run env-test -- --filter=pattern        # Subset by name.
+npm run env-test -- --group=name            # Subset by @group.
+composer test                               # Local (needs MySQL).
+
+# Code quality.
+composer lint                # PHPCS check.
+composer lint:fix            # PHPCS auto-fix.
+composer dump-autoload       # Regenerate classmap after adding/renaming classes.
+
+# Release.
+npm run release              # Interactive release script. See the release skill.
 ```
 
-### Testing Commands
+## Default URLs
+
+- Frontend: http://localhost:8884
+- Admin: http://localhost:8884/wp-admin — user `admin`, password `password`.
+- Tests instance: http://localhost:8885
+
+## Typical Loop
+
 ```bash
-npm run env-test                      # Run all PHP tests.
-npm run env-test -- --filter=pattern  # Run tests matching pattern.
-composer test                         # Run tests locally (needs MySQL).
-vendor/bin/phpunit --filter=pattern   # Run matching tests locally.
-```
-
-### Code Quality
-```bash
-composer lint         # Check PHP coding standards.
-composer lint:fix     # Auto-fix PHP issues.
-```
-
-### Autoloader
-```bash
-composer dump-autoload    # Regenerate classmap after adding/renaming classes.
-```
-
-### Release
-```bash
-bin/release.sh [version]  # Build release ZIP with production deps only.
-```
-
-## Common Development Workflows
-
-### Initial Setup
-```bash
-npm install           # Installs @wordpress/env.
-composer install      # Installs PHP dependencies.
-npm run env-start     # WordPress at http://localhost:8884.
-```
-
-### Making Changes Workflow
-```bash
-# 1. Make code changes.
-
-# 2. If you added/renamed a class file:
+# 1. Make changes.
+# 2. If a class file was added/renamed:
 composer dump-autoload
 
-# 3. Run relevant tests.
+# 3. Run relevant tests + lint.
 npm run env-test -- --filter=FeatureName
-
-# 4. Check code quality.
 composer lint
 
-# 5. Commit.
-git add .
-git commit -m "Description"
+# 4. Commit.
 ```
 
-### Before Creating PR
+## WP-CLI Inside wp-env
+
 ```bash
-# Run full test suite.
-npm run env-test
-
-# Final lint check.
-composer lint
+npm run env -- run cli wp plugin list
+npm run env -- run cli wp option get atmosphere_settings
+npm run env -- run cli wp transient delete --all
+npm run env -- run cli wp db cli
 ```
 
-### Debugging Failing Tests
-```bash
-# Run with verbose output.
-npm run env-test -- --verbose --filter=test_name
+## When to Read the Full Docs
 
-# Stop on first failure.
-npm run env-test -- --stop-on-failure
-```
+Read [`docs/development-environment.md`](../../../docs/development-environment.md) when you need:
 
-## Key Files
+- **Prerequisites** (Node version, Docker setup, Composer, `gh` CLI).
+- **Troubleshooting** (Docker not running, port conflicts, DB connection errors, slow performance on macOS).
+- **Code coverage** (Xdebug coverage mode, HTML coverage reports).
+- **PHPUnit argument reference** (every flag we use).
+- **wp-env configuration** (overriding PHP / WP versions, mounts, custom ports).
 
-- `package.json` - Node dependencies (wp-env) and environment scripts.
-- `composer.json` - PHP dependencies, autoloading, lint/test scripts.
-- `.wp-env.json` - wp-env configuration.
-- `phpcs.xml` - PHP coding standards.
-- `phpunit.xml.dist` - PHPUnit configuration.
-- `.gitattributes` - Release archive exclusions.
+## Related Skills
+
+- **code-style** — PHP conventions, hooks, security, error handling.
+- **test** — PHPUnit patterns, the Publisher capture fixture, simulating in-flight races.
+- **pr** — pre-PR checklist, commit format, special situations.
+- **release** — `npm run release`, patch releases.

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -5,113 +5,79 @@ description: INVOKE THIS SKILL before creating any PR to ensure compliance with 
 
 # ATmosphere PR Workflow
 
+Quick-reference for opening a PR. Full reference: [`docs/pull-request.md`](../../../docs/pull-request.md).
+
 ## Branch Naming
 
 | Prefix | Use |
 |--------|-----|
-| `add/{feature}` | New features |
-| `update/{feature}` | Iterating on existing features |
-| `fix/{bug}` | Bug fixes |
-| `try/{idea}` | Experimental ideas |
+| `add/{feature}` | New feature. |
+| `update/{feature}` | Iterating on an existing feature. |
+| `fix/{bug}` | Bug fix. |
+| `try/{idea}` | Experimental — open as draft. |
 
-**Reserved:** `release/{X.Y.Z}` (releases only), `trunk` (main branch).
+**Reserved:** `release/{X.Y.Z}` (owned by the release script), `trunk`.
 
-## Pre-PR Checks
-
-Before creating a PR, you **MUST** complete these steps in order:
-
-### 1. Run PHPCS and PHPUnit
 ```bash
-composer lint         # MUST pass with zero errors
-npm run env-test      # MUST pass all tests
+git checkout trunk && git pull origin trunk
+git checkout -b fix/something
 ```
-Fix any failures before proceeding. Do not create a PR with failing checks.
 
-### 2. Changelog entry
-Every PR **MUST** either:
-- Include a changelog file in `.github/changelog/` (see [Changelog](#changelog) below), **OR**
-- Add the `Skip Changelog` label to the PR
+## Required Before Opening
 
-**Add the changelog entry as part of your initial commit, not after the PR is created.** If neither changelog nor label is present, **stop and ask** the user which they prefer before creating the PR.
+1. **Lint + tests must pass.**
+   ```bash
+   composer lint
+   npm run env-test
+   ```
 
-### 3. Code review
-Delegate to the **code-review** agent to review all changes on the branch. Address any critical issues before proceeding.
+2. **Changelog entry or `Skip Changelog` label.**
+   ```bash
+   composer changelog:add
+   ```
+   Commit the entry on the same branch as the code change. End the message with punctuation. Write for end users — no class names, no internal jargon.
 
-## PR Creation
+   If neither a changelog entry nor a `Skip Changelog` label applies, **stop and ask the user** which they prefer. Don't open the PR with neither.
 
-**Every PR must:**
-- Assign `@me`
-- Include changelog entry OR "Skip Changelog" label
-- Pass PHPCS and PHPUnit (verified above)
-- Merge cleanly with trunk
+3. **Code review.** Delegate the diff to the **code-review** agent. Address every critical finding before opening the PR.
+
+## Opening the PR
 
 ```bash
-# Create PR (includes required assignment)
 gh pr create --assignee @me
 ```
 
-**Use the exact template from `.github/PULL_REQUEST_TEMPLATE.md`** — do not create custom formatting.
+Use `.github/PULL_REQUEST_TEMPLATE.md` as-is — don't invent custom formatting. The body must include:
 
-## Changelog
+- Summary explaining *why* (not just *what* — the diff covers that).
+- Testing instructions a reviewer can reproduce locally.
+- Screenshots for any visual change (before / after).
 
-**Write changelog messages for end users, not developers.** Users read these in the WordPress plugin update screen. Avoid internal jargon (OOM, batching, N+1), class names, or method names. Describe what the user experiences or what changed from their perspective.
+## Changelog Messages
+
+Write for end users; they appear in the WordPress update screen.
 
 ```
-✅ Fix automatic cleanup of old activities failing silently on sites with many items.
-✅ Add a Site Health check that warns when plugins are causing too many federation updates.
-❌ Fix collection purge methods to batch deletions and enforce a hard item cap.
-❌ Add Site Health test to detect excessive outbox activity rates.
+✅ Fix posts not appearing on Bluesky when published via Quick Edit.
+✅ Add option to disable standard.site document records.
+❌ Refactor Publisher class to handle edge case in applyWrites batch.
+❌ Fix TID collision in transformer output.
 ```
 
-End all changelog messages with punctuation.
+End with punctuation. Never mention AI tools or coding assistants.
 
-Add manually if forgotten:
-```bash
-composer changelog:add
-git add . && git commit -m "Add changelog entry" && git push
-```
+## When to Read the Full Docs
 
-See [release](../release/SKILL.md) for complete changelog details.
+Read [`docs/pull-request.md`](../../../docs/pull-request.md) when you need:
 
-## Workflow
+- The **full pre-PR checklist** (code preparation, testing, documentation, review).
+- **Commit message format** (the `Type: ` prefix table).
+- **Special situations** — Hotfix, Breaking Change, New Feature, Bug Fix, Experimental, Multi-PR Feature checklists.
+- **Common review feedback patterns** — what reviewers typically ask for and how to respond.
+- **Label reference**.
 
-### Create Branch
-```bash
-git checkout trunk && git pull origin trunk
-git checkout -b fix/notification-issue
-```
+## Related Skills
 
-### Pre-Push Checks
-```bash
-composer lint         # PHP standards (composer lint:fix to auto-fix)
-npm run env-test      # Run tests
-```
-
-### Keep Branch Updated
-```bash
-git fetch origin
-git rebase origin/trunk
-# Resolve conflicts if any
-git push --force-with-lease
-```
-
-## Special Cases
-
-**Hotfixes:** Branch `fix/critical-issue`, minimal changes, add "Hotfix" label, request expedited review.
-
-**Experimental:** Use `try/` prefix, mark as draft, get early feedback, convert to proper branch type once confirmed.
-
-**Multi-PR features:** Create tracking issue, link all PRs, use consistent naming (`add/feature-part-1`, etc.), merge in order.
-
-## Labels
-
-| Label | Use |
-|-------|-----|
-| `Bug` | Bug fixes |
-| `Enhancement` | New features |
-| `Documentation` | Doc updates |
-| `Code Quality` | Refactoring, cleanup, etc. |
-| `Skip Changelog` | No changelog needed |
-| `Needs Review` | Ready for review |
-| `In Progress` | Still working |
-| `Hotfix` | Urgent fix |
+- **release** — release script, patch releases, GitHub Release UI.
+- **dev** — running tests, linting, troubleshooting wp-env.
+- **code-style** — PHP conventions the reviewer will be checking against.

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -5,91 +5,88 @@ description: Version management and release processes using Jetpack Changelogger
 
 # ATmosphere Release Process
 
-Quick reference for managing releases and changelogs for the WordPress ATmosphere plugin.
+Quick-reference for cutting a release. Full reference: [`docs/release-process.md`](../../../docs/release-process.md).
 
-## Quick Reference
-
-### Release Commands
-```bash
-bin/release.sh [version]    # Build release ZIP with production deps only.
-composer changelog:add      # Add a changelog entry.
-composer changelog:write    # Write changelog entries to CHANGELOG.md.
-```
-
-### Version File Locations
-When updating versions manually, change these files:
-- `atmosphere.php` - Plugin header (`Version: X.Y.Z`) and `ATMOSPHERE_VERSION` constant.
-- `readme.txt` - WordPress.org readme (`Stable tag: X.Y.Z`).
-- `package.json` - npm version (`"version": "X.Y.Z"`).
-- `CHANGELOG.md` - Changelog file (auto-updated by changelogger).
-
-## Changelog Management
-
-### How It Works
-
-Changelogs are managed through the Jetpack Changelogger:
-
-1. **Adding entries:**
-   ```bash
-   composer changelog:add
-   ```
-   - Select significance: Patch/Minor/Major.
-   - Select type: Added/Fixed/Changed/Deprecated/Removed/Security.
-   - Write message **ending with punctuation!**
-   - Saves to `.github/changelog/` directory.
-
-2. **Writing changelog:**
-   ```bash
-   composer changelog:write
-   ```
-   - Aggregates all entries from `.github/changelog/`.
-   - Updates `CHANGELOG.md` automatically.
-
-### Critical Requirements
-
-**Always end changelog messages with punctuation:**
-```
-Good: Add support for custom post types.
-Good: Fix OAuth token refresh failing silently.
-Bad:  Add support for custom post types
-Bad:  Fix OAuth token refresh failing silently
-```
-
-**Write end-user friendly messages:**
-- Focus on user benefit, not implementation details.
-- Avoid technical jargon where possible.
-- Describe what users can now do, not how it works internally.
-```
-Good: Fix posts not appearing on Bluesky when published via Quick Edit.
-Good: Add option to disable standard.site document records.
-Bad:  Refactor Publisher class to handle edge case in applyWrites batch.
-Bad:  Fix TID collision in transformer output.
-```
-
-**Never mention AI tools or coding assistants in changelog messages.**
-
-## Version Numbering
-
-**Semantic versioning:**
-- **Major (X.0.0)** - Breaking changes.
-- **Minor (0.X.0)** - New features, backward compatible.
-- **Patch (0.0.X)** - Bug fixes only.
-
-## Release Workflow
+## Major / Minor Release
 
 ```bash
-# 1. Write changelog.
+npm run release
+```
+
+The script (`bin/release.js`) handles everything: changelog roll-up, version bump in `atmosphere.php` / `readme.txt` / `package.json`, `readme.txt` changelog mirror, `unreleased` marker replacement across `*.php`, optional Upgrade Notice prompt, then commits / pushes / opens a `Release X.Y.Z` PR.
+
+**Prerequisites:** clean working tree, on `trunk` (or it'll switch you), `gh` CLI authenticated, at least one entry in `.github/changelog/`.
+
+After the PR merges: draft the GitHub Release against `trunk` with the new tag.
+
+## Patch Release
+
+The script doesn't handle these — patches are cherry-picked manually onto the previous release branch:
+
+```bash
+git fetch origin release/X.Y.0
+git checkout release/X.Y.0
+git cherry-pick -m 1 <merge-commit-hash>
 composer changelog:write
-
-# 2. Update version numbers in all version file locations.
-
-# 3. Commit version bump.
-git add -A
-git commit -m "Release version X.Y.Z"
-
-# 4. Build release ZIP.
-bin/release.sh X.Y.Z
-
-# 5. Create GitHub release with the ZIP.
-gh release create X.Y.Z atmosphere-X.Y.Z.zip --title "X.Y.Z" --generate-notes
+# Update readme.txt changelog block, bump versions in atmosphere.php / readme.txt / package.json,
+# replace any remaining `unreleased` markers.
+git push origin release/X.Y.0
+# Open PR against release/X.Y.0; draft GitHub Release with the new tag targeting that branch.
 ```
+
+Full step-by-step: [`docs/release-process.md → Patch Releases`](../../../docs/release-process.md#patch-releases).
+
+## Changelog Entries
+
+```bash
+composer changelog:add       # Add one entry to .github/changelog/.
+composer changelog:write     # Roll up entries into CHANGELOG.md (script does this for you).
+```
+
+**Required:** end the message with punctuation, write for end users (no class names, no AI/assistant references).
+
+```
+✅ Fix posts not appearing on Bluesky when published via Quick Edit.
+✅ Add option to disable standard.site document records.
+❌ Refactor Publisher class to handle edge case in applyWrites batch.
+❌ Fix TID collision in transformer output.
+```
+
+## Marking Unreleased Code
+
+When adding a new public hook, deprecation, or `_doing_it_wrong` call, use the literal `unreleased`. The release script rewrites it:
+
+```php
+/**
+ * @since unreleased
+ */
+
+\_deprecated_function( __FUNCTION__, 'unreleased', 'new_function' );
+\apply_filters_deprecated( 'atmosphere_old_filter', array( $value ), 'unreleased', 'atmosphere_new_filter' );
+\_doing_it_wrong( __METHOD__, \__( 'Use new_method().', 'atmosphere' ), 'unreleased' );
+```
+
+## Semver Bumps
+
+| Bump | When |
+|------|------|
+| **Major (X.0.0)** | Breaking public-hook signature changes, removed features, schema requires migration. |
+| **Minor (0.X.0)** | New features, new public hooks, backward-compatible behaviour changes. |
+| **Patch (0.0.X)** | Bug fixes only — no public hook changes. |
+
+If any pending entry is marked `Significance: major`, the changelogger bumps to a new major version. Otherwise minor if any is `minor`, else patch.
+
+## When to Read the Full Docs
+
+Read [`docs/release-process.md`](../../../docs/release-process.md) when you need:
+
+- The **full step-by-step** for major / minor releases.
+- The **patch-release cherry-pick workflow** with conflict-resolution tips.
+- **Version file locations** for manual bumps (patch path).
+- **Manual steps** the script doesn't handle (distributable ZIP, wp.org SVN asset upload, GitHub Release tagging).
+- **Troubleshooting** (branch-already-exists, empty changelog section, mirrored readme.txt looks wrong).
+
+## Related Skills
+
+- **pr** — branching, pre-PR checklist, changelog entry format.
+- **dev** — wp-env, testing the release branch locally.

--- a/.agents/skills/test/SKILL.md
+++ b/.agents/skills/test/SKILL.md
@@ -45,12 +45,21 @@ Tests live in `tests/phpunit/tests/` with a directory structure mirroring `inclu
 
 ```
 tests/phpunit/tests/
+├── class-test-admin-handle.php
+├── class-test-atmosphere.php
+├── class-test-dpop.php
 ├── class-test-functions.php
-├── transformer/
-│   ├── class-test-tid.php
-│   ├── class-test-facet.php
-│   └── class-test-publication.php
-└── ...
+├── class-test-handle.php
+├── class-test-long-form-composition-setting.php
+├── class-test-post-types.php
+├── class-test-publisher.php          # Largest fixture; exposes register_capture() etc.
+├── class-test-reaction-sync.php
+├── oauth/
+└── transformer/
+    ├── class-test-facet.php
+    ├── class-test-post.php
+    ├── class-test-publication.php
+    └── class-test-tid.php
 ```
 
 Test files are prefixed with `class-test-` and the class name is `Test_` + feature name.
@@ -131,3 +140,8 @@ Note: `wp_delete_comment( $id, true )` removes commentmeta synchronously, which 
 The plugin's `register_async_hooks()` runs at `plugins_loaded` (via the bootstrap), so cron handlers ARE registered before tests execute. Use `\do_action( 'atmosphere_publish_comment', $comment_id )` to fire a handler synchronously; assert on `\wp_next_scheduled()` for follow-up scheduling.
 
 Always clean up scheduled hooks in `tear_down()` — leftover events from one test become flaky preconditions for the next.
+
+## See Also
+
+- [`docs/development-environment.md`](../../../docs/development-environment.md) — PHPUnit argument reference, coverage reports, troubleshooting wp-env.
+- [`docs/php-coding-standards.md → Cron-Specific Rules`](../../../docs/php-coding-standards.md#cron-specific-rules) — the publish/update/delete patterns the tests are exercising.

--- a/.claude/agents/code-review.md
+++ b/.claude/agents/code-review.md
@@ -59,11 +59,44 @@ Apply the **code-style** skill standards when reviewing. In addition, check for:
 - Record keys (rkeys) follow AT Protocol conventions
 
 ### Compatibility
-- PHP 8.1+ compatible syntax
-- No breaking changes to public APIs without deprecation path
+- PHP 8.2+ compatible syntax (matches `Requires PHP` in `atmosphere.php` and `composer.json`).
+- WordPress 6.2+ compatible (matches `Requires at least` in `readme.txt`).
+- No breaking changes to public APIs (filters, actions, REST shape) without a deprecation path.
 
 ### Tests
 - Apply the **test** skill patterns to evaluate test coverage for new/changed code.
+
+### Performance
+- N+1 query patterns where one query per row would batch.
+- Uncached repeated lookups in a request (use a static cache or transient).
+- Unbounded loops or result sets — every list operation should have a hard cap.
+- Synchronous PDS calls from a user-facing request path (should be cron-scheduled).
+- Heavy work inside hooks that fire often (`the_content`, `init`, `wp_loaded`).
+
+### Common Review Prompts
+
+Phrase findings as one of these patterns so authors can recognise the class of feedback:
+
+**Code quality**
+- "Please add error handling here." — surface `WP_Error`, don't swallow.
+- "This could use a comment explaining why." — non-obvious behaviour or hidden constraints.
+- "Consider extracting this." — long methods, repeated patterns.
+- "Please add type hints." — match the rest of the file's strictness.
+
+**Testing**
+- "Please add a test for this edge case."
+- "Can you verify this works with [scenario]?"
+- "What happens when [condition]?"
+
+**Documentation**
+- "Please update the docblock."
+- "The changelog entry needs more detail."
+- "Can you add an example?"
+
+**Performance**
+- "This could cause N+1 queries."
+- "Consider caching this result."
+- "This might be expensive for large datasets."
 
 ## Output Format
 

--- a/.claude/agents/security-audit.md
+++ b/.claude/agents/security-audit.md
@@ -2,7 +2,7 @@
 name: security-audit
 description: Audit the plugin for security vulnerabilities including SSRF, OAuth bypass, XSS, token leakage, and DPoP issues. Use when asked to check security, review attack surface, or find vulnerabilities.
 tools: Bash, Read, Glob, Grep, WebFetch
-model: sonnet
+model: claude-opus-4-7[1m]
 skills: code-style
 ---
 
@@ -37,14 +37,23 @@ Files: `includes/oauth/`
 
 Files: `includes/oauth/class-dpop.php`
 
-- Verify ES256 key generation uses cryptographically secure parameters (P-256 curve, proper entropy)
-- Check that DPoP private keys are never exposed in logs, error messages, or HTTP responses
-- Verify the JWT `ath` claim correctly binds proofs to access tokens
-- Check that `jti` values use sufficient entropy to prevent replay
-- Verify `iat` timestamps are current and not reusable
-- If using native OpenSSL signing: verify DER-to-raw signature conversion handles edge cases (leading zeros, variable-length integers)
-- If using native OpenSSL signing: verify JWK-to-PEM conversion produces valid SEC1/PKCS#8 structures
-- Check that the public JWK in proof headers never includes the private `d` parameter
+- Verify ES256 key generation uses cryptographically secure parameters (P-256 curve, proper entropy).
+- Check that DPoP private keys are never exposed in logs, error messages, or HTTP responses.
+- Verify the JWT `ath` claim correctly binds proofs to access tokens.
+- Check that `jti` values use sufficient entropy to prevent replay.
+- Verify `iat` timestamps are current and not reusable.
+- If using native OpenSSL signing: verify DER-to-raw signature conversion handles edge cases (leading zeros, variable-length integers).
+- If using native OpenSSL signing: verify JWK-to-PEM conversion produces valid SEC1/PKCS#8 structures.
+- Check that the public JWK in proof headers never includes the private `d` parameter.
+
+**Timestamp validation rigour** (lessons from sibling-plugin signature-verification incidents):
+
+- The `iat` window must be narrow (a few minutes either side of the server clock, not hours). A wide window enables replay if a proof is intercepted.
+- Reject proofs that omit `iat` entirely — every valid proof must carry a freshness timestamp.
+- If the spec allows `exp` or `nbf`, cap the maximum future expiry at a small bounded value (e.g. 5 minutes). An attacker should never be able to mint a long-lived proof.
+- For incoming responses from the auth server / PDS that carry signed nonces or timestamps, apply the same rules — narrow window, freshness required, sane upper bound.
+
+**Sign-only-with-the-bound-key.** The DPoP proof's `jwk` header must match the key tied to the access token. A confused-deputy attack succeeds if a different (attacker-supplied) `jwk` is accepted on a request that quotes a valid `ath`.
 
 ### 3. Token & Secret Management
 
@@ -64,14 +73,29 @@ Files: `includes/oauth/class-resolver.php`, `includes/class-api.php`
 
 The AT Protocol identity resolution chain (handle → DID → PDS → auth server) is a multi-hop SSRF surface:
 
-- Verify all outbound requests use `wp_safe_remote_get/post()` (blocks private IPs by default)
+- Verify all outbound requests use `wp_safe_remote_get/post()` (blocks private IPs by default).
 - Check handle resolution — can a malicious handle (e.g., `evil.internal`) resolve to an internal host?
-- Verify DID document fetching does not follow arbitrary URLs from `plc.directory` responses
-- Check PDS endpoint resolution — can a crafted DID document's `#atproto_pds` service point to internal services (e.g., `http://169.254.169.254`)?
-- Verify authorization server discovery (`/.well-known/oauth-protected-resource` → `/.well-known/oauth-authorization-server`) cannot chain into internal networks
-- Check for second-order SSRF — fetching a URL from a response, then fetching a URL from *that* response
-- Verify that redirect responses (3xx) are not blindly followed to internal hosts
-- Check well-known endpoint handlers for open redirect or SSRF via query parameters
+- Verify DID document fetching does not follow arbitrary URLs from `plc.directory` responses.
+- Check PDS endpoint resolution — can a crafted DID document's `#atproto_pds` service point to internal services (e.g., `http://169.254.169.254`, `http://[::1]`, `http://[fe80::1]`)?
+- Verify authorization server discovery (`/.well-known/oauth-protected-resource` → `/.well-known/oauth-authorization-server`) cannot chain into internal networks.
+- Check for second-order SSRF — fetching a URL from a response, then fetching a URL from *that* response.
+- Verify that redirect responses (3xx) are not blindly followed to internal hosts.
+- Check well-known endpoint handlers for open redirect or SSRF via query parameters.
+
+**IPv6 coverage:** WordPress core's safe-remote helpers block IPv4 private ranges by default, but ATmosphere must verify the resolver itself rejects IPv6-only payloads pointing at:
+
+- IPv6 loopback (`::1`).
+- Link-local (`fe80::/10`).
+- Unique local addresses (`fc00::/7`).
+- IPv4-mapped IPv6 (`::ffff:127.0.0.1`, `::ffff:169.254.169.254`).
+- Multicast (`ff00::/8`).
+- IPv6-only third-party hosts that resolve to internal networks via AAAA records.
+
+**URL-decode before the safety check.** A handle like `https://%6c%6f%63%61%6c%68%6f%73%74/.well-known/atproto-did` bypasses naive string comparisons against `localhost`. Decode percent-encoded forms and resolve canonical hostnames before applying any allowlist/blocklist.
+
+**Block at the route layer, too.** `wp_safe_remote_*` rejects unsafe URLs at the HTTP client, but request handlers that *receive* a remote URL (e.g. the OAuth callback's `state` round-trip, the publication endpoint) must reject internal-network targets at the route layer before the URL ever reaches `wp_safe_remote_*`. Defence in depth.
+
+**Localhost in production.** Restrict any "allow localhost" override (e.g. `WP_ENVIRONMENT_TYPE !== 'production'`) so test bypasses never ship to a live site.
 
 ### 5. Well-Known Endpoints
 
@@ -141,33 +165,115 @@ Files: `composer.json`, `package.json`
 
 Files: all PHP files
 
-- Catalog all `atmosphere_` filter and action hooks
-- Identify hooks that could weaken security if hooked by other plugins (e.g., disabling auth checks, modifying token handling)
-- Check that filter return values are validated after `apply_filters()` — a third-party filter returning unexpected types could cause type confusion
-- Verify that hooks processing sensitive data (tokens, keys) cannot be observed by lower-privilege code
+- Catalog all `atmosphere_` filter and action hooks.
+- Identify hooks that could weaken security if hooked by other plugins (e.g., disabling auth checks, modifying token handling).
+- Check that filter return values are validated after `apply_filters()` — a third-party filter returning unexpected types could cause type confusion.
+- Verify that hooks processing sensitive data (tokens, keys) cannot be observed by lower-privilege code.
+- For boolean-valued filters that gate sensitive behaviour (e.g. `atmosphere_should_publish_comment`), confirm the call site explicitly casts to `bool` so a filter returning a truthy string doesn't expand the gate semantics.
+
+### 12. Rate Limiting & Abuse Prevention
+
+Files: `includes/oauth/`, `includes/wp-admin/`, REST handlers.
+
+- Verify any endpoint that mints, validates, or accepts a token has per-IP rate limiting (or relies on a documented WordPress core / hosting-layer protection).
+- Rate-limit OAuth start, callback, and any retry endpoint — repeated `state` mismatches or PKCE failures are an abuse signal, not an error to ignore.
+- **Trust only the TCP peer by default.** Per-IP buckets that key off `$_SERVER['HTTP_X_FORWARDED_FOR']` are bypassable by directly-exposed sites. Default to `$_SERVER['REMOTE_ADDR']` and only honour proxy headers if an explicit allowlist filter (e.g. `atmosphere_client_ip_sources`) opts them in. Sites behind Cloudflare / Akamai / nginx will need this filter; sites without a reverse proxy must not.
+- **Fail closed when the client IP can't be determined.** A request with an empty `REMOTE_ADDR` or a malformed `X-Forwarded-For` must not share one rate-limit bucket with every other unidentified request. Treat unknown IP as untrusted and reject (or, for rate limiting specifically, treat as a one-of-its-own bucket that is conservatively limited).
+- Return the standard rate-limit response (`429 Too Many Requests` + `Retry-After`) from the OAuth token / refresh endpoints. Don't silently 401.
+
+### 13. CORS & Cross-Origin Behaviour
+
+Files: well-known handlers in `class-atmosphere.php`, any REST controllers.
+
+- ATmosphere endpoints that are not designed for browser-based clients **must not** advertise credentialed cross-origin access. If a handler sets `Access-Control-Allow-Origin: *`, it must not also set `Access-Control-Allow-Credentials: true`.
+- For bearer-token use cases (e.g. an OAuth-protected resource endpoint), allow credentialed CORS only with an explicit origin allowlist, not `*`.
+- Verify `Vary: Accept` / `Vary: Origin` are sent where the response differs by header — otherwise a CDN can cache the wrong variant.
+- Check that preflight (`OPTIONS`) responses don't leak more capabilities than the actual GET/POST handlers (e.g. allowing `PUT`, `DELETE`, custom auth headers when the real handler accepts only `GET`).
+
+### 14. JSON & Input Resilience
+
+Files: `includes/class-api.php`, `includes/oauth/class-resolver.php`, anywhere that consumes a PDS / auth-server response.
+
+- Defend against malformed JSON: every `json_decode()` must check for `JSON_ERROR_NONE` (or use `wp_json_decode()` and check `is_wp_error()`).
+- Defend against unexpected types: don't assume a field is an array because it was last time — guard with `is_array()` / `is_string()` before iterating or indexing. ActivityPub had a class of `array_keys(null)` fatals from third-party plugins returning unexpected types into `apply_filters`-style chains; the same pattern can break ATmosphere.
+- Defend against unexpected nesting: deeply nested attacker-controlled JSON can exhaust memory. Use a sane depth limit on `json_decode` (third arg) and reject oversized payloads at the HTTP layer (`max_input_vars`, body-size caps).
+- Cap large list fields. If a PDS response contains a list of records / reactions / facets and the plugin walks it, enforce a hard upper bound (e.g. 100 items). An attacker-controlled PDS could otherwise return a 50k-element list and OOM the WordPress process.
+
+### 15. Visibility & Authorization on Public Surfaces
+
+Files: well-known handlers, REST controllers, anywhere that exposes post / publication data unauthenticated.
+
+- Verify `/.well-known/site.standard.publication` exposes **only** the configured publication AT-URI, not anything derived from the current post context (e.g. draft data leaking via a query var injection).
+- Outbox-like endpoints (if any are added) must filter on `post_status === 'publish'` AND exclude password-protected / private posts before returning data to unauthenticated visitors.
+- Check that cross-post visibility checks happen at *every* boundary: the publisher gate, the backfill gate, the reaction-sync write-back, and any admin preview. A missed gate at any of these leaks private content.
+- Verify that querying `/.well-known/atproto-did` with unexpected query parameters (`?foo=bar`, `?atmosphere_wellknown=garbage`) cannot return data for the wrong site / user.
+
+### 16. Race Conditions & Cron Reentry
+
+Files: `includes/class-atmosphere.php` (cron registration), `includes/class-publisher.php` (publish/update/delete flow), `includes/class-reaction-sync.php`.
+
+- Verify cron handlers are idempotent. `wp_schedule_single_event` can fire twice (concurrent workers, plugin re-activation, traffic spikes triggering loopback requests). If a handler has user-visible side effects (a published Bluesky post, a stored comment), it must gate on a meta sentinel **before** the side effect.
+- Verify inflight-state races are reconciled. When a publish writes meta both before (rkey reservation in `get_rkey()`) and after (URI in `mirror_thread_records_meta()`), a concurrent comment-deletion or post-status transition can leave the system inconsistent. Confirm the reconcile-after-publish pattern is applied (see `reconcile_comment_after_publish()`).
+- Verify the `atmosphere_publishing` action loop guard cannot be bypassed by a third-party hook that resets it.
+
+### 17. Deletion & Revocation Authority
+
+Files: `includes/oauth/class-client.php` (`disconnect()`), `uninstall.php`, delete-handler paths in Publisher and Reaction_Sync.
+
+- On disconnect, the OAuth refresh token must be revoked at the auth server (`POST /oauth/revoke`), not just deleted locally. Local-only delete leaves a usable refresh token on the auth server.
+- On uninstall, both local state AND remote tokens should be cleaned up — a leaked credential file from a deleted install must not stay valid forever.
+- For comment / post deletion: verify the `caller-owns-this-record` check before deleting on the PDS. ATmosphere should never let a request from one user delete records owned by another (the AT-URI's repo DID must match the connected account).
+
+## Recently Noted Patterns
+
+Findings from sister-plugin audits (ActivityPub 8.1.x–8.2.x and parallel) that ATmosphere should be checked against. Treat each as a question to answer in the audit, not a pre-confirmed bug.
+
+- **IPv6 SSRF coverage** — outbound safety must cover IPv6 loopback, link-local, ULA, and IPv4-mapped-IPv6 addresses, not just IPv4 private ranges.
+- **Percent-encoded host bypasses** — URL safety checks that string-match `localhost` are bypassed by `%6c%6f%63%61%6c%68%6f%73%74`. Decode before checking.
+- **Route-layer SSRF** — handlers that *receive* a URL (OAuth callback, well-known) must reject internal-network targets before invoking `wp_safe_remote_*`.
+- **Localhost allowance scoping** — any "allow local URLs in dev" override must check `wp_get_environment_type() !== 'production'` or equivalent. The override must never apply on a live site.
+- **Trusted-proxy default** — per-IP rate limits should trust only `REMOTE_ADDR` by default; reading `X-Forwarded-For` must be opt-in via a filter so directly-exposed sites aren't spoofable.
+- **Fail-closed unknown IP** — a rate-limit bucket of "all unidentified requests" is one bucket attackers can fill cheaply. Reject or hard-limit when client IP is unavailable.
+- **CORS without credentials** — endpoints not designed for browser use must not advertise credentialed CORS. `Access-Control-Allow-Origin: *` + `Access-Control-Allow-Credentials: true` is the dangerous combination.
+- **Signature freshness** — clock-skew windows for incoming signed payloads (DPoP, future signed responses) must be narrow, freshness timestamps must be required, and unreasonable expiries must be capped.
+- **Visibility of private content on public surfaces** — outbox / well-known / preview handlers must filter on `post_status === 'publish'` AND exclude password-protected, private, or draft posts.
+- **Caller-owns-this-record on deletes** — every delete-on-PDS path must verify the AT-URI's repo DID matches the connected account.
+- **Revoke at auth server on disconnect** — local-only token delete leaves a valid refresh token usable from anywhere it leaked to.
+- **Type-confusion via third-party filters** — `apply_filters` chains processing data from external sources must validate return shapes; ActivityPub had a class of fatals where third-party plugins returned `null` into filters that expected arrays.
+- **Cron reentry idempotency** — handlers with user-visible side effects must claim the work atomically (`add_option( $key, $value, '', false )` is race-safe) **before** the side effect runs.
 
 ## Running Against a Live Instance
 
-If the user provides a live URL, run these `curl` checks:
+If the user provides a live URL, run these `curl` checks. **Do not run any active exploits against a third-party site without explicit authorization** — these are read-only probes.
 
 ```bash
-# Client metadata endpoint — check for info disclosure
+# Client metadata endpoint — check for info disclosure.
 curl -s "$URL/.well-known/oauth-client-metadata" | python3 -m json.tool 2>/dev/null
 
-# AT Protocol DID endpoint — should return only the DID
+# AT Protocol DID endpoint — should return only the DID, no body envelope.
 curl -s "$URL/.well-known/atproto-did"
 
-# Publication endpoint — check response
+# Publication endpoint — should return only the configured publication AT-URI.
 curl -s "$URL/.well-known/site.standard.publication"
 
-# Check if settings page is accessible without auth
+# Settings page must require auth (expect 302 to wp-login.php, not 200).
 curl -s -o /dev/null -w "%{http_code}" "$URL/wp-admin/options-general.php?page=atmosphere"
 
-# Check for token leakage in error responses
+# REST root should not advertise atmosphere-named routes in unauthenticated responses.
 curl -s "$URL/wp-json/" | grep -i "atmosphere" 2>/dev/null
 
-# Check well-known endpoint with unexpected query vars
+# Inject the well-known query var into other paths — should not coerce a well-known response.
 curl -s -o /dev/null -w "%{http_code}" "$URL/.well-known/atproto-did?atmosphere_wellknown=arbitrary"
+curl -s -o /dev/null -w "%{http_code}" "$URL/?atmosphere_wellknown=publication"
+
+# CORS preflight on the well-known endpoints — should not advertise credentials.
+curl -sI -X OPTIONS -H "Origin: https://evil.example" "$URL/.well-known/atproto-did" | grep -i "access-control"
+
+# Try to leak post visibility — request the publication endpoint with a draft / private post hint.
+curl -s "$URL/.well-known/site.standard.publication?post_id=999999"
+
+# Response-header hygiene on the public endpoints.
+curl -sI "$URL/.well-known/atproto-did" | grep -iE "x-powered-by|server|x-content-type-options|strict-transport-security"
 ```
 
 ## Output Format

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,11 +15,13 @@ WordPress plugin that publishes posts to AT Protocol in both `app.bsky.feed.post
 ```
 atmosphere.php                  # Main plugin file.
 includes/
-├── class-*.php                 # Core classes (Atmosphere, API, Publisher, Backfill).
+├── class-*.php                 # Core classes (Atmosphere, API, Publisher, Backfill, Handle, Post_Types, Reaction_Sync).
 ├── functions.php               # Helper functions.
+├── content-parser/             # Pluggable content formats for site.standard.document (interface only by default).
 ├── oauth/                      # OAuth flow (Client, DPoP, Encryption, Resolver, Nonce).
-├── transformer/                # AT Protocol record transformers (Post, Document, Publication, Facet, TID).
-└── wp-admin/                   # Admin UI (settings page, meta box).
+├── transformer/                # AT Protocol record transformers (Post, Document, Publication, Comment, Facet, TID).
+└── wp-admin/                   # Admin UI (settings page, sidebar panel).
+integrations/                   # Plugin-specific content-parser integrations (stubs).
 templates/                      # PHP template files.
 assets/                         # CSS and JS.
 tests/
@@ -50,7 +52,7 @@ composer changelog:add          # Add a changelog entry.
 composer changelog:write        # Write entries to CHANGELOG.md.
 
 # Release
-bin/release.sh [version]        # Build release ZIP with production deps only.
+npm run release                 # Interactive release: bumps version, regenerates CHANGELOG/readme.txt, pushes a release/X.Y.Z PR.
 ```
 
 ## Common Pitfalls
@@ -92,21 +94,50 @@ Test files live in `tests/phpunit/tests/` mirroring `includes/` structure. Files
 
 **Well-known endpoints** — Rewrite rules + `template_redirect` handlers in `Atmosphere` class serve `/.well-known/atproto-did` (domain handle verification) and `/.well-known/site.standard.publication` (publication AT-URI). All share the `atmosphere_wellknown` query var.
 
-## Release Process
+## Documentation Index
 
-Build a release ZIP with only production dependencies:
+```
+README.md                          — public-facing repo entry point (lean: intro + docs links).
+readme.txt                         — WordPress.org plugin readme (end-user friendly description, FAQ, changelog).
 
-```bash
-bin/release.sh [version]
+docs/developer-docs.md             — developer entry doc; index over the rest of docs/.
+docs/development-environment.md    — wp-env setup, prerequisites, troubleshooting, coverage.
+docs/php-coding-standards.md       — naming, escaping, error handling, performance, cron rules.
+docs/php-class-structure.md        — directory layout, namespaces, architectural patterns.
+docs/code-linting.md               — PHPCS rules and common fixes.
+docs/pull-request.md               — branching, pre-PR checklist, commit format, special situations.
+docs/release-process.md            — `npm run release`, patch releases, GitHub Release UI.
+docs/translations.md               — text domain, GlotPress, translator-friendly strings.
+docs/content-formats.md            — survey of AT Protocol `content` types for site.standard.document.
+docs/org.wordpress.html.md         — Lexicon for the org.wordpress.html content type.
+
+integrations/README.md             — registering custom Content_Parser implementations from third-party plugins.
+.github/PULL_REQUEST_TEMPLATE.md   — PR template (changelog block + testing instructions).
 ```
 
-This runs `git archive` (respects `.gitattributes export-ignore`), installs `--no-dev` Composer dependencies with an optimised autoloader, and produces `atmosphere-{version}.zip`.
+The skills under `.agents/skills/` are quick-references that link into these docs. Update the docs when conventions change; the skills inherit the change.
+
+## Release Process
+
+```bash
+npm run release
+```
+
+The release script (`bin/release.js`) does all of the version bookkeeping in one step:
+
+1. Runs `composer changelog:write` to roll up `.github/changelog/` entries into `CHANGELOG.md` (the next semver version is inferred from the entries' significance).
+2. Creates a `release/X.Y.Z` branch.
+3. Updates the version in `atmosphere.php` (header + `ATMOSPHERE_VERSION`), `readme.txt` (`Stable tag`), and `package.json`.
+4. Mirrors the new changelog section into `readme.txt` (same major-version history, with a link to the full GitHub `CHANGELOG.md`).
+5. Replaces `@since unreleased` / `@deprecated unreleased` and the equivalent `_deprecated_*` / `_doing_it_wrong` literals in PHP files with the new version.
+6. Optionally prompts for an Upgrade Notice.
+7. Pushes the branch and opens a PR titled `Release X.Y.Z` against `trunk`.
 
 The `.gitattributes` file controls what's excluded from `git archive` exports and GitHub release tarballs.
 
 ## Skills and Agents
 
-Skills are complex procedures loaded on demand. Canonical files live in `.claude/skills/`.
+Skills are complex procedures loaded on demand. Canonical files live in `.agents/skills/`; `.claude/skills/*/SKILL.md` are 1-line stubs that point at them so both Claude Code and other agents pick up the same instructions.
 
 | Skill | Use when… |
 |-------|-----------|

--- a/README.md
+++ b/README.md
@@ -1,124 +1,53 @@
 # ATmosphere
 
-> [!IMPORTANT]
-> **Proof of Concept** — This plugin is under active development and not yet ready for production use. APIs, data formats, and behavior may change without notice.
+This is the **ATmosphere** plugin repo.
 
-Publish WordPress posts to [AT Protocol](https://atproto.com/) ([Bluesky](https://bsky.social/) + [standard.site](https://standard.site/)) via native OAuth.
+Publish your WordPress posts to the [AT Protocol](https://atproto.com/) network — cross-post to [Bluesky](https://bsky.social/), register your articles as [standard.site](https://standard.site/) documents on your PDS, use your domain as your Bluesky handle, and mirror replies and reposts back into WordPress as native comments.
 
-## Description
+## Documentation
 
-ATmosphere connects your WordPress site to the AT Protocol network. When you publish a post, it is automatically cross-posted to Bluesky and registered as a standard.site document on your Personal Data Server (PDS).
+- [Developer Documentation](docs/developer-docs.md) — entry point for developers extending or integrating with ATmosphere.
+- [Development Environment](docs/development-environment.md) — wp-env setup, prerequisites, troubleshooting, coverage.
+- [PHP Coding Standards](docs/php-coding-standards.md) — naming, escaping, error handling, performance, cron rules.
+- [Class Structure](docs/php-class-structure.md) — directory layout, namespaces, architectural patterns.
+- [Code Linting](docs/code-linting.md) — PHPCS rules and common fixes.
+- [Pull Request Guide](docs/pull-request.md) — branching, pre-PR checklist, commit format.
+- [Release Process](docs/release-process.md) — `npm run release`, patch releases, GitHub Release UI.
+- [Translations](docs/translations.md) — text domain, GlotPress, translator-friendly strings.
+- [Content Formats](docs/content-formats.md) — AT Protocol `content` types for `site.standard.document`.
+- [`org.wordpress.html` Lexicon](docs/org.wordpress.html.md) — the rendered-HTML content type schema.
+- [Integrations](integrations/README.md) — registering custom `Content_Parser` implementations.
+- [Contributor instructions](AGENTS.md) — directory structure, commands, conventions, and skills/agents.
 
-The plugin uses native AT Protocol OAuth with PKCE and DPoP — no third-party proxy or intermediary service required. Your credentials never leave your site.
+## Protocol Support
 
-## Features
+ATmosphere implements the AT Protocol natively — no third-party proxy or intermediary service. Authentication uses OAuth 2.1 with PKCE and DPoP. Records are written to your PDS via `com.atproto.repo.applyWrites`.
 
-- **Native OAuth** — Authenticate directly with your PDS using OAuth 2.1 with PKCE and DPoP.
-- **Bluesky cross-posting** — Publish `app.bsky.feed.post` records that appear in your followers' timelines.
-- **standard.site records** — Create `site.standard.publication` and `site.standard.document` records on your PDS.
-- **Facet detection** — Automatically detects links, mentions, and hashtags in post content.
-- **Per-post control** — Enable or disable publishing for individual posts via a meta box.
-- **Domain handle verification** — Use your WordPress domain as your Bluesky handle via `/.well-known/atproto-did`.
-- **Backfill** — Sync existing published posts to AT Protocol in bulk.
+Currently supported record types:
 
-## How It Works
+- `app.bsky.feed.post` — Bluesky posts and reply threads.
+- `site.standard.publication` — your site as a publication record.
+- `site.standard.document` — one document record per WordPress post.
 
-1. Connect your Bluesky / AT Protocol account via OAuth on the settings page.
-2. Configure your publication metadata (name, description, icon).
-3. Publish a post — ATmosphere creates both a Bluesky post and a standard.site document record on your PDS.
+See [`docs/content-formats.md`](docs/content-formats.md) for more on the content union used by `site.standard.document`.
 
-## Requirements
+## Support
 
-- PHP 8.2+
-- WordPress 6.2+
+If you need help, [check the issue tracker on GitHub](https://github.com/Automattic/wordpress-atmosphere/issues) or open a new bug report.
 
-## Installation
+## Contribute
 
-1. Clone this repository into your `wp-content/plugins/` directory:
-   ```bash
-   git clone https://github.com/pfefferle/atmosphere.git wp-content/plugins/atmosphere
-   ```
-2. Activate the plugin through the "Plugins" menu in WordPress.
-3. Go to **Settings → ATmosphere** and connect your AT Protocol account.
+Contributions are welcome — bug fixes, new features, integrations, translations.
 
-## Development
+* **Keep issues focused.** Use the issue tracker for specific bugs or concrete proposals. Tangential ideas are best as GitHub Discussions.
+* **Stay within scope.** Open issues should relate directly to the plugin.
+* **Be concise.** Short, actionable descriptions are easier to respond to.
 
-### Setup
+Before opening a pull request, please read [`AGENTS.md`](AGENTS.md) for directory layout, coding conventions, and the release workflow.
 
-```bash
-composer install
-npm install
-```
+## Security
 
-### Local Environment (wp-env)
-
-```bash
-npm run env-start    # Start WordPress environment
-npm run env-stop     # Stop environment
-```
-
-### Linting
-
-```bash
-composer lint        # Check PHP coding standards
-composer lint:fix    # Auto-fix PHP issues
-```
-
-### Testing
-
-```bash
-composer test                            # Full PHPUnit test suite
-npm run env-test                         # Run tests via wp-env
-npm run env-test -- --filter test_name   # Run a single test
-```
-
-## Architecture
-
-```
-includes/
-├── oauth/            # Full PKCE + DPoP + PAR native OAuth flow
-│   ├── class-client.php
-│   ├── class-dpop.php
-│   ├── class-encryption.php
-│   ├── class-nonce-storage.php
-│   └── class-resolver.php
-├── transformer/      # WP → AT Protocol record conversion
-│   ├── class-base.php
-│   ├── class-document.php
-│   ├── class-facet.php
-│   ├── class-post.php
-│   ├── class-publication.php
-│   └── class-tid.php
-├── wp-admin/         # Settings page, meta box, REST endpoint
-├── class-api.php     # DPoP-authenticated PDS requests with nonce retry
-├── class-atmosphere.php
-├── class-backfill.php
-├── class-publisher.php  # Atomic batch applyWrites for both record types
-└── functions.php
-```
-
-## FAQ
-
-### Can I use my domain as my Bluesky handle?
-
-Yes. Once you connect your account, the plugin serves your DID at `/.well-known/atproto-did`. Go to the Bluesky app settings, choose "Change Handle", select "I have my own domain", and enter your WordPress site's domain. Bluesky will verify it automatically.
-
-### Do I need a Bluesky account?
-
-You need an AT Protocol account. Bluesky (`bsky.social`) is the most common provider, but any AT Protocol PDS will work.
-
-### Does this require a third-party service?
-
-No. The plugin authenticates directly with your PDS using native AT Protocol OAuth. No tokens are sent to or stored by any intermediary.
-
-### What records are created?
-
-Each published post creates:
-
-- An `app.bsky.feed.post` record (visible on Bluesky).
-- A `site.standard.document` record (structured metadata for the ATmosphere).
-
-Your site itself is represented by a `site.standard.publication` record.
+Found a security issue? Report it via [Automattic's security page](https://automattic.com/security/) or our HackerOne bug-bounty program at https://hackerone.com/automattic.
 
 ## License
 

--- a/docs/code-linting.md
+++ b/docs/code-linting.md
@@ -1,0 +1,223 @@
+# Linting and Code Quality
+
+## Table of Contents
+- [PHP Code Standards](#php-code-standards)
+- [Running Targeted Checks](#running-targeted-checks)
+- [Fixing Common Issues](#fixing-common-issues)
+- [Project-Specific Rules](#project-specific-rules)
+
+## PHP Code Standards
+
+### Quick Commands
+
+```bash
+# Check PHP code standards across the project.
+composer lint
+
+# Auto-fix what can be fixed.
+composer lint:fix
+
+# Check or fix a specific file or directory.
+vendor/bin/phpcs path/to/file.php
+vendor/bin/phpcbf path/to/file.php
+vendor/bin/phpcs includes/transformer/
+```
+
+### PHPCS Configuration
+
+The ruleset is defined in `phpcs.xml`:
+
+| Standard | Purpose |
+|----------|---------|
+| **WordPress** | Full WordPress Coding Standards (Core + Docs + Extra). |
+| **PHPCompatibility** | PHP 8.2+ compatibility (matches `Requires PHP` in `atmosphere.php`). |
+| **PHPCompatibilityWP** | WordPress 6.2+ compatibility (matches `Requires at least` in `readme.txt`). |
+| **VariableAnalysis** | Flags undefined or unused variables. |
+
+**Excluded paths:**
+
+- `vendor/` — Composer dependencies.
+- `node_modules/` — npm dependencies.
+- `tests/phpunit/data/` — fixture files (if any are added).
+- `.wordpress-org/` — WordPress.org repo assets.
+
+For the full coding standards reference (file headers, naming, escaping, error handling, performance), see [PHP Coding Standards](php-coding-standards.md).
+
+**Important:** All DocBlock descriptions must end with a period.
+
+## Running Targeted Checks
+
+### Files changed on the current branch
+
+```bash
+git diff --name-only origin/trunk...HEAD | grep '\.php$' | xargs vendor/bin/phpcs
+```
+
+### A single directory
+
+```bash
+vendor/bin/phpcs includes/oauth/
+```
+
+### Generate a report
+
+```bash
+vendor/bin/phpcs --report=summary
+vendor/bin/phpcs --report=full > phpcs-report.txt
+vendor/bin/phpcs --report=json > phpcs-report.json
+```
+
+## Fixing Common Issues
+
+### "Missing file comment"
+
+```php
+<?php
+/**
+ * {Feature} class file.
+ *
+ * @package Atmosphere
+ */
+```
+
+### "Unused use statement"
+
+```php
+// Remove or actually use the import.
+use Unused\Class;  // ← remove this.
+```
+
+### "Expected 1 space after closing parenthesis"
+
+```php
+// Bad.
+if ($condition){
+
+// Good.
+if ( $condition ) {
+```
+
+### "Array double arrow not aligned"
+
+PHPCS expects double-arrows aligned when adjacent keys differ in length:
+
+```php
+// Bad.
+$array = array(
+    'short' => 1,
+    'longer_key' => 2,
+);
+
+// Good.
+$array = array(
+    'short'      => 1,
+    'longer_key' => 2,
+);
+```
+
+`composer lint:fix` handles this automatically — keep using it.
+
+### "Use of [] short array syntax forbidden"
+
+WordPress standards require `array()`:
+
+```php
+// Bad.
+$items = [ 'a', 'b' ];
+
+// Good.
+$items = array( 'a', 'b' );
+```
+
+### "Loose comparison"
+
+```php
+// Bad.
+if ( $value == 'something' ) {
+
+// Good — Yoda + strict.
+if ( 'something' === $value ) {
+```
+
+### "Output not escaped"
+
+```php
+// Bad.
+echo $value;
+
+// Good.
+echo \esc_html( $value );
+echo \esc_html__( 'Translatable', 'atmosphere' );
+```
+
+See [PHP Coding Standards → Security Practices](php-coding-standards.md#security-practices) for the full sanitization / escaping reference.
+
+### "Direct database query"
+
+If you must run one, prepare it:
+
+```php
+$wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $id );
+```
+
+And annotate with a reason if WPCS can't infer safety:
+
+```php
+// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- Required for cross-table join on a large dataset.
+```
+
+## Project-Specific Rules
+
+### Text Domain
+
+Always `'atmosphere'`:
+
+```php
+\__( 'Text', 'atmosphere' );
+\esc_html_e( 'Text', 'atmosphere' );
+```
+
+### Namespace Pattern
+
+```php
+namespace Atmosphere;
+namespace Atmosphere\OAuth;
+namespace Atmosphere\Transformer;
+namespace Atmosphere\Content_Parser;
+namespace Atmosphere\WP_Admin;
+```
+
+### Backslash-Prefix Globals
+
+In namespaced code, WordPress and PHP global functions are explicitly backslash-prefixed:
+
+```php
+\get_option( 'atmosphere_settings' );
+\apply_filters( 'atmosphere_should_publish_comment', $bool, $comment );
+\is_wp_error( $result );
+\strlen( $body );
+```
+
+This is a project convention — PHP falls back to global scope anyway, but the explicit backslash makes global-vs-namespaced calls scannable and prevents accidental shadowing.
+
+### File Naming
+
+```
+class-{name}.php         # Regular classes.
+trait-{name}.php         # Traits.
+interface-{name}.php     # Interfaces (e.g. interface-content-parser.php).
+```
+
+### Ignored Files
+
+PHPCS skips:
+
+- `vendor/` — Composer dependencies.
+- `node_modules/` — npm dependencies.
+- `.wordpress-org/` — wp.org repo assets (banner, icon).
+
+## See Also
+
+- [PHP Coding Standards](php-coding-standards.md) — naming, security, error handling, performance.
+- [Class Structure](php-class-structure.md) — directory layout, architectural patterns.
+- [Pull Request Guide](pull-request.md) — when these checks must pass.

--- a/docs/developer-docs.md
+++ b/docs/developer-docs.md
@@ -1,0 +1,99 @@
+# ATmosphere Plugin Developer Documentation
+
+## Table of Contents
+- [Introduction](#introduction)
+- [Where to Start](#where-to-start)
+- [Public Hooks](#public-hooks)
+- [Extending Content Formats](#extending-content-formats)
+- [Custom Post Type Support](#custom-post-type-support)
+- [Templates and Admin UI](#templates-and-admin-ui)
+
+## Introduction
+
+This documentation is for developers who want to extend, integrate with, or build on the ATmosphere plugin — whether you're writing a companion plugin, adding a content parser for the `site.standard.document` content union, or hooking into the publish / reaction pipeline.
+
+If you're contributing to ATmosphere itself, start with [`AGENTS.md`](../AGENTS.md) for repository conventions.
+
+## Where to Start
+
+- [Development Environment Setup](development-environment.md) — wp-env, prerequisites, troubleshooting.
+- [PHP Coding Standards](php-coding-standards.md) — naming, escaping, error handling, performance.
+- [Class Structure](php-class-structure.md) — directory layout and architectural patterns.
+- [Code Linting](code-linting.md) — PHPCS rules and common fixes.
+- [Pull Request Guide](pull-request.md) — branch naming, checklists, commit format.
+- [Release Process](release-process.md) — `npm run release`, patch releases, GitHub Release UI.
+- [Translations](translations.md) — text domain, GlotPress, translator-friendly strings.
+- [Content Formats](content-formats.md) — the AT Protocol content types ATmosphere can produce.
+- [`org.wordpress.html` Lexicon](org.wordpress.html.md) — the rendered-HTML content type schema.
+- [Integrations Guide](../integrations/README.md) — how third-party plugins register content parsers.
+
+## Public Hooks
+
+ATmosphere exposes a small set of filters and actions for plugins to extend behaviour. The full catalog with signatures lives in [`docs/php-coding-standards.md → Hook Patterns`](php-coding-standards.md#hook-patterns). The most commonly used:
+
+| Hook | Type | Use |
+|------|------|-----|
+| `atmosphere_content_parser` | filter | Return a `Content_Parser` instance to populate `site.standard.document.content`. |
+| `atmosphere_document_content` | filter | Last-chance modification of the parsed content object. |
+| `atmosphere_syncable_post_types` | filter | Add or remove post types eligible for cross-posting. |
+| `atmosphere_should_publish_comment` | filter | Customise which approved comments are mirrored as Bluesky replies. |
+| `atmosphere_should_sync_reply` | filter | Customise which inbound Bluesky replies become WordPress comments. |
+| `atmosphere_transform_bsky_post` | filter | Mutate the Bluesky post record before write. |
+| `atmosphere_transform_document` | filter | Mutate the document record before write. |
+| `atmosphere_publish_post_result` | action | React to a post-publish outcome (success or `WP_Error`). |
+| `atmosphere_publish_comment_result` | action | React to a comment-publish outcome. |
+| `atmosphere_reaction_synced` | action | React when a Bluesky reaction is stored as a WordPress comment. |
+
+When adding a new public hook, mark its `@since` tag as `unreleased` — the release script rewrites it (see [Release Process → Marking Unreleased Code](release-process.md#marking-unreleased-code)).
+
+## Extending Content Formats
+
+The `site.standard.document` record's `content` field is an open union of typed content objects (see [`docs/content-formats.md`](content-formats.md)). ATmosphere ships only the `Content_Parser` interface — concrete parsers come from integrations.
+
+To provide a parser:
+
+1. Implement `Atmosphere\Content_Parser\Content_Parser` (defined in `includes/content-parser/interface-content-parser.php`).
+2. Register through the `atmosphere_content_parser` filter, returning your instance.
+3. Return `null` from the filter when you don't want to handle a given post — other integrations can then take over.
+
+A complete worked example (with `class-load.php` registration) is in [`integrations/README.md`](../integrations/README.md).
+
+## Custom Post Type Support
+
+ATmosphere only cross-posts post types that opt in. Two ways to add one:
+
+### Per-site option
+
+```php
+\update_option( 'atmosphere_support_post_types', array( 'post', 'product' ) );
+```
+
+### Native theme/plugin support
+
+```php
+\add_post_type_support( 'product', 'atmosphere' );
+```
+
+### Filter override
+
+```php
+\add_filter(
+    'atmosphere_syncable_post_types',
+    static function ( array $types ): array {
+        $types[] = 'event';
+        return $types;
+    }
+);
+```
+
+The plugin merges all three sources, dedupes, and sanitises.
+
+## Templates and Admin UI
+
+ATmosphere's admin screens render from `templates/`. The settings page is rendered from a single template; the editor sidebar panel is a React surface registered through `class-admin.php`. There is currently no public template-override mechanism — file an issue if you have a use case that requires one.
+
+## Reporting Issues
+
+Bugs and feature requests: [GitHub Issues](https://github.com/Automattic/wordpress-atmosphere/issues).
+
+Security issues: see the project's security disclosure policy in [`README.md`](../README.md#security).

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -1,0 +1,270 @@
+# Development Environment Setup
+
+## Overview
+
+This guide walks through setting up a local development environment for the ATmosphere WordPress plugin. You'll clone the repo, install dependencies, run a local WordPress instance, and verify the test suite.
+
+## Table of Contents
+- [Prerequisites](#prerequisites)
+- [Getting Started](#getting-started)
+- [wp-env Configuration](#wp-env-configuration)
+- [Docker Management](#docker-management)
+- [Running Tests](#running-tests)
+- [Code Coverage](#code-coverage)
+- [Troubleshooting](#troubleshooting)
+- [Environment Variables](#environment-variables)
+
+## Prerequisites
+
+### Required Software
+
+1. **Node.js** (v18 or later)
+   ```bash
+   node --version
+   ```
+
+2. **npm** (ships with Node.js)
+   ```bash
+   npm --version
+   ```
+
+3. **Docker Desktop** — backs `wp-env`. Must be running before any `npm run env-*` command.
+   - [Download Docker Desktop](https://www.docker.com/products/docker-desktop)
+
+4. **Composer** — PHP dependencies, lint, tests, Jetpack Changelogger.
+   ```bash
+   # macOS via Homebrew.
+   brew install composer
+
+   # Or the official installer.
+   curl -sS https://getcomposer.org/installer | php
+   ```
+
+5. **Git** with SSH key setup
+   - [GitHub's SSH key guide](https://docs.github.com/en/authentication/connecting-to-github-with-ssh)
+   ```bash
+   ssh -T git@github.com
+   ```
+
+6. **`gh` CLI** — required by `npm run release`.
+   ```bash
+   gh --version
+   ```
+
+## Getting Started
+
+### Clone the Repository
+
+```bash
+git clone git@github.com:Automattic/wordpress-atmosphere.git
+cd wordpress-atmosphere
+```
+
+### Install Dependencies
+
+```bash
+# JavaScript dependencies.
+npm install
+
+# PHP dependencies.
+composer install
+```
+
+### Start the Development Environment
+
+```bash
+npm run env-start
+```
+
+This boots WordPress with the ATmosphere plugin installed and activated.
+
+### Access WordPress
+
+- **Frontend:** http://localhost:8884
+- **Admin:** http://localhost:8884/wp-admin
+- **Username:** `admin`
+- **Password:** `password`
+- **Tests instance:** http://localhost:8885
+
+### Stop the Environment
+
+```bash
+npm run env-stop
+```
+
+## wp-env Configuration
+
+### Default Configuration
+
+`wp-env` reads `.wp-env.json`. The defaults shipped with ATmosphere mount the plugin, set ports `8884` / `8885`, and force `WP_ENVIRONMENT_TYPE=production` for the tests instance so production code paths are exercised.
+
+### Common Commands
+
+```bash
+npm run env-start            # Start.
+npm run env-stop             # Stop.
+npm run env-test             # Run PHPUnit inside wp-env.
+
+npm run env -- <wp-env-args> # Pass through any wp-env subcommand.
+
+# WP-CLI inside the container.
+npm run env -- run cli wp plugin list
+npm run env -- run cli wp option get atmosphere_settings
+npm run env -- run cli wp transient delete --all
+npm run env -- run cli wp db cli   # MySQL shell.
+```
+
+### Multiple WordPress / PHP Versions
+
+Override in `.wp-env.json`:
+
+```json
+{
+  "core": "WordPress/WordPress#6.7",
+  "phpVersion": "8.3"
+}
+```
+
+## Docker Management
+
+```bash
+# List running containers.
+docker ps
+
+# View container logs.
+docker logs $(docker ps -q --filter name=wordpress)
+
+# Shell into the WordPress container.
+docker exec -it $(docker ps -q --filter name=wordpress) bash
+
+# Resource usage.
+docker system df
+docker system prune -a   # Reclaim space.
+```
+
+### Ports
+
+| Service | Port |
+|---------|------|
+| WordPress | 8884 |
+| Tests WordPress | 8885 |
+| MySQL | Random external port (see `docker ps`) |
+
+Override in `.wp-env.json` if 8884/8885 are in use:
+
+```json
+{ "port": 8886, "testsPort": 8887 }
+```
+
+## Running Tests
+
+```bash
+npm run env-start
+npm run env-test                                # All tests.
+npm run env-test -- --filter=pattern            # Tests matching a name pattern.
+npm run env-test -- --group=transformer         # Tests with @group transformer.
+npm run env-test -- tests/phpunit/tests/transformer/class-test-post.php
+```
+
+Common PHPUnit flags:
+
+- `--filter=pattern` — only tests matching the name regex.
+- `--group=name` — only tests tagged `@group name`.
+- `--exclude-group=name` — skip a group.
+- `--stop-on-failure` — stop at the first failure.
+- `--verbose` — more diagnostics.
+- `--debug` — print test names as they run (useful when a test hangs).
+
+For test-writing patterns (fixtures, the Publisher capture filter, in-flight race simulation), see the **test** skill.
+
+### Local (without wp-env)
+
+If you have a local MySQL and the `WP_TESTS_*` env vars configured, you can run the suite without Docker:
+
+```bash
+composer test
+vendor/bin/phpunit --filter=pattern
+```
+
+## Code Coverage
+
+Restart `wp-env` with Xdebug in coverage mode:
+
+```bash
+npm run env-start -- --xdebug=coverage
+```
+
+Then run tests with a coverage flag:
+
+```bash
+npm run env-test -- --coverage-text                  # Terminal summary.
+npm run env-test -- --coverage-html ./coverage       # Full HTML report.
+open coverage/index.html                              # macOS.
+```
+
+`phpunit.xml.dist` scopes coverage to `includes/`.
+
+## Troubleshooting
+
+### "Docker is not running"
+
+```bash
+open -a Docker          # macOS.
+# Wait for the daemon to start, then retry.
+npm run env-start
+```
+
+### Port already in use
+
+The `env-start` script passes `--auto-port`, so `wp-env` normally picks a free port automatically. If it still fails:
+
+```bash
+lsof -i :8884
+kill -9 <PID>
+# Or pick a different port.
+npm run env-start -- --port=8886
+```
+
+### "Error establishing database connection"
+
+```bash
+npm run env-stop
+npm run env-start
+# Still broken? Clear dangling containers and try again.
+docker system prune -f
+```
+
+### Plugin not activated in the test environment
+
+```bash
+npm run env -- run cli wp plugin activate atmosphere
+npm run env -- run cli wp plugin list --status=active
+```
+
+### Slow performance on macOS
+
+- Increase Docker CPU/RAM in Docker Desktop → Settings → Resources.
+- Enable VirtioFS in Docker Desktop → Settings → General.
+- Exclude `node_modules`, `vendor`, `.git` from Spotlight / Time Machine watchers.
+
+### Verbose wp-env output
+
+```bash
+DEBUG=wp-env:* npm run env-start
+```
+
+## Environment Variables
+
+`wp-env` understands these:
+
+- `WP_ENV_HOME` — wp-env home directory.
+- `WP_ENV_PORT` — WordPress port.
+- `WP_ENV_TESTS_PORT` — tests port.
+
+## Next Steps
+
+- [PHP Coding Standards](php-coding-standards.md) — naming, escaping, error handling, performance.
+- [Class Structure](php-class-structure.md) — directory layout and architectural patterns.
+- [Code Linting](code-linting.md) — PHPCS rules and how to fix common findings.
+- [Pull Request Guide](pull-request.md) — branch naming, checklists, commit format.
+- [Release Process](release-process.md) — `npm run release` and patch-release workflow.

--- a/docs/php-class-structure.md
+++ b/docs/php-class-structure.md
@@ -1,0 +1,329 @@
+# Class Structure and Organization
+
+## Table of Contents
+- [Directory Layout](#directory-layout)
+- [Core Components](#core-components)
+- [Namespace Organization](#namespace-organization)
+- [File Placement Guidelines](#file-placement-guidelines)
+- [Architectural Patterns](#architectural-patterns)
+- [Class Design Patterns](#class-design-patterns)
+
+## Directory Layout
+
+```
+wordpress-atmosphere/
+├── atmosphere.php                  # Main plugin file (header, bootstrap, autoloader registration).
+├── uninstall.php                   # WordPress uninstall hook — removes meta, options, scheduled events.
+│
+├── includes/                       # Core plugin code.
+│   ├── class-atmosphere.php        # Plugin orchestration; rewrite rules + well-known handlers; cron registration.
+│   ├── class-api.php               # DPoP-authenticated PDS request layer with nonce retry.
+│   ├── class-autoloader.php        # Custom classmap autoloader.
+│   ├── class-backfill.php          # Bulk re-sync of existing posts.
+│   ├── class-handle.php            # Domain-handle setup helper (writes /.well-known/atproto-did).
+│   ├── class-post-types.php        # Supported post-type discovery and option storage.
+│   ├── class-publisher.php         # Atomic applyWrites for both Bluesky post + standard.site document.
+│   ├── class-reaction-sync.php     # Mirrors Bluesky reactions back to WordPress comments.
+│   ├── functions.php               # Helper functions (loaded via Composer `files`).
+│   │
+│   ├── content-parser/             # Pluggable content formats for site.standard.document.
+│   │   └── interface-content-parser.php
+│   │
+│   ├── oauth/                      # Native OAuth flow (PKCE + DPoP + PAR).
+│   │   ├── class-client.php        # OAuth lifecycle (authorize, callback, refresh, disconnect).
+│   │   ├── class-dpop.php          # ES256 DPoP proof generation.
+│   │   ├── class-encryption.php    # libsodium token / key encryption at rest.
+│   │   ├── class-nonce-storage.php # DPoP nonce persistence.
+│   │   └── class-resolver.php      # handle → DID → PDS → auth server resolution chain.
+│   │
+│   ├── transformer/                # WordPress → AT Protocol record transformers.
+│   │   ├── class-base.php          # Abstract base.
+│   │   ├── class-comment.php       # Comment → app.bsky.feed.post (reply).
+│   │   ├── class-document.php      # Post → site.standard.document.
+│   │   ├── class-facet.php         # Detects links, mentions, hashtags in post text.
+│   │   ├── class-post.php          # Post → app.bsky.feed.post.
+│   │   ├── class-publication.php   # Site → site.standard.publication.
+│   │   └── class-tid.php           # AT Protocol Timestamp ID generation.
+│   │
+│   └── wp-admin/                   # Admin functionality.
+│       └── class-admin.php         # Settings page, sidebar panel, REST handlers.
+│
+├── integrations/                   # Third-party plugin integrations.
+│   └── class-load.php              # Integration loader stub.
+│
+├── templates/                      # PHP template files.
+├── assets/                         # CSS and JS.
+├── bin/                            # Build/release scripts (release.js, install-wp-tests.sh).
+├── docs/                           # This directory.
+└── tests/
+    └── phpunit/                    # PHPUnit tests, mirroring `includes/`.
+```
+
+## Core Components
+
+### Plugin Bootstrap (`atmosphere.php`)
+
+The main file registers the autoloader, defines `ATMOSPHERE_VERSION` and path constants, instantiates `Atmosphere\Atmosphere`, and wires plugin activation / deactivation / uninstall.
+
+### Atmosphere (`includes/class-atmosphere.php`)
+
+Plugin orchestration class:
+
+- Registers rewrite rules + `template_redirect` handlers for `/.well-known/atproto-did` and `/.well-known/site.standard.publication`. All share the `atmosphere_wellknown` query var.
+- Registers async cron hooks (`register_async_hooks()`) that delegate to the Publisher / Reaction_Sync.
+- Listens on `transition_post_status` and comment-status transitions to schedule cross-post / update / delete jobs.
+
+### API (`includes/class-api.php`)
+
+DPoP-authenticated PDS request layer:
+
+- `apply_writes( array $writes )` — the only PDS write path. Filters through `atmosphere_pre_apply_writes` first for test interception.
+- Handles DPoP nonce retry transparently: on `use_dpop_nonce` server hint, recompute the proof with the new nonce and retry once.
+- Returns `WP_Error` for non-2xx PDS responses, with `data.status` set to the HTTP code so callers can branch on transient vs permanent failures.
+
+### Publisher (`includes/class-publisher.php`)
+
+Atomic batch publish path:
+
+- `publish_post()` — initial publish of a WordPress post (single record + document, or a teaser thread).
+- `update_post()` — in-place update or destructive rewrite based on whether the new record count matches the stored count.
+- `delete_post()` / `delete_post_by_tids()` — removes both Bluesky and document records.
+- `publish_comment()` — cross-posts a WordPress comment as a Bluesky reply.
+
+### Transformers (`includes/transformer/`)
+
+Convert WordPress objects to AT Protocol records. Extend `Atmosphere\Transformer\Base`:
+
+```php
+namespace Atmosphere\Transformer;
+
+abstract class Base {
+    /**
+     * Build the AT Protocol record array.
+     *
+     * @return array
+     */
+    abstract public function transform(): array;
+
+    /**
+     * The collection (NSID) this transformer writes to.
+     */
+    abstract public function get_collection(): string;
+
+    /**
+     * Reserve or return the rkey (TID) for this record.
+     *
+     * Writes Post::META_TID (or the equivalent) on first call so
+     * the rkey is reused across retries.
+     */
+    abstract public function get_rkey(): string;
+}
+```
+
+Concrete transformers:
+
+| Class | Produces |
+|-------|----------|
+| `Atmosphere\Transformer\Post` | `app.bsky.feed.post` (short-form + teaser-thread variants). |
+| `Atmosphere\Transformer\Comment` | `app.bsky.feed.post` reply under a cross-posted record. |
+| `Atmosphere\Transformer\Document` | `site.standard.document`. |
+| `Atmosphere\Transformer\Publication` | `site.standard.publication`. |
+
+`Atmosphere\Transformer\Facet` is a helper, not a record producer — it detects links, mentions, and hashtags in post text. `Atmosphere\Transformer\TID` generates Timestamp IDs.
+
+### OAuth (`includes/oauth/`)
+
+Full PKCE + DPoP + PAR native OAuth flow. The handle → DID → PDS → Auth Server resolution chain is implemented across `class-resolver.php` (resolution) and `class-client.php` (OAuth lifecycle). DPoP proofs are generated in `class-dpop.php` (ES256). Tokens and the DPoP private key are encrypted at rest via `class-encryption.php` (libsodium).
+
+### Reaction Sync (`includes/class-reaction-sync.php`)
+
+Periodically polls the PDS for notifications and self-collections (`app.bsky.feed.like`, `app.bsky.feed.repost`, `app.bsky.feed.post`) and stores them as WordPress comments. Replies become regular comments; likes and reposts become dedicated comment types so they show up as engagement counts.
+
+### Content Parser (`includes/content-parser/`)
+
+Provides the `Atmosphere\Content_Parser\Content_Parser` interface for plugins that want to populate the `content` field of `site.standard.document` records (see [`docs/content-formats.md`](content-formats.md)). The plugin ships only the interface — concrete parsers register through the `atmosphere_content_parser` filter from `integrations/` or third-party plugins.
+
+## Namespace Organization
+
+```php
+// Root namespace.
+namespace Atmosphere;
+
+// Feature namespaces.
+namespace Atmosphere\OAuth;
+namespace Atmosphere\Transformer;
+namespace Atmosphere\Content_Parser;
+namespace Atmosphere\Integrations;
+namespace Atmosphere\WP_Admin;
+namespace Atmosphere\Tests;
+```
+
+### Using Namespaces
+
+```php
+<?php
+namespace Atmosphere;
+
+use Atmosphere\OAuth\Client;
+use Atmosphere\Transformer\Post;
+use Atmosphere\Transformer\Document;
+use function Atmosphere\is_connected;
+use function Atmosphere\get_did;
+
+class Publisher {
+    public static function publish_post( \WP_Post $post ) {
+        // Imported classes used unqualified.
+        $bsky = new Post( $post );
+        $doc  = new Document( $post );
+
+        // WordPress and PHP globals are backslash-prefixed.
+        if ( ! is_connected() ) {
+            return new \WP_Error( 'atmosphere_not_connected', \__( 'Not connected.', 'atmosphere' ) );
+        }
+    }
+}
+```
+
+## File Placement Guidelines
+
+### File Naming Rules
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Class | `class-{name}.php` | `class-publisher.php` |
+| Trait | `trait-{name}.php` | `trait-singleton.php` |
+| Interface | `interface-{name}.php` | `interface-content-parser.php` |
+| Functions | `functions.php` | `includes/functions.php` |
+| Templates | `{name}.php` | `templates/admin-settings.php` |
+
+### Where to Place New Classes
+
+| Class Type | Location | Namespace |
+|------------|----------|-----------|
+| Core functionality | `includes/` | `Atmosphere` |
+| AT Protocol record transformers | `includes/transformer/` | `Atmosphere\Transformer` |
+| OAuth flow components | `includes/oauth/` | `Atmosphere\OAuth` |
+| Content parsers (NSID-typed `content` producers) | `includes/content-parser/` | `Atmosphere\Content_Parser` |
+| Admin screens / REST handlers | `includes/wp-admin/` | `Atmosphere\WP_Admin` |
+| Third-party plugin integrations | `integrations/` | `Atmosphere\Integrations` |
+
+### Creating a New Subdirectory
+
+Add one when you have:
+
+- Multiple related classes (3+) that form a cohesive subsystem.
+- A clear domain boundary (e.g. all OAuth-flow concerns live in `oauth/`).
+- A reason to keep the concerns from leaking into surrounding files.
+
+After adding or renaming a class file, run `composer dump-autoload` so the Composer classmap picks it up.
+
+## Architectural Patterns
+
+### Transformer Pattern
+
+The transformer pattern (`includes/transformer/`) is the canonical way to add a new AT Protocol record type:
+
+```php
+namespace Atmosphere\Transformer;
+
+class Custom_Record extends Base {
+    public function transform(): array {
+        return array(
+            '$type'     => 'app.example.record',
+            'createdAt' => to_iso8601( $this->object->post_date_gmt ),
+            // ...
+        );
+    }
+
+    public function get_collection(): string {
+        return 'app.example.record';
+    }
+
+    public function get_rkey(): string {
+        $rkey = \get_post_meta( $this->object->ID, self::META_TID, true );
+        if ( ! $rkey ) {
+            $rkey = TID::generate();
+            \update_post_meta( $this->object->ID, self::META_TID, $rkey );
+        }
+        return $rkey;
+    }
+}
+```
+
+Always reserve the rkey at the start of `get_rkey()` and persist it via meta. The reserved rkey survives a failed publish and is reused on retry — this is the marker that distinguishes "pristine post" from "failed prior attempt" in `Publisher::update_post()`.
+
+### Static Initialization
+
+```php
+class Feature {
+    public static function init(): void {
+        \add_action( 'init', array( self::class, 'register' ) );
+        \add_filter( 'the_content', array( self::class, 'filter' ) );
+    }
+
+    public static function register(): void {
+        // Registration logic.
+    }
+}
+```
+
+Most plugin classes are static — there's no per-request state worth carrying in instances. Use `self::class` for callback strings rather than hardcoding the FQCN.
+
+### Singleton (use sparingly)
+
+```php
+class Manager {
+    private static ?self $instance = null;
+
+    private function __construct() {}
+
+    public static function get_instance(): self {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+}
+```
+
+Singletons make tests harder; prefer static helper classes unless you genuinely need lazy initialisation.
+
+### Factory
+
+```php
+namespace Atmosphere\Transformer;
+
+class Factory {
+    public static function for_object( $object ): Base {
+        if ( $object instanceof \WP_Post ) {
+            return new Post( $object );
+        }
+        if ( $object instanceof \WP_Comment ) {
+            return new Comment( $object );
+        }
+        throw new \InvalidArgumentException( 'Unsupported object type.' );
+    }
+}
+```
+
+### Integration Loader
+
+`integrations/class-load.php` is the canonical entry point for plugin-specific integrations. Conditional registration based on plugin detection:
+
+```php
+namespace Atmosphere\Integrations;
+
+class Load {
+    public static function init(): void {
+        \add_action( 'plugins_loaded', array( self::class, 'register' ), 20 );
+    }
+
+    public static function register(): void {
+        if ( \defined( 'JETPACK__VERSION' ) ) {
+            Jetpack::init();
+        }
+    }
+}
+```
+
+See [`integrations/README.md`](../integrations/README.md) for the full pattern, including how `atmosphere_content_parser` and `atmosphere_document_content` filters compose.

--- a/docs/php-coding-standards.md
+++ b/docs/php-coding-standards.md
@@ -1,0 +1,531 @@
+# PHP Coding Standards Reference
+
+## Table of Contents
+- [WordPress Coding Standards](#wordpress-coding-standards)
+- [File Organization](#file-organization)
+- [Naming Conventions](#naming-conventions)
+- [Namespaces and Imports](#namespaces-and-imports)
+- [Hook Patterns](#hook-patterns)
+- [Documentation Standards](#documentation-standards)
+- [Security Practices](#security-practices)
+- [Performance Considerations](#performance-considerations)
+- [Error Handling](#error-handling)
+- [Cron-Specific Rules](#cron-specific-rules)
+
+## WordPress Coding Standards
+
+The ATmosphere plugin follows the WordPress Coding Standards (WPCS) with the following PHPCS configuration:
+
+| Standard | Purpose |
+|----------|---------|
+| **WordPress** | Full WordPress Coding Standards. |
+| **PHPCompatibility** | PHP 8.2+ compatibility (matches `Requires PHP` in `atmosphere.php`). |
+| **PHPCompatibilityWP** | WordPress 6.2+ compatibility (matches `Requires at least` in `readme.txt`). |
+| **VariableAnalysis** | Flags undefined or unused variables. |
+
+The full ruleset lives in `phpcs.xml`. Run `composer lint` to check and `composer lint:fix` to auto-fix what can be fixed.
+
+### Indentation and Spacing
+
+```php
+// Tabs for indentation.
+function example_function() {
+→   $variable = 'value';
+→   if ( $condition ) {
+→   →   do_something();
+→   }
+}
+
+// Spaces inside parentheses.
+if ( $condition ) {       // Correct.
+if ($condition) {         // Incorrect.
+
+// Spaces around operators.
+$sum = $a + $b;
+
+// Use array() — not the short syntax [].
+$array = array(
+→   'key_one'   => 'value',
+→   'key_two'   => 'value',
+→   'key_three' => 'value',
+);
+```
+
+### Control Structures
+
+```php
+if ( $condition ) {
+→   // Code.
+} elseif ( $other_condition ) {
+→   // Code.
+} else {
+→   // Code.
+}
+
+switch ( $variable ) {
+→   case 'value1':
+→   →   do_something();
+→   →   break;
+
+→   case 'value2':
+→   →   do_something_else();
+→   →   break;
+
+→   default:
+→   →   do_default();
+}
+
+foreach ( $items as $key => $item ) {
+→   process_item( $item );
+}
+```
+
+### Yoda Conditions
+
+Yoda conditions are preferred for value-against-variable comparisons, to prevent accidental assignment:
+
+```php
+if ( 'value' === $variable ) {
+if ( true === $condition ) {
+if ( null !== $result ) {
+```
+
+Readable conditions (no value-on-the-left to flip) are fine without Yoda:
+
+```php
+if ( $user->has_cap( 'edit_posts' ) ) {
+if ( \is_array( $data ) ) {
+```
+
+## File Organization
+
+### File Naming Patterns
+
+```
+class-{name}.php         # Regular classes.
+trait-{name}.php         # Traits.
+interface-{name}.php     # Interfaces (e.g. interface-content-parser.php).
+functions.php            # Global functions.
+```
+
+### File Header Template
+
+```php
+<?php
+/**
+ * {Feature} class file.
+ *
+ * @package Atmosphere
+ * @subpackage {Component}
+ * @since {version}
+ */
+
+namespace Atmosphere\{Component};
+
+use Atmosphere\Other\Class;
+use WP_Error;
+
+/**
+ * {Feature} Class.
+ *
+ * Handles {what the class does}.
+ *
+ * @since {version}
+ */
+class {Feature} {
+```
+
+Use the literal `unreleased` for `@since` and `@deprecated` markers on new code — the release script rewrites them at release time.
+
+## Naming Conventions
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| **Classes** | `Pascal_Snake_Case` | `class Reaction_Sync` |
+| **Methods** | `snake_case` | `public function get_rkey()` |
+| **Functions** | `snake_case` | `function to_iso8601()` |
+| **Properties** | `snake_case` | `private $access_token` |
+| **Constants** | `UPPER_SNAKE_CASE` | `const META_TID = '_atmosphere_bsky_tid';` |
+| **Hooks** | `snake_case`, `atmosphere_` prefix | `\apply_filters( 'atmosphere_should_publish_comment', … );` |
+| **Files** | `hyphen-case`, `class-` prefix | `class-reaction-sync.php` |
+| **Namespaces** | `PascalCase`, one segment per directory | `namespace Atmosphere\OAuth;` |
+
+### Text Domain
+
+Always use `'atmosphere'`:
+
+```php
+\__( 'Text', 'atmosphere' );
+\esc_html_e( 'Text', 'atmosphere' );
+\_n( 'one', 'many', $count, 'atmosphere' );
+```
+
+## Namespaces and Imports
+
+### Backslash-prefix global functions
+
+WordPress and PHP global functions are always backslash-prefixed in namespaced code. This is a project convention — PHP would fall back to the global scope anyway, but the explicit backslash makes the global call site visible at a glance and prevents accidental shadowing:
+
+```php
+\get_option( 'atmosphere_settings' );
+\add_action( 'init', …, );
+\apply_filters( 'atmosphere_should_publish_comment', $bool, $comment );
+\is_wp_error( $result );
+\strlen( $body );
+\time();
+```
+
+### Use `use` imports for cross-namespace references
+
+Never inline `\Atmosphere\OAuth\Client` — import it once at the top of the file:
+
+```php
+use Atmosphere\OAuth\Client;
+use Atmosphere\Transformer\Post;
+use function Atmosphere\get_did;
+use function Atmosphere\is_connected;
+```
+
+## Hook Patterns
+
+### Naming
+
+```php
+// Filters return a value; actions are fire-and-forget.
+\apply_filters( 'atmosphere_{subject}',           $value );
+\apply_filters( 'atmosphere_{subject}_{context}', $value, $extra );
+\do_action(     'atmosphere_{event}',             $context… );
+```
+
+### Public Hooks (Atmosphere ships these)
+
+**Transform filters** (mutate the record array before write):
+```php
+\apply_filters( 'atmosphere_transform_bsky_post',   $record, $post );
+\apply_filters( 'atmosphere_transform_comment',     $record, $comment );
+\apply_filters( 'atmosphere_transform_document',    $record, $post );
+\apply_filters( 'atmosphere_transform_publication', $record );
+```
+
+**Content / composition filters:**
+```php
+\apply_filters( 'atmosphere_content_parser',        $parser, $post );        // Return a Content_Parser instance.
+\apply_filters( 'atmosphere_document_content',      $content, $post, $parser );
+\apply_filters( 'atmosphere_long_form_composition', $composition, $post );
+\apply_filters( 'atmosphere_teaser_thread_posts',   $max_posts, $post );
+```
+
+**Behaviour / gating filters:**
+```php
+\apply_filters( 'atmosphere_syncable_post_types',     array( 'post' ) );
+\apply_filters( 'atmosphere_should_publish_comment',  $bool, $comment );
+\apply_filters( 'atmosphere_should_sync_reply',       $bool, $notification, $post_id );
+\apply_filters( 'atmosphere_backfill_limit',          50 );
+\apply_filters( 'atmosphere_oauth_redirect_uri',      $uri );
+\apply_filters( 'atmosphere_client_metadata',         $metadata );
+```
+
+**Actions:**
+```php
+\do_action( 'atmosphere_publishing' );                                            // Once per publish/update/delete cycle (loop guard).
+\do_action( 'atmosphere_publish_post_result',          $post, $result );
+\do_action( 'atmosphere_publish_comment_result',       $comment, $result );
+\do_action( 'atmosphere_update_skipped_unsynced_post', $post );
+\do_action( 'atmosphere_long_form_strategy_downgraded', $post, $from, $to );
+\do_action( 'atmosphere_reaction_synced', $comment_id, $notification, $post_id, $comment_type );
+```
+
+**Test-only short-circuit:**
+```php
+\apply_filters( 'atmosphere_pre_apply_writes', null, $writes );
+```
+
+## Documentation Standards
+
+### Class
+
+```php
+/**
+ * Short description (one line).
+ *
+ * Longer description. Multiple paragraphs are fine.
+ *
+ * @since 1.0.0
+ *
+ * @see Related_Class
+ */
+class Example_Class {
+```
+
+### Method
+
+```php
+/**
+ * Get the stored thread records for a post.
+ *
+ * @since 1.0.0
+ *
+ * @param int $post_id Post ID.
+ * @return array[]|\WP_Error Array of records on success, WP_Error on failure.
+ */
+public function stored_thread_records( $post_id ) {
+```
+
+### Property
+
+```php
+/**
+ * Cache of resolved DIDs, keyed by handle.
+ *
+ * @since 1.0.0
+ *
+ * @var array<string, string>
+ */
+private static $did_cache = array();
+```
+
+### Inline Comments
+
+- Single-line `//` for brief clarifications.
+- Block `/* */` for multi-line context. Avoid stacking consecutive `//` lines for a paragraph — use a block comment instead.
+- `/**` DocBlocks are for functions, classes, methods, properties, and constants.
+
+```php
+// Single-line clarification.
+
+/*
+ * Multi-line block comment for context that spans
+ * more than one line.
+ */
+
+// TODO: Implement caching.
+// FIXME: Handle the edge case when the PDS returns 410.
+// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- Needed for batch insert performance.
+```
+
+## Security Practices
+
+### Input Sanitization
+
+```php
+$text  = \sanitize_text_field( $_POST['text'] );
+$body  = \sanitize_textarea_field( $_POST['body'] );
+$url   = \sanitize_url( $_POST['url'] );
+$email = \sanitize_email( $_POST['email'] );
+$slug  = \sanitize_key( $_POST['slug'] );
+$int   = \absint( $_POST['count'] );
+$html  = \wp_kses_post( $_POST['html'] );
+```
+
+### Output Escaping
+
+```php
+echo \esc_html( $text );
+echo \esc_html__( 'Translatable text', 'atmosphere' );
+
+echo '<input value="' . \esc_attr( $value ) . '">';
+echo '<a href="' . \esc_url( $url ) . '">Link</a>';
+
+echo '<script>var data = ' . \wp_json_encode( $data ) . ';</script>';
+```
+
+For restricted HTML:
+
+```php
+echo \wp_kses(
+    $html,
+    array(
+        'a'      => array( 'href' => array(), 'title' => array() ),
+        'br'     => array(),
+        'em'     => array(),
+        'strong' => array(),
+    )
+);
+```
+
+### Prepared SQL
+
+Never concatenate user input into a query. Always use `$wpdb->prepare()`:
+
+```php
+$sql = $wpdb->prepare(
+    "SELECT * FROM {$wpdb->prefix}atmosphere_x WHERE post_id = %d AND collection = %s",
+    $post_id,
+    $collection
+);
+```
+
+### Nonces
+
+```php
+// Issue.
+\wp_nonce_field( 'atmosphere_save_settings', 'atmosphere_nonce' );
+
+// Verify.
+if ( ! \isset( $_POST['atmosphere_nonce'] )
+    || ! \wp_verify_nonce( $_POST['atmosphere_nonce'], 'atmosphere_save_settings' ) ) {
+    \wp_die( \__( 'Security check failed.', 'atmosphere' ) );
+}
+
+// AJAX.
+\check_ajax_referer( 'atmosphere_ajax', 'nonce' );
+```
+
+### Capability Checks
+
+```php
+if ( ! \current_user_can( 'manage_options' ) ) {
+    \wp_die( \__( 'Insufficient permissions.', 'atmosphere' ) );
+}
+
+if ( ! \current_user_can( 'edit_post', $post_id ) ) {
+    return new \WP_Error( 'forbidden', \__( 'Access denied.', 'atmosphere' ) );
+}
+```
+
+### Tokens and Secrets
+
+OAuth tokens, DPoP private keys, and refresh tokens **must** go through `Atmosphere\OAuth\Encryption`. Never store or log them in plaintext.
+
+## Performance Considerations
+
+### Cache Expensive Lookups
+
+```php
+// Transients for cross-request reads.
+$cache_key = 'atmosphere_resolve_' . \md5( $handle );
+$cached    = \get_transient( $cache_key );
+
+if ( false === $cached ) {
+    $cached = self::resolve_handle( $handle );
+    \set_transient( $cache_key, $cached, \HOUR_IN_SECONDS );
+}
+
+// Object cache.
+\wp_cache_set( 'atmosphere_did_' . $handle, $did, 'atmosphere', \HOUR_IN_SECONDS );
+
+// Per-request static cache for hot paths.
+class Resolver {
+    private static $cache = array();
+
+    public static function get( $handle ) {
+        if ( ! isset( self::$cache[ $handle ] ) ) {
+            self::$cache[ $handle ] = self::resolve( $handle );
+        }
+        return self::$cache[ $handle ];
+    }
+}
+```
+
+### Cap Unbounded Collections
+
+Any list-like meta or PDS response must have a hard upper bound. Example: `Publisher::record_thread_rollback_failure()` caps `META_ORPHAN_RECORDS` at 10 entries so a stuck cron can't grow a `wp_postmeta` row past `max_allowed_packet`. Follow the same pattern when adding new manifests.
+
+### Database
+
+```php
+// Use get_posts() with `fields => 'ids'` if you only need IDs.
+$ids = \get_posts( array(
+    'post_type'      => 'post',
+    'posts_per_page' => 50,
+    'fields'         => 'ids',
+    'meta_key'       => Post::META_URI,
+) );
+
+// Batch inserts when looping is otherwise N queries.
+$values = array();
+foreach ( $items as $item ) {
+    $values[] = $wpdb->prepare( '(%s, %s)', $item['key'], $item['value'] );
+}
+if ( $values ) {
+    $wpdb->query( "INSERT INTO {$table} (key, value) VALUES " . implode( ',', $values ) );
+}
+```
+
+## Error Handling
+
+### Returning Errors
+
+```php
+return new \WP_Error(
+    'atmosphere_pds_unreachable',
+    \__( 'PDS could not be reached.', 'atmosphere' ),
+    array( 'status' => 502, 'pds' => $pds )
+);
+```
+
+Use error codes prefixed with `atmosphere_` so callers can pattern-match. Include any context that helps the caller decide on retry / fallback.
+
+### Checking Errors
+
+```php
+$result = API::apply_writes( $writes );
+
+if ( \is_wp_error( $result ) ) {
+    self::log_cron_error( 'publish_post', $post_id, $result );
+    return $result;
+}
+```
+
+### Aggregating
+
+```php
+$errors = new \WP_Error();
+
+if ( empty( $args['handle'] ) ) {
+    $errors->add( 'missing_handle', \__( 'Handle is required.', 'atmosphere' ) );
+}
+if ( empty( $args['pds'] ) ) {
+    $errors->add( 'missing_pds', \__( 'PDS is required.', 'atmosphere' ) );
+}
+
+if ( $errors->has_errors() ) {
+    return $errors;
+}
+```
+
+### Exceptions
+
+```php
+try {
+    $result = self::risky_operation();
+} catch ( \Exception $e ) {
+    // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- log for operators.
+    \error_log( '[atmosphere] ' . $e->getMessage() );
+    return new \WP_Error( 'atmosphere_exception', $e->getMessage(), array( 'code' => $e->getCode() ) );
+}
+```
+
+## Cron-Specific Rules
+
+### Three-Way Symmetry
+
+Every plugin-owned `wp_schedule_*` hook **MUST** appear in `Atmosphere\get_cron_hooks()` (`includes/functions.php`). That single list is consumed by:
+
+- `Atmosphere\deactivate()` (`atmosphere.php`)
+- `Atmosphere\OAuth\Client::disconnect()` (`includes/oauth/class-client.php`)
+- `uninstall.php`
+
+When adding a new cron hook:
+
+1. Add it to `get_cron_hooks()` — do not duplicate the literal in deactivate / disconnect / uninstall.
+2. If the handler issues PDS writes without re-checking `is_connected()` (e.g. `atmosphere_delete_records`, `atmosphere_delete_comment_record`), the symmetry is load-bearing — a queued event from a previous connection would otherwise fire against a different repo on reconnect.
+3. If the handler stores or sweeps post/comment meta keys, mirror those keys in `uninstall.php`.
+
+This pattern was extracted in PR #32; see review by @kraftbj for the cross-install risk that motivated it.
+
+### Never Swallow `WP_Error`
+
+Cron handlers in `register_async_hooks()` MUST surface `Publisher::*` errors via `error_log()` — typically through `log_cron_error()`. `wp_schedule_single_event` does not retry, so a silent drop loses the only signal operators have for transient PDS failures, expired refresh tokens, or DPoP nonce drift.
+
+When the handler operates on records the caller has already lost local state for (e.g. `atmosphere_delete_comment_record` after the WP comment row is gone), include the TID/identifier in the log line so the orphan is recoverable manually.
+
+### Inflight-State Races
+
+When a cron handler writes meta both *before* an `apply_writes` call (e.g. `Comment::get_rkey()` persists `META_TID`) and *after* (e.g. `store_comment_result()` writes `META_URI`), and a concurrent state change can short-circuit the cleanup gates that key off the *post-call* meta, the handler MUST re-check eligibility after the call returns and roll back if needed.
+
+Concrete pattern: `atmosphere_publish_comment` → `reconcile_comment_after_publish()`. Re-fetch the WP object, re-run the eligibility gate, schedule the orphan-cleanup cron (not direct delete) so transient PDS failures retry through the standard channel.
+
+### Idempotency
+
+The same cron callback can fire twice — concurrent workers, plugin deactivate→reactivate (which re-runs `register_schedules()`), `wp cron event run`, or traffic spikes triggering overlapping loopback requests. If the handler has user-visible side effects (a Bluesky post, a mirrored reaction), gate on a meta sentinel **before** the side effect, not after.

--- a/docs/pull-request.md
+++ b/docs/pull-request.md
@@ -1,0 +1,300 @@
+# Pull Request Guide
+
+This guide covers the complete lifecycle of a pull request — from planning to merge.
+
+## Table of Contents
+- [Planning Your PR](#planning-your-pr)
+- [Creating a Branch](#creating-a-branch)
+- [Development Process](#development-process)
+- [Changelog Entry](#changelog-entry)
+- [Before Creating the PR](#before-creating-the-pr)
+- [Creating the PR](#creating-the-pr)
+- [After Creating the PR](#after-creating-the-pr)
+- [Before Merge](#before-merge)
+- [Commit Message Guidelines](#commit-message-guidelines)
+- [Special Situations](#special-situations)
+- [Common Review Feedback](#common-review-feedback)
+- [Labels](#labels)
+
+## Planning Your PR
+
+**Break large features into small pieces — one PR per piece.** Long-running branches are harder to review, more likely to conflict with `trunk`, and tend to ship subtly different code than what was reviewed. If a PR grows past ~3 logical changes or its description starts needing sub-headings for distinct features, split it.
+
+## Creating a Branch
+
+All branches are cut from the latest `trunk`:
+
+| Prefix | Use |
+|--------|-----|
+| `add/{something}` | New feature. |
+| `update/{something}` | Iterating on an existing feature. |
+| `fix/{something}` | Bug fix. |
+| `try/{something}` | Experimental idea — open as a draft. |
+
+**Reserved branch names:**
+
+- `release/{X.Y.Z}` — owned by the release script (`npm run release`). Do not create these by hand.
+- `trunk` — the integration branch.
+
+```bash
+git checkout trunk && git pull origin trunk
+git checkout -b fix/notification-issue
+```
+
+## Development Process
+
+### Develop and Commit
+
+- Push your changes out frequently. Smaller commits are easier to review and reduce merge pain.
+- Don't be afraid to rewrite history on a feature branch you own. Force-push with `--force-with-lease` (never plain `--force`) so you don't clobber someone else's push.
+- Squash typo fixes and review-feedback commits into the original commits before review (or use [fixup commits with autosquash](http://fle.github.io/git-tip-keep-your-branch-clean-with-fixup-and-autosquash.html)).
+- If you have [Composer installed](https://getcomposer.org/), run `composer lint` on the files you changed.
+
+### Splitting Mid-PR
+
+If the change grows beyond what fits in one focused PR, comment in the PR explaining the split, open the smaller follow-ups, and link them. Reviewers far prefer two small PRs to one sprawling one.
+
+## Changelog Entry
+
+Every PR must either:
+
+- Include a changelog file in `.github/changelog/`, **or**
+- Be labelled `Skip Changelog`.
+
+```bash
+composer changelog:add
+```
+
+The prompts walk through `Significance` (Patch / Minor / Major), `Type` (Added / Changed / Deprecated / Removed / Fixed / Security), and the message. The file is written to `.github/changelog/{slug}` — commit it on the same branch as your code change, not as a follow-up.
+
+### Writing good entries
+
+**Always end the message with punctuation:**
+
+```
+Good: Add support for custom post types.
+Good: Fix OAuth token refresh failing silently.
+Bad:  Add support for custom post types
+Bad:  Fix OAuth token refresh failing silently
+```
+
+**Write for end users, not developers.** Messages appear in the WordPress update screen and in `readme.txt`:
+
+```
+Good: Fix posts not appearing on Bluesky when published via Quick Edit.
+Good: Add option to disable standard.site document records.
+Bad:  Refactor Publisher class to handle edge case in applyWrites batch.
+Bad:  Fix TID collision in transformer output.
+```
+
+**Never reference AI tools, coding assistants, or internal class / method names** in the message.
+
+See the [Release Process](release-process.md) for the full pipeline that consumes these entries.
+
+## Before Creating the PR
+
+Walk this checklist. Required checks are blocking.
+
+### Code preparation
+- [ ] Branch cut from latest `trunk`.
+- [ ] Branch follows the `add/` / `update/` / `fix/` / `try/` convention.
+- [ ] Changes are focused and single-purpose.
+- [ ] No debug code, `var_dump`, `console.log`, or temporary `error_log` calls left in.
+- [ ] Code follows [WordPress Coding Standards](php-coding-standards.md) and the project's [class structure](php-class-structure.md).
+
+### Testing
+- [ ] PHP tests pass: `npm run env-test`.
+- [ ] Linting passes: `composer lint`.
+- [ ] New behaviour is covered by a test where reasonable.
+- [ ] No regressions in adjacent features (run the full suite, not just `--filter`).
+
+### Documentation
+- [ ] Changelog entry created via `composer changelog:add` and committed, **or** `Skip Changelog` will be applied.
+- [ ] Changelog message ends with punctuation and is end-user friendly.
+- [ ] Inline docblocks added or updated for new / changed public methods, hooks, constants.
+- [ ] `README.md` / `readme.txt` updated if a user-visible feature changed.
+- [ ] Relevant doc in `docs/` updated if architecture changed.
+
+### Code review
+- [ ] Delegate the diff to the **code-review** agent and address every critical finding before opening the PR.
+
+## Creating the PR
+
+Use the template at `.github/PULL_REQUEST_TEMPLATE.md` — don't invent custom formatting.
+
+```bash
+gh pr create --assignee @me
+```
+
+Every PR must:
+
+- Be assigned to the author (`--assignee @me`).
+- Include a changelog file **or** the `Skip Changelog` label.
+- Have PHPCS + PHPUnit green.
+- Merge cleanly with `trunk`.
+
+### PR description
+- [ ] Clear, descriptive title (under ~70 characters).
+- [ ] Summary section explains *why*, not just *what* — the diff covers *what*.
+- [ ] Testing instructions provided. Reviewer should be able to reproduce locally.
+- [ ] Screenshots attached for any visual change (before / after).
+- [ ] Linked issue (if applicable).
+
+### Required checks
+- [ ] All CI checks at the bottom of the PR are green.
+- [ ] Branch merges cleanly. Rebase against `trunk` if there are conflicts.
+- [ ] Changelog entry committed (or `Skip Changelog` label set).
+- [ ] If the change is visual, before-and-after screenshots are in the PR description.
+- [ ] If possible, add unit tests.
+- [ ] Helpful testing instructions for the reviewer.
+
+## After Creating the PR
+
+### CI/CD
+- [ ] All CI checks passing.
+- [ ] No merge conflicts with `trunk`.
+- [ ] Code coverage maintained or improved.
+
+### Review process
+- [ ] Reply to every review comment inline.
+- [ ] Mark resolved threads as resolved.
+- [ ] Re-request review after addressing feedback.
+- [ ] If review surfaces a scope that should be its own PR, open a follow-up — don't expand the current PR.
+
+## Before Merge
+
+### Final checks
+- [ ] Branch is up to date with `trunk`.
+- [ ] All review feedback addressed.
+- [ ] CI still green after the final push.
+- [ ] Changelog entry still accurate (a rebase may have stale wording).
+- [ ] No accidentally committed files (vendored deps, `.env`, screenshots in random folders).
+
+### Clean history
+- [ ] Commits are logical and well-organised.
+- [ ] Fixup commits squashed.
+- [ ] Commit messages are clear.
+- [ ] No merge commits in the branch (prefer rebase over merge for keeping the branch updated).
+
+## Commit Message Guidelines
+
+```
+Type: Brief description
+
+Longer explanation if needed.
+Multiple paragraphs are fine.
+
+Fixes #123.
+```
+
+### Types
+
+| Type | Use |
+|------|-----|
+| `Add:` | New feature. |
+| `Fix:` | Bug fix. |
+| `Update:` | Enhancement to an existing feature. |
+| `Remove:` | Removed functionality. |
+| `Refactor:` | Code restructuring without behaviour change. |
+| `Test:` | Test additions or changes only. |
+| `Docs:` | Documentation only. |
+
+### Example
+
+```
+Fix: Skip update_post fresh-publish fallback for unsynced legacy posts
+
+Routine edits of pre-Atmosphere WordPress posts no longer silently mint
+a fresh Bluesky record. The retry path for failed initial publishes
+(rkey reserved, URI never written) is preserved.
+
+Fixes Automattic/fosse#145.
+```
+
+The first line is for everyone (PR list, release notes). Use the body for *why*, not *what* — the diff already explains *what*.
+
+## Special Situations
+
+### Hotfix PR
+- [ ] Marked with the `Hotfix` label.
+- [ ] Minimal changeset.
+- [ ] Tested thoroughly despite urgency.
+- [ ] Changelog marks as `patch` release.
+
+### Breaking Change
+- [ ] Marked with the `Breaking Change` label.
+- [ ] Migration guide in the PR body.
+- [ ] Deprecation notices added (`_deprecated_function`, `apply_filters_deprecated`) for removed/renamed public symbols.
+- [ ] Major version bump indicated.
+
+### New Feature
+- [ ] `README.md` / `readme.txt` updated.
+- [ ] Documentation added in `docs/` if the feature has its own surface.
+- [ ] Performance impact assessed (mention in the PR body if non-trivial).
+- [ ] Inline examples or docs entry for any new public hook.
+
+### Bug Fix
+- [ ] Root cause identified — explain it in the PR body, not just the symptom.
+- [ ] Regression test added that points back at the issue / report.
+- [ ] Related issues linked.
+- [ ] Verified the fix doesn't break adjacent features.
+
+### Experimental
+- [ ] Use the `try/` prefix.
+- [ ] Open as a draft PR.
+- [ ] Once direction is confirmed, rename / recreate the branch under `add/` / `update/` / `fix/`.
+
+### Multi-PR Feature
+- [ ] Tracking issue opened.
+- [ ] Every related PR linked.
+- [ ] Consistent naming (`add/feature-part-1`, `add/feature-part-2`, …).
+- [ ] PRs merged in order.
+
+## Common Review Feedback
+
+If a reviewer says any of the following, you should usually act on it directly rather than push back:
+
+### Code quality
+- "Please add error handling here." — surface `WP_Error`, don't swallow.
+- "This could use a comment explaining why." — non-obvious behaviour or hidden constraints.
+- "Consider extracting this." — long methods, repeated patterns.
+- "Please add type hints." — match the rest of the file's strictness.
+
+### Testing
+- "Please add a test for this edge case."
+- "Can you verify this works with [scenario]?"
+- "What happens when [condition]?"
+
+### Documentation
+- "Please update the docblock."
+- "The changelog entry needs more detail."
+- "Can you add an example?"
+
+### Performance
+- "This could cause N+1 queries." — batch or cache.
+- "Consider caching this result." — transient or object cache.
+- "This might be expensive for large datasets." — add a hard cap or paginate.
+
+## Labels
+
+| Label | Use |
+|-------|-----|
+| `Bug` | Bug fix. |
+| `Enhancement` | New feature. |
+| `Documentation` | Documentation-only change. |
+| `Code Quality` | Refactoring, cleanup. |
+| `Breaking Change` | Public-API break. |
+| `Skip Changelog` | No changelog entry needed (docs / CI only). |
+| `Needs Review` | Ready for review. |
+| `In Progress` | Draft, still working. |
+| `Hotfix` | Urgent fix; expedite. |
+
+## Resources
+
+- [Development Environment Setup](development-environment.md)
+- [PHP Coding Standards](php-coding-standards.md)
+- [Class Structure](php-class-structure.md)
+- [Code Linting](code-linting.md)
+- [Release Process](release-process.md)
+- [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/)
+- [GitHub PR Documentation](https://docs.github.com/en/pull-requests)

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,217 @@
+# Release Process
+
+This document outlines the process for releasing the WordPress ATmosphere plugin. The process differs between major / minor releases (driven by the release script off `trunk`) and patch releases (cherry-picked onto a previous release branch).
+
+## Table of Contents
+- [Major and Minor Releases](#major-and-minor-releases)
+- [Patch Releases](#patch-releases)
+- [Changelog Management](#changelog-management)
+- [Marking Unreleased Code](#marking-unreleased-code)
+- [Version File Locations](#version-file-locations)
+- [Manual Steps Around the Release](#manual-steps-around-the-release)
+- [Troubleshooting](#troubleshooting)
+
+## Major and Minor Releases
+
+Major and minor releases share the same workflow. They are cut off `trunk` by the release script.
+
+### Steps
+
+1. **Generate the version-bump PR.**
+
+   From a clean working tree on `trunk`:
+
+   ```bash
+   npm run release
+   ```
+
+   The script (`bin/release.js`):
+
+   1. Runs `composer changelog:write` to roll up `.github/changelog/` entries into `CHANGELOG.md`. The next semver version is inferred from the entries' significance.
+   2. Creates a `release/X.Y.Z` branch off `trunk`.
+   3. Updates the version in `atmosphere.php` (plugin header `Version:` and the `ATMOSPHERE_VERSION` constant), `readme.txt` (`Stable tag:`), and `package.json`.
+   4. Mirrors the new changelog block into `readme.txt`'s `== Changelog ==` section (same-major-version history, with a trailing link to the full GitHub `CHANGELOG.md`).
+   5. Replaces `@since unreleased` / `@deprecated unreleased` and the equivalent `_deprecated_*` / `_doing_it_wrong` / `apply_filters_deprecated` literals across all `*.php` files (excluding `vendor/`).
+   6. Prompts for an optional `== Upgrade Notice ==` entry.
+   7. Commits, pushes the branch, and opens a `Release X.Y.Z` PR against `trunk` (reviewer: `Automattic/fediverse`).
+
+2. **Review and merge the PR.**
+
+   Walk the diff:
+
+   - Versions match across `atmosphere.php`, `readme.txt`, `package.json`.
+   - `CHANGELOG.md` and `readme.txt` changelog blocks match.
+   - `unreleased` markers were replaced.
+   - The Upgrade Notice (if any) makes sense to a non-technical user.
+
+   Once approved, merge into `trunk`.
+
+3. **Create the GitHub Release.**
+
+   - Repository → **Releases** → **Draft a new release**.
+   - **Choose a tag:** type `X.Y.Z`, click **Create new tag**.
+   - **Target:** `trunk`.
+   - **Previous tag:** the most recent prior tag.
+   - **Generate release notes** to seed the body.
+   - Trim the auto-generated notes to match the `CHANGELOG.md` voice (end-user friendly).
+   - Attach the distributable ZIP if one was built (see [Manual Steps](#manual-steps-around-the-release)).
+   - **Publish release.**
+
+### Prerequisites
+
+- The `gh` CLI installed and authenticated.
+- Working tree clean — the script does `git checkout trunk` + `git pull origin trunk` before branching.
+- At least one entry in `.github/changelog/` (otherwise `composer changelog:write` will fail).
+
+## Patch Releases
+
+The release script only handles major / minor. Patch releases (e.g. `1.2.1` on top of `1.2.0`) are cherry-picked onto the previous release branch manually.
+
+### Steps
+
+1. **Restore the release branch.**
+
+   Find the most recent `release/X.Y.0` branch on GitHub. If it was deleted after merge, click **Restore branch**. Then locally:
+
+   ```bash
+   git fetch origin release/X.Y.0
+   git checkout release/X.Y.0
+   ```
+
+2. **Cherry-pick the fixes from `trunk`.**
+
+   Identify the merge commits that need to ride this patch (the bottom of each PR shows the merge hash). Cherry-pick each one with `-m 1`:
+
+   ```bash
+   git cherry-pick -m 1 <merge-commit-hash>
+   ```
+
+   `-m 1` tells Git to apply the changes as they appeared on the main-branch side of the merge. Resolve conflicts as they come up.
+
+3. **Update changelog and version numbers manually.**
+
+   ```bash
+   composer changelog:write
+   ```
+
+   This adds a new section to `CHANGELOG.md` from the entries the cherry-picked PRs brought in and prints the next patch version. Then:
+
+   - Edit `readme.txt` and paste the new section into `== Changelog ==`.
+   - Bump `Version:` and `ATMOSPHERE_VERSION` in `atmosphere.php`.
+   - Bump `Stable tag` in `readme.txt`.
+   - Bump `"version"` in `package.json`.
+   - Replace any `unreleased` markers (`@since unreleased`, `_deprecated_*`, etc.) introduced by the cherry-picked commits.
+
+4. **Push and open a PR.**
+
+   ```bash
+   git push origin release/X.Y.0
+   ```
+
+   Open a PR from `release/X.Y.0` against `release/X.Y.0` for review (the patch release is merged back into its own branch, not `trunk`).
+
+5. **Create the GitHub Release.**
+
+   - Repository → **Releases** → **Draft a new release**.
+   - **Choose a tag:** type `X.Y.Z`, click **Create new tag**.
+   - **Target:** the `release/X.Y.0` branch (not `trunk`).
+   - **Previous tag:** the previous patch (or the `.0` if this is the first patch).
+   - **Generate release notes** to seed the body.
+   - **Publish release.**
+
+## Changelog Management
+
+Changelogs are managed via the [Jetpack Changelogger](https://github.com/Automattic/jetpack/tree/trunk/projects/packages/changelogger).
+
+### Add an entry
+
+```bash
+composer changelog:add
+```
+
+Prompts:
+- **Significance** — Patch / Minor / Major.
+- **Type** — Added / Changed / Deprecated / Removed / Fixed / Security.
+- **Message** — end with punctuation, end-user friendly.
+
+Result: a new file at `.github/changelog/{slug}`. Commit it on the same branch as your code change.
+
+### Write the changelog
+
+```bash
+composer changelog:write
+```
+
+Aggregates `.github/changelog/*` into `CHANGELOG.md`, picks the next semver version from the significance, and clears the changelog folder. The release script runs this automatically; you only need to invoke it directly for patch releases.
+
+See [Pull Request Guide → Changelog Entry](pull-request.md#changelog-entry) for writing guidance.
+
+## Marking Unreleased Code
+
+When adding a new public hook, deprecation, or `_doing_it_wrong` call, use the literal `unreleased` in the version slot. The release script rewrites it at release time:
+
+```php
+/**
+ * @since unreleased
+ */
+
+\_deprecated_function( __FUNCTION__, 'unreleased', 'new_function' );
+\apply_filters_deprecated( 'atmosphere_old_filter', array( $value ), 'unreleased', 'atmosphere_new_filter' );
+\_doing_it_wrong( __METHOD__, \__( 'Use new_method() instead.', 'atmosphere' ), 'unreleased' );
+```
+
+`version_compare()` callsites that gate behaviour by version can also use `'unreleased'`; the script rewrites them too.
+
+Do not hardcode a future version. Existing already-released version tags in the codebase are fine.
+
+## Version File Locations
+
+For patch releases (where the script doesn't help), bump these files:
+
+- `atmosphere.php` — plugin header `Version: X.Y.Z` and `ATMOSPHERE_VERSION` constant.
+- `readme.txt` — `Stable tag: X.Y.Z`.
+- `package.json` — `"version": "X.Y.Z"`.
+- `CHANGELOG.md` — auto-updated by `composer changelog:write`.
+- Any PHP file with `@since unreleased` / `@deprecated unreleased` introduced by the cherry-picked commits.
+
+## Manual Steps Around the Release
+
+The release script does not handle these — do them yourself:
+
+### Build the distributable ZIP
+
+After the release PR merges and the tag is in place:
+
+```bash
+git checkout X.Y.Z
+composer install --no-dev --optimize-autoloader
+git archive HEAD --format=zip -o atmosphere-X.Y.Z.zip
+```
+
+`git archive` respects `.gitattributes export-ignore`, so `tests/`, `node_modules/`, `bin/`, `docs/`, etc. don't ship in the ZIP.
+
+### Upload WordPress.org assets
+
+`.wordpress-org/` (banner, icon) is committed to git for review but lives in the wp.org plugin SVN, not the release ZIP. Push asset updates through the WordPress.org plugin team's SVN workflow.
+
+### Tag and publish the GitHub Release
+
+After the version-bump PR merges, follow the GitHub Release UI steps above. Attach the ZIP if you built one.
+
+## Troubleshooting
+
+### "Branch release/X.Y.Z already exists"
+
+The script aborts if a release branch is left over. Delete it (`git branch -D release/X.Y.Z`) and re-run. If a release PR is already open, close or finish it first.
+
+### `composer changelog:write` fails or produces an empty section
+
+No entries in `.github/changelog/`. Add at least one with `composer changelog:add` before running the release script.
+
+### Mirrored `readme.txt` changelog looks wrong
+
+The script formats `#### Type` subheadings from the Jetpack Changelogger type list and strips trailing `[#123]` PR references. If the output looks off, check the type / significance fields in each `.github/changelog/{slug}` file.
+
+### Released the wrong version
+
+Don't try to "undo" a published release. Open a follow-up patch release on top of the same `release/X.Y.0` branch and roll forward.

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,0 +1,53 @@
+# How To Translate the ATmosphere Plugin
+
+## Who translates ATmosphere? How can I get involved?
+
+Once ATmosphere is hosted on the WordPress.org plugin directory, anyone can suggest new translations through the [WordPress.org translation platform](https://translate.wordpress.org/projects/wp-plugins/atmosphere/) (link will be live after the first wp.org release).
+
+Once you've suggested a new translation, [a GlotPress validator](https://make.wordpress.org/polyglots/teams/) will review it. They will then approve, reject, or refine your suggestions. Approved changes ship automatically to all ATmosphere users running WordPress in your language.
+
+## How does GlotPress work?
+
+You can find detailed GlotPress documentation in [the WordPress Polyglots Handbook](https://make.wordpress.org/polyglots/handbook/tools/glotpress-translate-wordpress-org/).
+
+## I want to change translations locally. Where do I download the .PO file for my language?
+
+Each language page on translate.wordpress.org has options at the bottom to create and export `.PO` / `.MO` files.
+
+## I found a missing translation, but I can't find the string in GlotPress
+
+If you can't find a string in GlotPress, it may have been:
+
+- Added very recently and not yet sync'd to translate.wordpress.org.
+- Coming from a third-party integration that ships its own text domain.
+
+Open an issue on [GitHub](https://github.com/Automattic/wordpress-atmosphere/issues) with the exact text and where you saw it (admin screen, error message, post sidebar, etc.) and we'll track it down.
+
+## Plugin Text Domain
+
+ATmosphere's text domain is `'atmosphere'`. All translatable strings must pass this exact string to `__()`, `_e()`, `_x()`, `_n()`, and friends:
+
+```php
+\__( 'Connect to Bluesky', 'atmosphere' );
+\esc_html__( 'Cross-post settings', 'atmosphere' );
+\_n( '%s post', '%s posts', $count, 'atmosphere' );
+```
+
+If you're writing a third-party integration, use **your own** text domain — never `'atmosphere'`. That way your strings live in your plugin's translation file and you control them.
+
+## Writing Translation-Friendly Strings
+
+- **Full sentences, not fragments.** Translators need context. `"Saved"` is harder to translate than `"Settings saved."`.
+- **Use placeholders, not concatenation.** Languages reorder words differently. `\sprintf( \__( 'Published to %s.', 'atmosphere' ), 'Bluesky' )` works; `\__( 'Published to ', 'atmosphere' ) . 'Bluesky.'` doesn't.
+- **Use `_n()` for plurals.** Languages have more than two plural forms. `\_n( '%s reply', '%s replies', $count, 'atmosphere' )` is required for translation to work.
+- **Add context with `_x()` when the same string means different things.** `\_x( 'Post', 'verb', 'atmosphere' )` vs. `\_x( 'Post', 'noun', 'atmosphere' )`.
+- **Don't translate dynamic data.** Handles, URLs, post titles, and other user content stay as-is.
+- **Translator comments for non-obvious placeholders.** Add a `/* translators: %s is the Bluesky handle */` comment immediately before the string so the translator knows what to substitute.
+
+```php
+\sprintf(
+    /* translators: %s is the Bluesky handle the post was published as. */
+    \__( 'Posted as %s.', 'atmosphere' ),
+    $handle
+);
+```

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,47 +1,74 @@
 # Integrations
 
-Plugin-specific integrations that teach ATmosphere how to handle custom block types and content from third-party plugins.
+Plugin-specific integrations that teach ATmosphere how to format the `content` field of `site.standard.document` records for content produced by third-party plugins.
 
 ## How it works
 
-When ATmosphere converts a WordPress post to an AT Protocol record, the Markpub content parser walks through each Gutenberg block and converts it to markdown. Core blocks (paragraph, heading, image, list, etc.) are handled by default. For custom blocks from other plugins, integrations hook into the `atmosphere_markpub_block` filter to provide their own conversion.
+`site.standard.document` records have an [open content union](../docs/content-formats.md) — any object with a valid `$type` is accepted. ATmosphere doesn't ship a default content parser; integrations register one by hooking the `atmosphere_content_parser` filter and returning an implementation of the `Content_Parser` interface (`includes/content-parser/interface-content-parser.php`).
+
+When the parser returns a content object, it is added to the document record under `content`. If no integration is loaded — or every integration returns `null` — the document is published without a `content` field, which is valid.
 
 ## Adding an integration
 
 1. Create `class-{plugin-name}.php` in this directory.
-2. Register the integration in `class-load.php` with a check for the target plugin.
-3. Hook into `atmosphere_markpub_block` to handle the plugin's custom blocks.
+2. Register it from `class-load.php` behind a check that the target plugin is active.
+3. Hook `atmosphere_content_parser` to return a `Content_Parser` instance for posts your integration can handle.
 
-### Example: Jetpack
+### Content_Parser interface
 
-**`class-jetpack.php`**
+```php
+namespace Atmosphere\Content_Parser;
+
+interface Content_Parser {
+    /**
+     * Parse a post's content into an AT Protocol content object.
+     *
+     * The returned array must include a '$type' key identifying the
+     * lexicon NSID (e.g. 'org.wordpress.html', 'at.markpub.markdown').
+     */
+    public function parse( string $content, \WP_Post $post ): array;
+
+    /**
+     * The lexicon NSID this parser produces.
+     */
+    public function get_type(): string;
+}
+```
+
+### Example: `org.wordpress.html`
+
+**`class-wordpress-html.php`**
 
 ```php
 <?php
 namespace Atmosphere\Integrations;
 
+use Atmosphere\Content_Parser\Content_Parser;
+
 \defined( 'ABSPATH' ) || exit;
 
-class Jetpack {
+class WordPress_HTML implements Content_Parser {
 
     public static function init(): void {
-        \add_filter( 'atmosphere_markpub_block', array( self::class, 'transform_block' ), 10, 2 );
+        \add_filter(
+            'atmosphere_content_parser',
+            static function ( $parser, \WP_Post $post ): ?Content_Parser {
+                return $parser ?? new self();
+            },
+            10,
+            2
+        );
     }
 
-    public static function transform_block( ?string $markdown, array $block ): ?string {
-        return match ( $block['blockName'] ) {
-            'jetpack/slideshow' => self::slideshow( $block ),
-            'jetpack/tiled-gallery' => self::gallery( $block ),
-            default => $markdown,
-        };
+    public function parse( string $content, \WP_Post $post ): array {
+        return array(
+            '$type' => $this->get_type(),
+            'html'  => (string) \apply_filters( 'the_content', $content ),
+        );
     }
 
-    private static function slideshow( array $block ): ?string {
-        // Convert slideshow block to markdown image list.
-    }
-
-    private static function gallery( array $block ): ?string {
-        // Convert gallery block to markdown image list.
+    public function get_type(): string {
+        return 'org.wordpress.html';
     }
 }
 ```
@@ -50,9 +77,7 @@ class Jetpack {
 
 ```php
 public static function register(): void {
-    if ( \defined( 'JETPACK__VERSION' ) ) {
-        Jetpack::init();
-    }
+    WordPress_HTML::init();
 }
 ```
 
@@ -60,15 +85,18 @@ public static function register(): void {
 
 | Filter | Arguments | Description |
 |---|---|---|
-| `atmosphere_markpub_block` | `?string $markdown`, `array $block` | Handle a custom block type. Return markdown string or `null` to pass through to default handling. |
-| `atmosphere_content_parser` | `Content_Parser\|null $parser`, `WP_Post $post` | Replace the entire content parser or return `null` to disable. |
-| `atmosphere_document_content` | `array $content`, `WP_Post $post`, `Content_Parser $parser` | Modify the parsed content object before it is added to the document record. |
-| `atmosphere_html_to_markdown` | `string $markdown`, `string $content` | Override the final markdown output from the Markpub parser. |
+| `atmosphere_content_parser` | `Content_Parser\|null $parser`, `WP_Post $post` | Return a `Content_Parser` instance to provide one, or `null` to skip the content field. |
+| `atmosphere_document_content` | `array $content`, `WP_Post $post`, `Content_Parser $parser` | Last-chance modification of the parsed content object before it is added to the document record. |
 
 ## Conventions
 
-- One class per plugin, all methods static.
+- One class per plugin, methods static unless the parser holds state.
 - File naming: `class-{plugin-name}.php`.
-- Namespace: `Atmosphere\Integrations`.
+- Namespace: `Atmosphere\Integrations` for the loader class; parsers can implement `Atmosphere\Content_Parser\Content_Parser`.
 - Always guard with a plugin check (`\defined()`, `\class_exists()`, etc.) in `class-load.php`.
-- Return `$markdown` (the first argument) unchanged from the filter when the block is not yours.
+- Return the existing `$parser` unchanged from `atmosphere_content_parser` when the post isn't yours, so multiple integrations can coexist.
+
+## Further reading
+
+- [`docs/content-formats.md`](../docs/content-formats.md) — survey of known AT Protocol content formats (markpub, leaflet, pckt, org.wordpress.html).
+- [`docs/org.wordpress.html.md`](../docs/org.wordpress.html.md) — Lexicon for the `org.wordpress.html` content type.

--- a/readme.txt
+++ b/readme.txt
@@ -8,62 +8,82 @@ Stable tag: unreleased
 License: GPL-2.0-or-later
 License URI: https://spdx.org/licenses/GPL-2.0-or-later.html
 
-Publish WordPress posts to AT Protocol (Bluesky and standard.site) via native OAuth.
+Share your WordPress posts on Bluesky and the wider AT Protocol network — and let conversations there come back as comments on your site.
 
 == Description ==
 
-ATmosphere connects your WordPress site to the AT Protocol network. When you publish a post, it is automatically cross-posted to Bluesky and registered as a standard.site document on your Personal Data Server (PDS).
+**ATmosphere** turns your WordPress site into a first-class citizen of the AT Protocol — the open network behind [Bluesky](https://bsky.social/).
 
-The plugin uses native AT Protocol OAuth with PKCE and DPoP — no third-party proxy or intermediary service required. Your credentials never leave your site.
+When you publish a post, ATmosphere automatically shares it on Bluesky and stores the full article on your AT Protocol account so any compatible app can read it. When people on Bluesky reply, like, or repost what you shared, those reactions show up as comments on your post. And approved comments your readers leave on WordPress are sent right back to Bluesky as replies under your original post — so the same conversation happens in both places without you having to copy anything by hand.
 
-= Features =
+= What you get =
 
-* **Native OAuth** — Authenticate directly with your PDS using OAuth 2.1 with PKCE and DPoP.
-* **Bluesky cross-posting** — Publish `app.bsky.feed.post` records that appear in your followers' timelines.
-* **standard.site records** — Create `site.standard.publication` and `site.standard.document` records on your PDS.
-* **Facet detection** — Automatically detects links, mentions, and hashtags in post content.
-* **Per-post control** — Enable or disable publishing for individual posts via a meta box.
-* **Domain handle verification** — Use your WordPress domain as your Bluesky handle via `/.well-known/atproto-did`.
-* **Backfill** — Sync existing published posts to AT Protocol in bulk.
+* **Your posts on Bluesky, automatically.** Hit "Publish" on WordPress, and a moment later your post appears on Bluesky. Links, @-mentions, and #hashtags are detected for you.
+* **Long posts done right.** A long article becomes a short, readable Bluesky thread that links back to the full piece on your site. Edits are kept tidy so existing replies and reposts on Bluesky don't get orphaned.
+* **Use your own domain as your Bluesky handle.** With one click, your handle becomes something like `@yourblog.com` instead of `@you.bsky.social`. ATmosphere does the technical bit; Bluesky verifies it.
+* **Bluesky reactions become WordPress comments.** Replies appear in your comments. Likes and reposts show up alongside them with their own counts so the engagement is visible to your readers.
+* **WordPress comments become Bluesky replies.** When a logged-in reader leaves an approved comment on a cross-posted article, it's sent to Bluesky as a reply under the original post.
+* **Catch up on older posts.** A built-in Backfill tool can publish posts you wrote before installing the plugin.
+* **Per-post control.** You can opt individual posts out of cross-posting straight from the editor sidebar.
+* **No middleman.** ATmosphere talks directly to your Bluesky account using modern, secure sign-in. Nothing is routed through a third-party service, and your tokens never leave your WordPress site.
+* **Translation-ready.** Help translate ATmosphere into your language.
 
-= How It Works =
+= How it works =
 
-1. Connect your Bluesky / AT Protocol account via OAuth on the settings page.
-2. Configure your publication metadata (name, description, icon).
-3. Publish a post — ATmosphere creates both a Bluesky post and a standard.site document record on your PDS.
+1. Install ATmosphere and activate it.
+2. Go to **Settings → ATmosphere** and click "Connect" — sign in to Bluesky in the normal Bluesky window, then come back to WordPress.
+3. Fill in a name, description, and icon for your "publication" — this is how your site is represented on the AT Protocol.
+4. Publish a post.
+5. Open Bluesky — your post is there. People can reply, like, repost, and follow as they normally would.
+6. Replies, likes, and reposts will start appearing as comments on your WordPress post. Comments you approve on WordPress will appear as replies on Bluesky.
+
+**Note:** Cross-posting only kicks in for posts you publish *after* connecting. To bring older posts across, use the **Backfill** tool on the settings page.
 
 == Installation ==
 
-1. Upload the `atmosphere` folder to `/wp-content/plugins/`.
-2. Activate the plugin through the "Plugins" menu in WordPress.
-3. Go to **Settings → ATmosphere** and connect your AT Protocol account.
+1. Upload the `atmosphere` folder to `/wp-content/plugins/` (or install from the Plugins screen in WordPress).
+2. Activate the plugin through the "Plugins" menu.
+3. Go to **Settings → ATmosphere** and click "Connect" to sign in with your Bluesky account.
+4. Set the name, description, and icon for how your site should appear on the AT Protocol.
+5. You're done — your next WordPress post will appear on Bluesky.
 
 == Frequently Asked Questions ==
 
 = Do I need a Bluesky account? =
 
-You need an AT Protocol account. Bluesky (`bsky.social`) is the most common provider, but any AT Protocol PDS will work.
+Yes — or an account on any AT Protocol provider. Most people sign up at [bsky.app](https://bsky.app/), but the plugin works with any compatible AT Protocol service.
 
-= Does this require a third-party service? =
+= Does my account information stay on my site? =
 
-No. The plugin authenticates directly with your PDS using native AT Protocol OAuth. No tokens are sent to or stored by any intermediary.
+Yes. ATmosphere signs in to Bluesky directly from your WordPress site. Nothing is routed through Automattic or any other intermediary, and your sign-in tokens are stored encrypted on your site.
 
-= What records are created? =
+= Can I use my own domain as my Bluesky handle? =
 
-Each published post creates:
+Yes — that's one of the headline features. Once you've connected, open Bluesky's app settings, choose "Change Handle", pick "I have my own domain", and enter your WordPress site's domain. Bluesky will check that it really is your site (ATmosphere takes care of the verification file) and switch your handle.
 
-* An `app.bsky.feed.post` record (visible on Bluesky).
-* A `site.standard.document` record (structured metadata for the ATmosphere).
+= Can I stop a single post from being cross-posted? =
 
-Your site itself is represented by a `site.standard.publication` record.
+Yes. In the post editor sidebar there's an "ATmosphere" panel where you can opt the current post out before publishing.
 
-= Can I use my domain as my Bluesky handle? =
+= What about long posts? =
 
-Yes. Once you connect your account, the plugin serves your DID at `/.well-known/atproto-did`. Go to the Bluesky app settings, choose "Change Handle", select "I have my own domain", and enter your WordPress site's domain. Bluesky will verify it automatically.
+Long posts are turned into a short Bluesky thread of a few connected posts, with the last one linking back to the full article on your site. The full text of your post lives on your AT Protocol account, so other AT Protocol-aware apps and readers can show it too.
 
-= Can I disable Bluesky cross-posting? =
+= Are my WordPress comments published to Bluesky? =
 
-Per-post controls are available in the post editor meta box. Global defaults can be configured on the settings page.
+Yes — approved comments left by logged-in readers on cross-posted articles are sent to Bluesky as replies under your original post. Anonymous comments, trackbacks, and pingbacks are skipped.
+
+= Are Bluesky replies and reposts pulled back into WordPress? =
+
+Yes. ATmosphere checks Bluesky periodically and turns replies, likes, and reposts into WordPress comments on the matching post. Likes and reposts have their own comment types so they show up as engagement counts, not as duplicate comment text.
+
+= What about posts I already published before installing? =
+
+By default, only new posts are shared. You can publish older ones on demand with the **Backfill** tool on the settings page.
+
+= Can I undo a cross-post? =
+
+Yes. If you delete or unpublish a WordPress post, the matching Bluesky post and AT Protocol records are removed too. If you trash a post and then restore it, ATmosphere re-publishes it.
 
 == Changelog ==
 


### PR DESCRIPTION
Fixes #

## Proposed changes:

Docs, skills, and agents refresh ahead of the wp.org launch. No code changes.

* New `docs/` set mirroring the wordpress-activitypub layout: `developer-docs.md`, `development-environment.md`, `php-coding-standards.md`, `php-class-structure.md`, `code-linting.md`, `pull-request.md`, `release-process.md`, `translations.md`.
* Skills (`.agents/skills/`) slimmed to quick-references linking into the new docs.
* `README.md` restyled to ActivityPub's lean format; `readme.txt` rewritten end-user-friendly with corrected FAQ (comment publishing and reaction sync are automatic, not opt-in).
* `AGENTS.md`: Documentation Index added; release cmd points at `npm run release`; canonical-skills path corrected to `.agents/skills/`.
* `integrations/README.md`: rewrote against the real API (`Content_Parser` interface + `atmosphere_content_parser` filter, not the phantom `atmosphere_markpub_block` hook).
* `security-audit` agent: model upgraded to **Opus 4.7 with 1M context**. Added sections for Rate Limiting & Abuse Prevention, CORS & Cross-Origin, JSON & Input Resilience, Visibility & Authorization on Public Surfaces, Race Conditions & Cron Reentry, Deletion & Revocation Authority. Extended SSRF (IPv6 coverage, percent-decoded host bypasses, route-layer blocking, scoped localhost allowance) and DPoP (timestamp window, freshness required, expiry caps, jwk-binding). Seeded a "Recently Noted Patterns" section from ActivityPub 8.1.x/8.2.x findings.
* `code-review` agent: PHP 8.1+ → 8.2+; added WP 6.2+ floor; added Performance checks and Common Review Prompts.

### Other information:

- [x] Have you written new tests for your changes, if applicable? — N/A (docs only).

## Testing instructions:

* Browse the new `docs/*.md` files in GitHub's rendered Markdown view.
* Open one of the slimmed skills (e.g. `.agents/skills/dev/SKILL.md`) and confirm its links into `docs/` resolve correctly.
* Open `.claude/agents/security-audit.md` and confirm the new audit sections read coherently.
* `composer lint` still passes (verified locally).

### Changelog entry

No changelog entry — `Skip Changelog` label applied (developer docs and skill/agent definitions only, no user-visible behaviour change).