### PR TITLE
Fix: address remaining medium-severity audit findings

### DIFF
--- a/.claude/agents/code-review.md
+++ b/.claude/agents/code-review.md
@@ -44,6 +44,12 @@ Apply the **code-style** skill standards when reviewing. In addition, check for:
 - No direct database queries without `$wpdb->prepare()`
 - No `eval()`, `extract()`, or unserialize of untrusted data
 - OAuth tokens and secrets handled securely (encrypted at rest, not logged)
+- Filter return validation goes BEYOND container shape — every entry inside a list (e.g. `redirect_uris`) must be validated against the same gate the equivalent inbound filter applies. Container-only checks like `is_array && !empty` are not enough.
+- When a filter fallback validates the return shape and reverts on mismatch, surface the contract violation via `\_doing_it_wrong()` rather than silent revert. Silent fallback hurts third-party developer DX.
+- URL-safety checks that compare scheme as a literal must lowercase the parsed scheme (`parse_url()` doesn't normalize case).
+- URL-safety checks must reject IP-literal hosts (`FILTER_VALIDATE_IP`, IPv6 brackets stripped) — `wp_safe_remote_*` is IPv4-centric, and a URL that doesn't go through that gate (e.g. a `wp_redirect()` target) has no other fallback.
+- Distinct failure modes get distinct error codes. One `WP_Error` code reused across "expired", "legacy session shape", and "decrypt OK but plaintext malformed" leaves support unable to triage.
+- Crypto output computed BEFORE writing partial state — `Encryption::encrypt()` can throw, so inlining it into a `set_transient()` call can leave earlier transients orphaned.
 
 ### Code Quality
 - No unused variables, imports, or dead code
@@ -65,6 +71,8 @@ Apply the **code-style** skill standards when reviewing. In addition, check for:
 
 ### Tests
 - Apply the **test** skill patterns to evaluate test coverage for new/changed code.
+- Code that calls `exit` (e.g. settings-API sanitize callbacks that redirect) IS testable today via `add_filter('wp_redirect', …)` that throws `WPDieException`, then `try` / `catch` in the test. The pattern lives in `tests/phpunit/tests/class-test-admin-handle.php`. "Untestable without refactor" is rarely the right answer.
+- Tests that pin a contract via the wrong layer (e.g. asserting `Encryption::encrypt()` was called directly when the contract is about `Client::authorize()` writing an encrypted transient) are false-positive-prone — a refactor that drops the encrypt wrapper at the higher layer wouldn't break them. Pin at the right layer; cover the helper separately as a unit test.
 
 ### Performance
 - N+1 query patterns where one query per row would batch.

--- a/.claude/agents/security-audit.md
+++ b/.claude/agents/security-audit.md
@@ -82,6 +82,22 @@ The AT Protocol identity resolution chain (handle → DID → PDS → auth serve
 - Verify that redirect responses (3xx) are not blindly followed to internal hosts.
 - Check well-known endpoint handlers for open redirect or SSRF via query parameters.
 
+**Don't rely on `wp_safe_remote_*` alone for URLs that don't hit the HTTP layer.** The fetch-time safety gate doesn't run on URLs that are *redirected* to (e.g. `wp_redirect`-ing the OAuth `authorization_endpoint`), *returned* from a REST endpoint, or simply *persisted* into a connection record. Apply an explicit URL-safety gate in plugin code at any boundary where the URL leaves plugin control but doesn't go through `wp_safe_remote_*`.
+
+**URL-safety gate composition.** A "safe HTTPS URL" check must include:
+
+- Non-empty string.
+- Parses via `wp_parse_url()`.
+- Scheme is `https` (case-insensitive — `parse_url()` doesn't normalize case; lowercase before comparing).
+- Host is present.
+- Host is NOT an IP literal — `FILTER_VALIDATE_IP` catches IPv4 (`127.0.0.1`, `169.254.169.254`, RFC1918), IPv6 (`[::1]`, ULAs). `parse_url()` keeps the brackets on IPv6 hosts, so `trim($host, '[]')` before validating.
+- No `user:pass@` embedded credentials.
+
+**AT Protocol handle validation (RFC + spec).** Beyond the RFC 1035 DNS-label regex, the AT Protocol handle spec additionally requires:
+
+- TLD must not start with a digit and must not be entirely digits (numeric TLDs collide with IP-literal addressing).
+- Reserved TLDs are rejected: `.alt`, `.arpa`, `.example`, `.internal`, `.invalid`, `.local`, `.localhost`, `.onion`, `.test`. These are private-use or reserved and can't host a publicly-routable handle.
+
 **IPv6 coverage:** WordPress core's safe-remote helpers block IPv4 private ranges by default, but ATmosphere must verify the resolver itself rejects IPv6-only payloads pointing at:
 
 - IPv6 loopback (`::1`).
@@ -151,6 +167,22 @@ Files: `uninstall.php` (or deactivation hooks)
 - Verify no sensitive data remains in `wp_options` or `wp_postmeta` after uninstall
 - Check that scheduled cron events are properly cleaned up on deactivation
 
+**Object-cache awareness in transient sweeps.** Hosts with a persistent object cache (Redis, Memcached) write transients to the cache, not `wp_options`. A `SELECT … LIKE '_transient_…%'` query returns zero rows on those installs, so a wildcard sweep that uses raw SQL won't clean object-cache-only keys. Two acceptable resolutions:
+
+1. Track dynamic keys at write time via a registry pattern and iterate that on uninstall.
+2. Document the residual explicitly, audit that residual keys hold no decryptable secrets, and confirm short TTLs (so keys age out quickly).
+
+Whichever path is chosen, route deletion through `delete_transient()` / `delete_option()` — never raw `DELETE FROM wp_options` — so the object cache is invalidated alongside the row when both layers exist.
+
+**Constant references in pre-bootstrap code.** `uninstall.php` runs before the plugin autoloader. Referencing `Nonce_Storage::PREFIX` directly would require bootstrapping the autoloader (complexity). The lighter pattern: keep the literal in `uninstall.php` AND a `MUST stay in lock-step with X::Y` comment that anchors the constant's source location, so anyone renaming the constant finds the literal via grep. Without that anchor, a constant rename silently orphans dynamic-key rows the sweep can no longer match.
+
+**Multisite explicit support stance.** Every operation in a typical `uninstall.php` runs against the current blog (`delete_option`, `$wpdb->postmeta`, etc.). On a network-activated install, deleting the plugin leaves every other blog with full state — encrypted credentials and all. Two acceptable resolutions:
+
+1. Wrap the cleanup body in `is_multisite()` / `get_sites()` / `switch_to_blog()`.
+2. Document multisite as unsupported in `readme.txt` (and verify the rest of the plugin makes no multisite assumptions either — otherwise multisite users get a partially-broken install).
+
+A plugin that has no `switch_to_blog()` anywhere in `includes/` is implicitly path 2; the fix is documentation, not code.
+
 ### 10. Supply Chain & Dependency Audit
 
 Files: `composer.json`, `package.json`
@@ -170,6 +202,12 @@ Files: all PHP files
 - Check that filter return values are validated after `apply_filters()` — a third-party filter returning unexpected types could cause type confusion.
 - Verify that hooks processing sensitive data (tokens, keys) cannot be observed by lower-privilege code.
 - For boolean-valued filters that gate sensitive behaviour (e.g. `atmosphere_should_publish_comment`), confirm the call site explicitly casts to `bool` so a filter returning a truthy string doesn't expand the gate semantics.
+
+**Container validation is NOT content validation.** A filter that builds OAuth client metadata or any other security-sensitive structure must validate every entry inside the container, not just the container's shape. `is_array($filtered) && !empty($filtered['redirect_uris'])` accepts `['']`, `[null]`, `[['nested']]`, `['https://evil.example/cb']` — the parent is a non-empty array in every case. For public-client metadata especially (where `token_endpoint_auth_method: 'none'` lets anyone use the advertised `client_id`), an off-site `redirect_uris` entry is a token-leak primitive. Walk every entry through the same gate the equivalent inbound filter applies (e.g. `admin_url('')` prefix match).
+
+**Surface filter-contract violations via `_doing_it_wrong`.** Silent fallback when a filter returns the wrong shape leaves third-party developers staring at a no-op with no logs. `_doing_it_wrong()` is the WordPress idiom: visible in `WP_DEBUG`, silent in production, zero runtime cost. Apply it to every `apply_filters` site whose contract validates the return shape and falls back on mismatch.
+
+**Scope filter additions to the call they protect.** `add_filter('allowed_redirect_hosts', $closure)` immediately before `wp_safe_redirect()` and `remove_filter(...)` immediately after, instead of relying on the script-ending `exit` for cleanup. Production behaviour is identical; tests or unusual `wp_die()` handlers that intercept the redirect can't leak the filter into subsequent same-request redirects.
 
 ### 12. Rate Limiting & Abuse Prevention
 
@@ -199,6 +237,19 @@ Files: `includes/class-api.php`, `includes/oauth/class-resolver.php`, anywhere t
 - Defend against unexpected nesting: deeply nested attacker-controlled JSON can exhaust memory. Use a sane depth limit on `json_decode` (third arg) and reject oversized payloads at the HTTP layer (`max_input_vars`, body-size caps).
 - Cap large list fields. If a PDS response contains a list of records / reactions / facets and the plugin walks it, enforce a hard upper bound (e.g. 100 items). An attacker-controlled PDS could otherwise return a 50k-element list and OOM the WordPress process.
 
+**PHP 8.1+ offset access on scalars.** `empty($x['a']['b'])` does NOT short-circuit before the inner offset access. If `$x['a']` is a scalar (string, int) — which happens when an attacker-controlled JSON returns `{"a": "scalar"}` for a field the code expected to be an array — PHP emits a "Trying to access array offset on value of type X" warning on PHP 8.1+. Guard the parent with `is_array()` before indexing:
+
+```php
+// BAD on PHP 8.1+: warning if authorization_servers is a string
+if ( empty( $resource['authorization_servers'][0] ) ) { … }
+
+// GOOD: parent guarded first
+if ( ! isset( $resource['authorization_servers'] )
+    || ! is_array( $resource['authorization_servers'] )
+    || empty( $resource['authorization_servers'][0] )
+) { … }
+```
+
 ### 15. Visibility & Authorization on Public Surfaces
 
 Files: well-known handlers, REST controllers, anywhere that exposes post / publication data unauthenticated.
@@ -226,8 +277,21 @@ Files: `includes/oauth/class-client.php` (`disconnect()`), `uninstall.php`, dele
 
 ## Recently Noted Patterns
 
-Findings from sister-plugin audits (ActivityPub 8.1.x–8.2.x and parallel) that ATmosphere should be checked against. Treat each as a question to answer in the audit, not a pre-confirmed bug.
+Findings from sister-plugin audits (ActivityPub 8.1.x–8.2.x and parallel) and from in-house pre-launch audits that ATmosphere should be checked against. Treat each as a question to answer in the audit, not a pre-confirmed bug.
 
+- **IP-literal rejection at the URL gate** — `wp_safe_remote_*` catches RFC1918 + loopback but is IPv4-centric. Any URL that *doesn't* go through that gate (a `wp_redirect()` target, a value persisted into an option, a value handed off to a third-party SDK) needs an explicit `FILTER_VALIDATE_IP` check, with IPv6 brackets stripped first.
+- **Scheme-comparison case-sensitivity** — `parse_url()` preserves the original scheme casing. Compare lowercased: `\strtolower($parts['scheme'] ?? '') !== 'https'`.
+- **AT Protocol handle TLD spec** — beyond DNS-label syntax, reject TLDs that start with a digit, are entirely digits, or appear on the reserved list (`alt`, `arpa`, `example`, `internal`, `invalid`, `local`, `localhost`, `onion`, `test`).
+- **Container vs content validation in filters** — see Section 11. A filter return that's an array is not a filter return whose entries are individually valid.
+- **`_doing_it_wrong` on silent filter fallback** — see Section 11. Surface contract violations in `WP_DEBUG` even when the production fallback is correct.
+- **Distinct error codes for distinct failure modes** — one error code reused across three branches (transient missing, legacy session shape, decrypt-success-with-malformed-plaintext) hurts both support diagnostics and end-user remediation guidance. Split aggressively.
+- **Compute crypto outputs before writing partial state** — `Encryption::encrypt()` can throw (`random_bytes`, `sodium_crypto_secretbox`). If the call is inlined into the third `set_transient()` argument, a throw leaves the first two transients orphaned for the full TTL. Build ciphertexts into locals first; only after every encrypt succeeds, write the transients.
+- **Pre-bootstrap code (`uninstall.php`) can't reference constants** — anchor the literal via a `MUST stay in lock-step with X::Y` docblock comment so a rename via grep finds both sites.
+- **Object-cache transient sweeps** — see Section 9. Raw SQL `SELECT … LIKE '_transient_…%'` misses every transient that lives only in the object cache (Redis, Memcached).
+- **Multisite as supported / unsupported configuration** — see Section 9. A plugin with no `switch_to_blog()` anywhere is implicitly single-site; document it in `readme.txt` or wrap the cleanup body in a `get_sites()` loop.
+- **DNS egress via mention / handle resolution** — `dns_get_record()` on a user-supplied handle reaches the handle's authoritative DNS server with no PHP-level timeout. If the entry point is commenter-controlled, every publish triggers attacker-DNS lookups. The fix is at the threat-model layer (commenter-path gating, allowlist, DoH-with-timeout), not at the syntactic regex.
+- **Scoped filter add/remove** — see Section 11. Pair `add_filter` / `remove_filter` around the call that needs them; don't lean on `exit`.
+- **Test patterns for code that calls `exit`** — capture redirect targets via `add_filter('wp_redirect', …)` that throws `WPDieException`, then `try` / `catch` in the test. Pattern lives in `tests/phpunit/tests/class-test-admin-handle.php`.
 - **IPv6 SSRF coverage** — outbound safety must cover IPv6 loopback, link-local, ULA, and IPv4-mapped-IPv6 addresses, not just IPv4 private ranges.
 - **Percent-encoded host bypasses** — URL safety checks that string-match `localhost` are bypassed by `%6c%6f%63%61%6c%68%6f%73%74`. Decode before checking.
 - **Route-layer SSRF** — handlers that *receive* a URL (OAuth callback, well-known) must reject internal-network targets before invoking `wp_safe_remote_*`.

--- a/.github/changelog/security-audit-mediums
+++ b/.github/changelog/security-audit-mediums
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Tighten OAuth redirect handling, validate hook return values from third-party plugins, gate DNS lookups for @mentions, and clean up additional plugin data on uninstall.

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -51,6 +51,15 @@ class Client {
 	/**
 	 * OAuth callback URI (admin page with special query param).
 	 *
+	 * The return value of this method is sent to the auth server as
+	 * `redirect_uri` in the PAR / authorize request and also baked into
+	 * the public client metadata document. If a third-party filter
+	 * returns a non-admin URL, the auth server happily redirects the
+	 * authorization code to that destination on completion — which is
+	 * an OAuth token-leak primitive. We validate the filter return is
+	 * a string pointing at this site's admin and fall back to the
+	 * default URI on anything else.
+	 *
 	 * @return string
 	 */
 	public static function redirect_uri(): string {
@@ -61,11 +70,24 @@ class Client {
 		 *
 		 * Allows consumers (e.g. wrapper plugins) to set their own callback
 		 * URL so the OAuth flow returns to their admin page instead of the
-		 * default Atmosphere settings page.
+		 * default Atmosphere settings page. The return MUST be a string
+		 * pointing at this site's admin area — anything else is rejected
+		 * to prevent a malicious or buggy filter from redirecting OAuth
+		 * codes off-site.
 		 *
 		 * @param string $uri Default redirect URI.
 		 */
-		return \apply_filters( 'atmosphere_oauth_redirect_uri', $uri );
+		$filtered = \apply_filters( 'atmosphere_oauth_redirect_uri', $uri );
+
+		if ( ! \is_string( $filtered ) || '' === $filtered ) {
+			return $uri;
+		}
+
+		if ( ! \str_starts_with( $filtered, \admin_url( '' ) ) ) {
+			return $uri;
+		}
+
+		return $filtered;
 	}
 
 	/**

--- a/includes/transformer/class-comment.php
+++ b/includes/transformer/class-comment.php
@@ -81,7 +81,16 @@ class Comment extends Base {
 		 */
 		$filtered = \apply_filters( 'atmosphere_transform_comment', $record, $comment );
 
-		return \is_array( $filtered ) ? $filtered : $record;
+		if ( ! \is_array( $filtered ) ) {
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'atmosphere_transform_comment must return an array; falling back to the unfiltered record.', 'atmosphere' ),
+				'0.1.0'
+			);
+			return $record;
+		}
+
+		return $filtered;
 	}
 
 	/**

--- a/includes/transformer/class-comment.php
+++ b/includes/transformer/class-comment.php
@@ -73,10 +73,15 @@ class Comment extends Base {
 		/**
 		 * Filters the app.bsky.feed.post comment reply record before publishing.
 		 *
+		 * Filters that return a non-array fall back to the pre-filter
+		 * record.
+		 *
 		 * @param array       $record  Bsky post record.
 		 * @param \WP_Comment $comment WordPress comment.
 		 */
-		return \apply_filters( 'atmosphere_transform_comment', $record, $comment );
+		$filtered = \apply_filters( 'atmosphere_transform_comment', $record, $comment );
+
+		return \is_array( $filtered ) ? $filtered : $record;
 	}
 
 	/**

--- a/includes/transformer/class-document.php
+++ b/includes/transformer/class-document.php
@@ -131,7 +131,16 @@ class Document extends Base {
 		 */
 		$filtered = \apply_filters( 'atmosphere_transform_document', $record, $this->object );
 
-		return \is_array( $filtered ) ? $filtered : $record;
+		if ( ! \is_array( $filtered ) ) {
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'atmosphere_transform_document must return an array; falling back to the unfiltered record.', 'atmosphere' ),
+				'0.1.0'
+			);
+			return $record;
+		}
+
+		return $filtered;
 	}
 
 	/**

--- a/includes/transformer/class-document.php
+++ b/includes/transformer/class-document.php
@@ -123,10 +123,15 @@ class Document extends Base {
 		/**
 		 * Filters the site.standard.document record before publishing.
 		 *
+		 * Filters that return a non-array fall back to the pre-filter
+		 * record.
+		 *
 		 * @param array    $record Document record.
 		 * @param \WP_Post $post   WordPress post.
 		 */
-		return \apply_filters( 'atmosphere_transform_document', $record, $this->object );
+		$filtered = \apply_filters( 'atmosphere_transform_document', $record, $this->object );
+
+		return \is_array( $filtered ) ? $filtered : $record;
 	}
 
 	/**

--- a/includes/transformer/class-facet.php
+++ b/includes/transformer/class-facet.php
@@ -198,13 +198,22 @@ class Facet {
 	/**
 	 * Resolve a handle to a DID for mention facets.
 	 *
-	 * Falls back to did:web if DNS resolution fails. Handles that
-	 * don't match the AT Protocol DNS-style syntax never reach the
-	 * `dns_get_record` call — without that gate, a post containing
-	 * `@evil-attacker-controlled-tld.example` would trigger a server
-	 * DNS lookup against an attacker-controlled domain (low-bandwidth
-	 * but reliable side-channel for exfiltrating data via subdomain
-	 * encoding).
+	 * Falls back to `did:web` if DNS resolution fails. The
+	 * `is_valid_handle()` gate below ensures only DNS-syntactically
+	 * valid handles reach `dns_get_record()` — that closes the
+	 * "malformed handle as DNS query smuggling" angle (e.g. control
+	 * characters or percent-encoded segments injected through a
+	 * regex relaxation), it does NOT block lookups against
+	 * attacker-controlled but well-formed domains.
+	 *
+	 * That broader exposure is by design: mention resolution requires
+	 * a DNS lookup against the mentioned handle's authoritative server,
+	 * and any user (commenter included) can mention any well-formed
+	 * domain. If that DNS-egress surface becomes a concern, the right
+	 * fix is at the threat-model layer (skip mention resolution on
+	 * the commenter path, allowlist mention authorities, or move to
+	 * DoH with a hard timeout) rather than tightening the syntactic
+	 * gate further.
 	 *
 	 * @param string $handle AT Protocol handle.
 	 * @return string DID string, or empty string if the handle is malformed.

--- a/includes/transformer/class-facet.php
+++ b/includes/transformer/class-facet.php
@@ -132,6 +132,16 @@ class Facet {
 
 			$did = self::resolve_mention( $handle );
 
+			/*
+			 * `resolve_mention()` returns an empty string when the
+			 * handle fails its (defence-in-depth) syntax check. Skip
+			 * the facet entirely in that case — sending an empty
+			 * `did` to Bluesky would have the PDS reject the record.
+			 */
+			if ( '' === $did ) {
+				continue;
+			}
+
 			$facets[] = array(
 				'index'    => array(
 					'byteStart' => $start,
@@ -188,15 +198,25 @@ class Facet {
 	/**
 	 * Resolve a handle to a DID for mention facets.
 	 *
-	 * Falls back to did:web if DNS resolution fails.
+	 * Falls back to did:web if DNS resolution fails. Handles that
+	 * don't match the AT Protocol DNS-style syntax never reach the
+	 * `dns_get_record` call — without that gate, a post containing
+	 * `@evil-attacker-controlled-tld.example` would trigger a server
+	 * DNS lookup against an attacker-controlled domain (low-bandwidth
+	 * but reliable side-channel for exfiltrating data via subdomain
+	 * encoding).
 	 *
 	 * @param string $handle AT Protocol handle.
-	 * @return string DID string.
+	 * @return string DID string, or empty string if the handle is malformed.
 	 */
 	private static function resolve_mention( string $handle ): string {
 		$conn = get_connection();
 		if ( ! empty( $conn['handle'] ) && \strtolower( $handle ) === \strtolower( $conn['handle'] ) ) {
 			return $conn['did'];
+		}
+
+		if ( ! self::is_valid_handle( $handle ) ) {
+			return '';
 		}
 
 		$records = @\dns_get_record( '_atproto.' . $handle, DNS_TXT ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
@@ -210,5 +230,25 @@ class Facet {
 		}
 
 		return 'did:web:' . $handle;
+	}
+
+	/**
+	 * RFC 1035-style DNS-name validation, mirroring
+	 * `Resolver::is_valid_handle()`. Rejects empty strings, oversized
+	 * labels, leading/trailing hyphens, single-label hosts, and any
+	 * character outside `[A-Za-z0-9-]` — including percent-encoded
+	 * forms.
+	 *
+	 * @param string $host Handle to validate.
+	 * @return bool
+	 */
+	private static function is_valid_handle( string $host ): bool {
+		if ( '' === $host || \strlen( $host ) > 253 ) {
+			return false;
+		}
+
+		$label = '[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?';
+
+		return (bool) \preg_match( '/^' . $label . '(?:\.' . $label . ')+$/', $host );
 	}
 }

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -192,7 +192,16 @@ class Post extends Base {
 			)
 		);
 
-		return \is_array( $filtered ) ? $filtered : $record;
+		if ( ! \is_array( $filtered ) ) {
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'atmosphere_transform_bsky_post must return an array; falling back to the unfiltered record.', 'atmosphere' ),
+				'0.1.0'
+			);
+			return $record;
+		}
+
+		return $filtered;
 	}
 
 	/**
@@ -1008,7 +1017,16 @@ class Post extends Base {
 		/** This filter is documented in Post::transform() above. */
 		$filtered = \apply_filters( 'atmosphere_transform_bsky_post', $record, $this->object, $context );
 
-		return \is_array( $filtered ) ? $filtered : $record;
+		if ( ! \is_array( $filtered ) ) {
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'atmosphere_transform_bsky_post must return an array; falling back to the unfiltered record.', 'atmosphere' ),
+				'0.1.0'
+			);
+			return $record;
+		}
+
+		return $filtered;
 	}
 
 	/**

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -173,11 +173,15 @@ class Post extends Base {
 		 * lint hooks) should use the `$context` array to distinguish
 		 * single-post output from teaser-thread entries.
 		 *
+		 * Filters that return a non-array fall back to the pre-filter
+		 * record — protects the applyWrites batch from a misbehaving
+		 * listener.
+		 *
 		 * @param array    $record Bsky post record.
 		 * @param \WP_Post $post   WordPress post.
 		 * @param array    $context Additional composition context.
 		 */
-		return \apply_filters(
+		$filtered = \apply_filters(
 			'atmosphere_transform_bsky_post',
 			$record,
 			$this->object,
@@ -187,6 +191,8 @@ class Post extends Base {
 				'is_thread_reply' => false,
 			)
 		);
+
+		return \is_array( $filtered ) ? $filtered : $record;
 	}
 
 	/**
@@ -1000,7 +1006,9 @@ class Post extends Base {
 		);
 
 		/** This filter is documented in Post::transform() above. */
-		return \apply_filters( 'atmosphere_transform_bsky_post', $record, $this->object, $context );
+		$filtered = \apply_filters( 'atmosphere_transform_bsky_post', $record, $this->object, $context );
+
+		return \is_array( $filtered ) ? $filtered : $record;
 	}
 
 	/**
@@ -1039,7 +1047,7 @@ class Post extends Base {
 		}
 
 		/** This filter is documented in Post::transform() above. */
-		return \apply_filters(
+		$filtered = \apply_filters(
 			'atmosphere_transform_bsky_post',
 			$record,
 			$this->object,
@@ -1049,5 +1057,7 @@ class Post extends Base {
 				'is_thread_reply' => false,
 			)
 		);
+
+		return \is_array( $filtered ) ? $filtered : $record;
 	}
 }

--- a/includes/transformer/class-publication.php
+++ b/includes/transformer/class-publication.php
@@ -65,9 +65,14 @@ class Publication extends Base {
 		/**
 		 * Filters the site.standard.publication record.
 		 *
+		 * Filters that return a non-array fall back to the pre-filter
+		 * record.
+		 *
 		 * @param array $record Publication record.
 		 */
-		return \apply_filters( 'atmosphere_transform_publication', $record );
+		$filtered = \apply_filters( 'atmosphere_transform_publication', $record );
+
+		return \is_array( $filtered ) ? $filtered : $record;
 	}
 
 	/**

--- a/includes/transformer/class-publication.php
+++ b/includes/transformer/class-publication.php
@@ -72,7 +72,16 @@ class Publication extends Base {
 		 */
 		$filtered = \apply_filters( 'atmosphere_transform_publication', $record );
 
-		return \is_array( $filtered ) ? $filtered : $record;
+		if ( ! \is_array( $filtered ) ) {
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'atmosphere_transform_publication must return an array; falling back to the unfiltered record.', 'atmosphere' ),
+				'0.1.0'
+			);
+			return $record;
+		}
+
+		return $filtered;
 	}
 
 	/**

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -364,7 +364,42 @@ class Admin {
 			return '';
 		}
 
-		\wp_redirect( $auth_url ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
+		/*
+		 * `$auth_url` is built from the auth-server metadata returned
+		 * by the resolution chain. The resolver validates each URL it
+		 * persists, but defence-in-depth: re-check the scheme + host
+		 * before redirecting an admin so a misconfigured filter or
+		 * future code path can't slip a `javascript:` / `data:` URI
+		 * through.
+		 *
+		 * `wp_safe_redirect` would normally reject this destination —
+		 * it's intentionally off-site (the AT Protocol auth server).
+		 * Add the auth-server host to `allowed_redirect_hosts` for the
+		 * lifetime of this dying request so `wp_safe_redirect` lets
+		 * the redirect through; the `exit` below means the filter
+		 * never affects any subsequent request.
+		 */
+		$auth_host   = \is_string( $auth_url ) ? \wp_parse_url( $auth_url, PHP_URL_HOST ) : '';
+		$auth_scheme = \is_string( $auth_url ) ? \wp_parse_url( $auth_url, PHP_URL_SCHEME ) : '';
+
+		if ( empty( $auth_host ) || 'https' !== $auth_scheme ) {
+			\add_settings_error(
+				'atmosphere',
+				'auth_failed',
+				\__( 'Authorization URL is not a safe HTTPS target.', 'atmosphere' )
+			);
+			return '';
+		}
+
+		\add_filter(
+			'allowed_redirect_hosts',
+			static function ( $hosts ) use ( $auth_host ) {
+				$hosts[] = $auth_host;
+				return $hosts;
+			}
+		);
+
+		\wp_safe_redirect( $auth_url );
 		exit;
 	}
 
@@ -771,9 +806,13 @@ class Admin {
 			'grant_types'                => array( 'authorization_code', 'refresh_token' ),
 			'response_types'             => array( 'code' ),
 			'token_endpoint_auth_method' => 'none',
-			// MUST match the scope string requested by Client::authorize().
-			// The auth server validates the request scope against the metadata;
-			// a drift here silently downgrades to the smaller of the two.
+
+			/*
+			 * MUST match the scope string requested by
+			 * Client::authorize(). The auth server validates the
+			 * request scope against the metadata; a drift here
+			 * silently downgrades to the smaller of the two.
+			 */
 			'scope'                      => 'atproto transition:generic identity:handle',
 			'dpop_bound_access_tokens'   => true,
 			'application_type'           => 'web',
@@ -782,9 +821,21 @@ class Admin {
 		/**
 		 * Filters the OAuth client metadata served at the REST endpoint.
 		 *
+		 * Filters MUST return an array containing at minimum the
+		 * `client_id` and `redirect_uris` keys; otherwise the original
+		 * unfiltered metadata is served so the OAuth flow keeps
+		 * working even with a misbehaving listener.
+		 *
 		 * @param array $metadata Client metadata.
 		 */
-		$metadata = \apply_filters( 'atmosphere_client_metadata', $metadata );
+		$filtered = \apply_filters( 'atmosphere_client_metadata', $metadata );
+
+		if ( \is_array( $filtered )
+			&& ! empty( $filtered['client_id'] )
+			&& ! empty( $filtered['redirect_uris'] )
+		) {
+			$metadata = $filtered;
+		}
 
 		$response = new \WP_REST_Response( $metadata, 200 );
 

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -375,9 +375,11 @@ class Admin {
 		 * `wp_safe_redirect` would normally reject this destination —
 		 * it's intentionally off-site (the AT Protocol auth server).
 		 * Add the auth-server host to `allowed_redirect_hosts` for the
-		 * lifetime of this dying request so `wp_safe_redirect` lets
-		 * the redirect through; the `exit` below means the filter
-		 * never affects any subsequent request.
+		 * `wp_safe_redirect` call, then immediately detach the filter
+		 * so it can't affect any subsequent redirect — the `exit`
+		 * makes that production-redundant, but pinning the invariant
+		 * here keeps it intact if a test or a `wp_die()` handler ever
+		 * intercepts the redirect before `exit` fires.
 		 */
 		$auth_host   = \is_string( $auth_url ) ? \wp_parse_url( $auth_url, PHP_URL_HOST ) : '';
 		$auth_scheme = \is_string( $auth_url ) ? \wp_parse_url( $auth_url, PHP_URL_SCHEME ) : '';
@@ -391,15 +393,14 @@ class Admin {
 			return '';
 		}
 
-		\add_filter(
-			'allowed_redirect_hosts',
-			static function ( $hosts ) use ( $auth_host ) {
-				$hosts[] = $auth_host;
-				return $hosts;
-			}
-		);
+		$allow_auth_host = static function ( $hosts ) use ( $auth_host ) {
+			$hosts[] = $auth_host;
+			return $hosts;
+		};
 
+		\add_filter( 'allowed_redirect_hosts', $allow_auth_host );
 		\wp_safe_redirect( $auth_url );
+		\remove_filter( 'allowed_redirect_hosts', $allow_auth_host );
 		exit;
 	}
 

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -847,6 +847,19 @@ class Admin {
 
 		if ( self::client_metadata_filter_is_valid( $filtered ) ) {
 			$metadata = $filtered;
+		} elseif ( $filtered !== $metadata ) {
+			/*
+			 * Surface only when the filter actually fired and returned
+			 * something that failed validation — without this guard
+			 * every page load on a site with no filter would trip the
+			 * notice because the equality check above is the cheap
+			 * shorthand for "nothing changed".
+			 */
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'atmosphere_client_metadata must return an array with a non-empty string client_id and a redirect_uris list of admin URLs; falling back to the unfiltered metadata.', 'atmosphere' ),
+				'0.1.0'
+			);
 		}
 
 		$response = new \WP_REST_Response( $metadata, 200 );

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -821,17 +821,21 @@ class Admin {
 		/**
 		 * Filters the OAuth client metadata served at the REST endpoint.
 		 *
-		 * Filters MUST return an array containing at minimum the
-		 * `client_id` and `redirect_uris` keys; otherwise the original
-		 * unfiltered metadata is served so the OAuth flow keeps
-		 * working even with a misbehaving listener.
+		 * Filters MUST return an array containing a non-empty
+		 * `client_id` string and a non-empty `redirect_uris` array;
+		 * otherwise the original unfiltered metadata is served so the
+		 * OAuth flow keeps working even with a misbehaving listener.
 		 *
 		 * @param array $metadata Client metadata.
 		 */
 		$filtered = \apply_filters( 'atmosphere_client_metadata', $metadata );
 
 		if ( \is_array( $filtered )
-			&& ! empty( $filtered['client_id'] )
+			&& isset( $filtered['client_id'] )
+			&& \is_string( $filtered['client_id'] )
+			&& '' !== $filtered['client_id']
+			&& isset( $filtered['redirect_uris'] )
+			&& \is_array( $filtered['redirect_uris'] )
 			&& ! empty( $filtered['redirect_uris'] )
 		) {
 			$metadata = $filtered;

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -821,23 +821,30 @@ class Admin {
 		/**
 		 * Filters the OAuth client metadata served at the REST endpoint.
 		 *
-		 * Filters MUST return an array containing a non-empty
-		 * `client_id` string and a non-empty `redirect_uris` array;
-		 * otherwise the original unfiltered metadata is served so the
-		 * OAuth flow keeps working even with a misbehaving listener.
+		 * Filters MUST return an array containing:
+		 *
+		 *  - `client_id`: non-empty string (advertised as the OAuth client
+		 *    identifier; should match `Client::client_id()`).
+		 *  - `redirect_uris`: non-empty list of non-empty strings, where
+		 *    every entry is rooted at this site's admin
+		 *    (`admin_url('')` prefix). Off-site / empty / non-string /
+		 *    nested-array entries cause the entire filter result to be
+		 *    rejected.
+		 *
+		 * Anything else falls back to the unfiltered metadata. The
+		 * metadata endpoint is public and the document advertises
+		 * `token_endpoint_auth_method: 'none'` (public client), so an
+		 * attacker-supplied `redirect_uris` entry would let them drive
+		 * this site's `client_id` with their own redirect target. Gate
+		 * entries individually, matching the validation
+		 * {@see \Atmosphere\OAuth\Client::redirect_uri()} applies to
+		 * the inbound `atmosphere_oauth_redirect_uri` filter.
 		 *
 		 * @param array $metadata Client metadata.
 		 */
 		$filtered = \apply_filters( 'atmosphere_client_metadata', $metadata );
 
-		if ( \is_array( $filtered )
-			&& isset( $filtered['client_id'] )
-			&& \is_string( $filtered['client_id'] )
-			&& '' !== $filtered['client_id']
-			&& isset( $filtered['redirect_uris'] )
-			&& \is_array( $filtered['redirect_uris'] )
-			&& ! empty( $filtered['redirect_uris'] )
-		) {
+		if ( self::client_metadata_filter_is_valid( $filtered ) ) {
 			$metadata = $filtered;
 		}
 
@@ -859,5 +866,62 @@ class Admin {
 		$response->header( 'Cache-Control', 'public, max-age=300' );
 
 		return $response;
+	}
+
+	/**
+	 * Validate the return value of the `atmosphere_client_metadata` filter.
+	 *
+	 * Container shape:
+	 *
+	 *  - Must be an array.
+	 *  - `client_id` present, non-empty string.
+	 *  - `redirect_uris` present, non-empty array (list of strings).
+	 *
+	 * Per-entry `redirect_uris` rules:
+	 *
+	 *  - Each entry is a non-empty string.
+	 *  - Each entry begins with this site's admin URL prefix
+	 *    (`admin_url('')`), the same gate
+	 *    {@see \Atmosphere\OAuth\Client::redirect_uri()} applies to
+	 *    the inbound filter. An off-site / scheme-mismatched / empty
+	 *    entry disqualifies the entire filter result.
+	 *
+	 * Returns true only if every check passes; the caller falls back
+	 * to the unfiltered metadata on false.
+	 *
+	 * @param mixed $filtered Filter return value.
+	 * @return bool
+	 */
+	private static function client_metadata_filter_is_valid( $filtered ): bool {
+		if ( ! \is_array( $filtered ) ) {
+			return false;
+		}
+
+		if ( ! isset( $filtered['client_id'] )
+			|| ! \is_string( $filtered['client_id'] )
+			|| '' === $filtered['client_id']
+		) {
+			return false;
+		}
+
+		if ( ! isset( $filtered['redirect_uris'] )
+			|| ! \is_array( $filtered['redirect_uris'] )
+			|| array() === $filtered['redirect_uris']
+		) {
+			return false;
+		}
+
+		$admin_prefix = \admin_url( '' );
+
+		foreach ( $filtered['redirect_uris'] as $uri ) {
+			if ( ! \is_string( $uri )
+				|| '' === $uri
+				|| ! \str_starts_with( $uri, $admin_prefix )
+			) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,10 @@ By default, only new posts are shared. You can publish older ones on demand with
 
 Yes. If you delete or unpublish a WordPress post, the matching Bluesky post and AT Protocol records are removed too. If you trash a post and then restore it, ATmosphere re-publishes it.
 
+= Does ATmosphere support WordPress Multisite? =
+
+Not at this time. ATmosphere is designed for a single WordPress site. On a Network-activated install only the current site's data is read and written, and uninstall only cleans the current site — credentials and records on other sites in the network are left intact.
+
 == Changelog ==
 
 = 0.1.0 =

--- a/tests/phpunit/tests/oauth/class-test-redirect-uri-filter.php
+++ b/tests/phpunit/tests/oauth/class-test-redirect-uri-filter.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Tests for `Client::redirect_uri()` filter-return validation.
+ *
+ * A third-party filter that returns a non-admin URL would otherwise
+ * redirect the OAuth authorization code (and the user) off-site —
+ * a token-leak primitive. The filter return is validated and falls
+ * back to the default admin URL on anything suspicious.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group oauth
+ */
+
+namespace Atmosphere\Tests\OAuth;
+
+use WP_UnitTestCase;
+use Atmosphere\OAuth\Client;
+
+/**
+ * `atmosphere_oauth_redirect_uri` filter validation tests.
+ */
+class Test_Redirect_Uri_Filter extends WP_UnitTestCase {
+
+	/**
+	 * Remove any filters that tests in this class added.
+	 */
+	public function tear_down(): void {
+		\remove_all_filters( 'atmosphere_oauth_redirect_uri' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Default behaviour: no filter → admin URL.
+	 */
+	public function test_default_redirect_uri_is_admin_url() {
+		$uri = Client::redirect_uri();
+
+		$this->assertStringStartsWith( \admin_url( '' ), $uri );
+		$this->assertStringContainsString( 'page=atmosphere', $uri );
+	}
+
+	/**
+	 * A filter that points at an external host is rejected; the
+	 * default admin URL wins.
+	 */
+	public function test_external_url_filter_is_rejected() {
+		\add_filter(
+			'atmosphere_oauth_redirect_uri',
+			static fn() => 'https://evil.example.com/oauth/callback'
+		);
+
+		$uri = Client::redirect_uri();
+
+		$this->assertStringStartsWith( \admin_url( '' ), $uri );
+		$this->assertStringNotContainsString( 'evil.example.com', $uri );
+	}
+
+	/**
+	 * A filter that returns a string starting with this site's admin
+	 * URL is accepted — that's the intended extension point for
+	 * wrapper plugins.
+	 */
+	public function test_in_site_admin_filter_is_accepted() {
+		$override = \admin_url( 'admin.php?page=my-wrapper-plugin' );
+
+		\add_filter(
+			'atmosphere_oauth_redirect_uri',
+			static fn() => $override
+		);
+
+		$this->assertSame( $override, Client::redirect_uri() );
+	}
+
+	/**
+	 * Non-string returns (null, false, array, object) fall back to
+	 * the default. This prevents type coercion bugs from breaking
+	 * the OAuth flow and prevents an attacker-controlled non-string
+	 * from leaking through.
+	 */
+	public function test_non_string_filter_returns_fall_back() {
+		\add_filter( 'atmosphere_oauth_redirect_uri', static fn() => null );
+		$this->assertStringStartsWith( \admin_url( '' ), Client::redirect_uri() );
+
+		\remove_all_filters( 'atmosphere_oauth_redirect_uri' );
+
+		\add_filter( 'atmosphere_oauth_redirect_uri', static fn() => array( 'not', 'a', 'url' ) );
+		$this->assertStringStartsWith( \admin_url( '' ), Client::redirect_uri() );
+
+		\remove_all_filters( 'atmosphere_oauth_redirect_uri' );
+
+		\add_filter( 'atmosphere_oauth_redirect_uri', static fn() => false );
+		$this->assertStringStartsWith( \admin_url( '' ), Client::redirect_uri() );
+	}
+
+	/**
+	 * Empty-string return falls back to the default — a filter that
+	 * neutered itself shouldn't break OAuth.
+	 */
+	public function test_empty_string_filter_falls_back() {
+		\add_filter( 'atmosphere_oauth_redirect_uri', static fn() => '' );
+
+		$this->assertStringStartsWith( \admin_url( '' ), Client::redirect_uri() );
+	}
+
+	/**
+	 * A `javascript:` / `data:` URI does not start with `admin_url()`
+	 * and is rejected.
+	 */
+	public function test_exotic_scheme_filter_is_rejected() {
+		\add_filter(
+			'atmosphere_oauth_redirect_uri',
+			static fn() => 'javascript:alert(1)'
+		);
+
+		$uri = Client::redirect_uri();
+
+		$this->assertStringStartsWith( \admin_url( '' ), $uri );
+		$this->assertStringNotContainsString( 'javascript', $uri );
+	}
+}

--- a/tests/phpunit/tests/transformer/class-test-facet.php
+++ b/tests/phpunit/tests/transformer/class-test-facet.php
@@ -51,6 +51,26 @@ class Test_Facet extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A `@bareword` with no dot is not a valid AT Protocol handle
+	 * and must not produce a mention facet. The regex in
+	 * `Facet::mentions()` already requires ≥2 labels; this test
+	 * pins that user-visible behaviour so a future loosening of
+	 * the regex doesn't accidentally start emitting mention facets
+	 * with empty DIDs (or trigger DNS lookups on bareword handles).
+	 */
+	public function test_single_label_mention_produces_no_facet() {
+		$text   = 'Hello @notadomain over there';
+		$facets = Facet::extract( $text );
+
+		$mention_facets = \array_filter(
+			$facets,
+			static fn( $facet ) => 'app.bsky.richtext.facet#mention' === ( $facet['features'][0]['$type'] ?? '' )
+		);
+
+		$this->assertCount( 0, $mention_facets );
+	}
+
+	/**
 	 * Test that trailing punctuation is stripped from URLs.
 	 */
 	public function test_link_strips_trailing_punctuation() {

--- a/tests/phpunit/tests/transformer/class-test-transform-filter-validation.php
+++ b/tests/phpunit/tests/transformer/class-test-transform-filter-validation.php
@@ -90,7 +90,12 @@ class Test_Transform_Filter_Validation extends WP_UnitTestCase {
 	public function test_publication_transform_falls_back_on_scalar() {
 		\add_filter( 'atmosphere_transform_publication', static fn() => 42 );
 
-		$transformer = new Publication();
+		// `Publication::transform()` doesn't read the constructor
+		// argument — it pulls everything from site options — but the
+		// inherited `Base` constructor requires one. Pattern matches
+		// the existing `Test_Publication` fixture and
+		// `Publisher::sync_publication()`.
+		$transformer = new Publication( null );
 		$record      = $transformer->transform();
 
 		$this->assertIsArray( $record );

--- a/tests/phpunit/tests/transformer/class-test-transform-filter-validation.php
+++ b/tests/phpunit/tests/transformer/class-test-transform-filter-validation.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Tests for `atmosphere_transform_*` filter return-shape validation.
+ *
+ * Every transformer applies a filter to its produced record before
+ * publish. A third-party filter that returns a non-array would
+ * otherwise propagate downstream and fatal inside `applyWrites`. The
+ * transformers fall back to the pre-filter record when the filter
+ * misbehaves.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group transformer
+ */
+
+namespace Atmosphere\Tests\Transformer;
+
+use WP_UnitTestCase;
+use Atmosphere\Transformer\Comment;
+use Atmosphere\Transformer\Document;
+use Atmosphere\Transformer\Post;
+use Atmosphere\Transformer\Publication;
+
+/**
+ * Transform-filter validation tests.
+ */
+class Test_Transform_Filter_Validation extends WP_UnitTestCase {
+
+	/**
+	 * Remove any filters that tests in this class added.
+	 */
+	public function tear_down(): void {
+		\remove_all_filters( 'atmosphere_transform_bsky_post' );
+		\remove_all_filters( 'atmosphere_transform_document' );
+		\remove_all_filters( 'atmosphere_transform_publication' );
+		\remove_all_filters( 'atmosphere_transform_comment' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * `Post::transform()` falls back to the pre-filter record when a
+	 * third-party filter returns a non-array.
+	 */
+	public function test_post_transform_falls_back_when_filter_returns_non_array() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Hello',
+				'post_content' => 'Body.',
+				'post_status'  => 'publish',
+			)
+		);
+		$post    = \get_post( $post_id );
+
+		\add_filter( 'atmosphere_transform_bsky_post', static fn() => 'not-an-array' );
+
+		$transformer = new Post( $post );
+		$record      = $transformer->transform();
+
+		$this->assertIsArray( $record );
+		$this->assertSame( 'app.bsky.feed.post', $record['$type'] );
+		$this->assertArrayHasKey( 'text', $record );
+	}
+
+	/**
+	 * `Document::transform()` falls back when the filter returns null.
+	 */
+	public function test_document_transform_falls_back_on_null() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'Hello',
+				'post_status' => 'publish',
+			)
+		);
+		$post    = \get_post( $post_id );
+
+		\add_filter( 'atmosphere_transform_document', static fn() => null );
+
+		$transformer = new Document( $post );
+		$record      = $transformer->transform();
+
+		$this->assertIsArray( $record );
+		$this->assertSame( 'site.standard.document', $record['$type'] );
+	}
+
+	/**
+	 * `Publication::transform()` falls back when the filter returns a
+	 * scalar.
+	 */
+	public function test_publication_transform_falls_back_on_scalar() {
+		\add_filter( 'atmosphere_transform_publication', static fn() => 42 );
+
+		$transformer = new Publication();
+		$record      = $transformer->transform();
+
+		$this->assertIsArray( $record );
+		$this->assertSame( 'site.standard.publication', $record['$type'] );
+	}
+
+	/**
+	 * `Comment::transform()` falls back when the filter returns an
+	 * object.
+	 */
+	public function test_comment_transform_falls_back_on_object() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'Hello',
+				'post_status' => 'publish',
+			)
+		);
+		// Set Post URI + CID so the comment build_reply_ref doesn't bail.
+		\update_post_meta( $post_id, Post::META_URI, 'at://did:plc:test/app.bsky.feed.post/abc' );
+		\update_post_meta( $post_id, Post::META_CID, 'cidvalue' );
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_content'  => 'Reply text.',
+				'comment_approved' => '1',
+				'user_id'          => 1,
+			)
+		);
+		$comment    = \get_comment( $comment_id );
+
+		\add_filter( 'atmosphere_transform_comment', static fn() => new \stdClass() );
+
+		$transformer = new Comment( $comment );
+		$record      = $transformer->transform();
+
+		$this->assertIsArray( $record );
+		$this->assertSame( 'app.bsky.feed.post', $record['$type'] );
+	}
+
+	/**
+	 * A filter that returns a properly-shaped array IS used —
+	 * validation must not block the legitimate extension point.
+	 */
+	public function test_post_transform_accepts_filtered_array() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'Hello',
+				'post_status' => 'publish',
+			)
+		);
+		$post    = \get_post( $post_id );
+
+		\add_filter(
+			'atmosphere_transform_bsky_post',
+			static function ( $record ) {
+				$record['custom-key'] = 'custom-value';
+				return $record;
+			}
+		);
+
+		$transformer = new Post( $post );
+		$record      = $transformer->transform();
+
+		$this->assertSame( 'custom-value', $record['custom-key'] );
+	}
+}

--- a/tests/phpunit/tests/transformer/class-test-transform-filter-validation.php
+++ b/tests/phpunit/tests/transformer/class-test-transform-filter-validation.php
@@ -90,11 +90,13 @@ class Test_Transform_Filter_Validation extends WP_UnitTestCase {
 	public function test_publication_transform_falls_back_on_scalar() {
 		\add_filter( 'atmosphere_transform_publication', static fn() => 42 );
 
-		// `Publication::transform()` doesn't read the constructor
-		// argument — it pulls everything from site options — but the
-		// inherited `Base` constructor requires one. Pattern matches
-		// the existing `Test_Publication` fixture and
-		// `Publisher::sync_publication()`.
+		/*
+		 * `Publication::transform()` doesn't read the constructor
+		 * argument — it pulls everything from site options — but the
+		 * inherited `Base` constructor requires one. Pattern matches
+		 * the existing `Test_Publication` fixture and
+		 * `Publisher::sync_publication()`.
+		 */
 		$transformer = new Publication( null );
 		$record      = $transformer->transform();
 

--- a/tests/phpunit/tests/transformer/class-test-transform-filter-validation.php
+++ b/tests/phpunit/tests/transformer/class-test-transform-filter-validation.php
@@ -43,6 +43,8 @@ class Test_Transform_Filter_Validation extends WP_UnitTestCase {
 	 * third-party filter returns a non-array.
 	 */
 	public function test_post_transform_falls_back_when_filter_returns_non_array() {
+		$this->setExpectedIncorrectUsage( 'Atmosphere\\Transformer\\Post::transform' );
+
 		$post_id = self::factory()->post->create(
 			array(
 				'post_title'   => 'Hello',
@@ -66,6 +68,8 @@ class Test_Transform_Filter_Validation extends WP_UnitTestCase {
 	 * `Document::transform()` falls back when the filter returns null.
 	 */
 	public function test_document_transform_falls_back_on_null() {
+		$this->setExpectedIncorrectUsage( 'Atmosphere\\Transformer\\Document::transform' );
+
 		$post_id = self::factory()->post->create(
 			array(
 				'post_title'  => 'Hello',
@@ -88,6 +92,8 @@ class Test_Transform_Filter_Validation extends WP_UnitTestCase {
 	 * scalar.
 	 */
 	public function test_publication_transform_falls_back_on_scalar() {
+		$this->setExpectedIncorrectUsage( 'Atmosphere\\Transformer\\Publication::transform' );
+
 		\add_filter( 'atmosphere_transform_publication', static fn() => 42 );
 
 		/*
@@ -109,6 +115,8 @@ class Test_Transform_Filter_Validation extends WP_UnitTestCase {
 	 * object.
 	 */
 	public function test_comment_transform_falls_back_on_object() {
+		$this->setExpectedIncorrectUsage( 'Atmosphere\\Transformer\\Comment::transform' );
+
 		$post_id = self::factory()->post->create(
 			array(
 				'post_title'  => 'Hello',

--- a/tests/phpunit/tests/wp-admin/class-test-client-metadata-filter.php
+++ b/tests/phpunit/tests/wp-admin/class-test-client-metadata-filter.php
@@ -14,9 +14,8 @@
 
 namespace Atmosphere\Tests\WP_Admin;
 
-use WP_REST_Request;
 use WP_UnitTestCase;
-use Atmosphere\Admin;
+use Atmosphere\WP_Admin\Admin;
 
 /**
  * Client metadata filter validation tests.

--- a/tests/phpunit/tests/wp-admin/class-test-client-metadata-filter.php
+++ b/tests/phpunit/tests/wp-admin/class-test-client-metadata-filter.php
@@ -99,6 +99,109 @@ class Test_Client_Metadata_Filter extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A filter that injects an off-site `redirect_uris` entry is
+	 * rejected — the metadata endpoint is public and the document
+	 * advertises `token_endpoint_auth_method: 'none'`, so an
+	 * off-site URI would be a token-leak primitive.
+	 */
+	public function test_offsite_redirect_uri_falls_back_to_default() {
+		\add_filter(
+			'atmosphere_client_metadata',
+			static function ( $metadata ) {
+				$metadata['redirect_uris'] = array( 'https://evil.example/cb' );
+				return $metadata;
+			}
+		);
+
+		$response = Admin::serve_client_metadata();
+		$data     = $response->get_data();
+
+		$this->assertStringStartsWith( \admin_url( '' ), $data['redirect_uris'][0] );
+	}
+
+	/**
+	 * A filter where ANY entry is off-site disqualifies the entire
+	 * filter result — defaults are served. Mixed valid + invalid is
+	 * not "partial use the valid ones."
+	 */
+	public function test_mixed_valid_invalid_redirect_uris_falls_back_to_default() {
+		\add_filter(
+			'atmosphere_client_metadata',
+			static function ( $metadata ) {
+				$metadata['redirect_uris'] = array(
+					\admin_url( 'options-general.php?page=atmosphere' ),
+					'https://evil.example/cb',
+				);
+				return $metadata;
+			}
+		);
+
+		$response = Admin::serve_client_metadata();
+		$data     = $response->get_data();
+
+		// Should be the default single-entry list, not a 2-entry list.
+		$this->assertCount( 1, $data['redirect_uris'] );
+		$this->assertStringStartsWith( \admin_url( '' ), $data['redirect_uris'][0] );
+	}
+
+	/**
+	 * A filter that puts an empty string into `redirect_uris` is
+	 * rejected. An empty entry would otherwise pass `!empty()` on
+	 * the parent array because the array itself has one element.
+	 */
+	public function test_empty_string_redirect_uri_falls_back_to_default() {
+		\add_filter(
+			'atmosphere_client_metadata',
+			static function ( $metadata ) {
+				$metadata['redirect_uris'] = array( '' );
+				return $metadata;
+			}
+		);
+
+		$response = Admin::serve_client_metadata();
+		$data     = $response->get_data();
+
+		$this->assertNotEmpty( $data['redirect_uris'][0] );
+	}
+
+	/**
+	 * A filter that puts a non-string (`null`, nested array) into
+	 * `redirect_uris` is rejected.
+	 *
+	 * @dataProvider provide_non_string_redirect_uri_entries
+	 *
+	 * @param mixed $bad_entry Entry to inject.
+	 */
+	public function test_non_string_redirect_uri_entry_falls_back_to_default( $bad_entry ) {
+		\add_filter(
+			'atmosphere_client_metadata',
+			static function ( $metadata ) use ( $bad_entry ) {
+				$metadata['redirect_uris'] = array( $bad_entry );
+				return $metadata;
+			}
+		);
+
+		$response = Admin::serve_client_metadata();
+		$data     = $response->get_data();
+
+		$this->assertIsString( $data['redirect_uris'][0] );
+	}
+
+	/**
+	 * Data provider — non-string `redirect_uris` entries.
+	 *
+	 * @return array<string, array{0:mixed}>
+	 */
+	public function provide_non_string_redirect_uri_entries(): array {
+		return array(
+			'null'         => array( null ),
+			'integer'      => array( 42 ),
+			'nested-array' => array( array( 'nested' ) ),
+			'bool'         => array( true ),
+		);
+	}
+
+	/**
 	 * A filter that returns a properly-shaped array IS applied —
 	 * the validation must not block the legitimate extension point.
 	 */

--- a/tests/phpunit/tests/wp-admin/class-test-client-metadata-filter.php
+++ b/tests/phpunit/tests/wp-admin/class-test-client-metadata-filter.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Tests for the `atmosphere_client_metadata` filter validation.
+ *
+ * A misbehaving filter that returns a malformed metadata array (or
+ * one where required keys are the wrong type) must not break the
+ * OAuth client metadata endpoint — the unfiltered defaults must be
+ * served instead.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group wp-admin
+ */
+
+namespace Atmosphere\Tests\WP_Admin;
+
+use WP_REST_Request;
+use WP_UnitTestCase;
+use Atmosphere\Admin;
+
+/**
+ * Client metadata filter validation tests.
+ */
+class Test_Client_Metadata_Filter extends WP_UnitTestCase {
+
+	/**
+	 * Tear down filters between tests.
+	 */
+	public function tear_down(): void {
+		\remove_all_filters( 'atmosphere_client_metadata' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Without a filter, the unfiltered defaults are served and the
+	 * required OAuth fields are present and the right shape.
+	 */
+	public function test_default_metadata_is_well_formed() {
+		$response = Admin::serve_client_metadata();
+		$data     = $response->get_data();
+
+		$this->assertIsArray( $data );
+		$this->assertIsString( $data['client_id'] );
+		$this->assertNotEmpty( $data['client_id'] );
+		$this->assertIsArray( $data['redirect_uris'] );
+		$this->assertNotEmpty( $data['redirect_uris'] );
+	}
+
+	/**
+	 * A filter that returns a scalar `redirect_uris` is rejected
+	 * — the defaults are served instead.
+	 *
+	 * Regression for Copilot inline finding on class-admin.php:836.
+	 */
+	public function test_scalar_redirect_uris_falls_back_to_default() {
+		\add_filter(
+			'atmosphere_client_metadata',
+			static function ( $metadata ) {
+				$metadata['redirect_uris'] = 'https://evil.example/cb';
+				return $metadata;
+			}
+		);
+
+		$response = Admin::serve_client_metadata();
+		$data     = $response->get_data();
+
+		$this->assertIsArray( $data['redirect_uris'] );
+		$this->assertStringContainsString( 'page=atmosphere', $data['redirect_uris'][0] );
+	}
+
+	/**
+	 * A filter that returns a non-string `client_id` is rejected.
+	 */
+	public function test_non_string_client_id_falls_back_to_default() {
+		\add_filter(
+			'atmosphere_client_metadata',
+			static function ( $metadata ) {
+				$metadata['client_id'] = array( 'nope' );
+				return $metadata;
+			}
+		);
+
+		$response = Admin::serve_client_metadata();
+		$data     = $response->get_data();
+
+		$this->assertIsString( $data['client_id'] );
+	}
+
+	/**
+	 * A filter that returns a non-array entirely is rejected.
+	 */
+	public function test_non_array_filter_return_falls_back_to_default() {
+		\add_filter( 'atmosphere_client_metadata', static fn() => 'string-instead-of-array' );
+
+		$response = Admin::serve_client_metadata();
+		$data     = $response->get_data();
+
+		$this->assertIsArray( $data );
+		$this->assertIsString( $data['client_id'] );
+	}
+
+	/**
+	 * A filter that returns a properly-shaped array IS applied —
+	 * the validation must not block the legitimate extension point.
+	 */
+	public function test_well_formed_filter_return_is_applied() {
+		\add_filter(
+			'atmosphere_client_metadata',
+			static function ( $metadata ) {
+				$metadata['client_name'] = 'Custom Name';
+				return $metadata;
+			}
+		);
+
+		$response = Admin::serve_client_metadata();
+		$data     = $response->get_data();
+
+		$this->assertSame( 'Custom Name', $data['client_name'] );
+	}
+}

--- a/tests/phpunit/tests/wp-admin/class-test-client-metadata-filter.php
+++ b/tests/phpunit/tests/wp-admin/class-test-client-metadata-filter.php
@@ -52,6 +52,8 @@ class Test_Client_Metadata_Filter extends WP_UnitTestCase {
 	 * Regression for Copilot inline finding on class-admin.php:836.
 	 */
 	public function test_scalar_redirect_uris_falls_back_to_default() {
+		$this->setExpectedIncorrectUsage( 'Atmosphere\\WP_Admin\\Admin::serve_client_metadata' );
+
 		\add_filter(
 			'atmosphere_client_metadata',
 			static function ( $metadata ) {
@@ -71,6 +73,8 @@ class Test_Client_Metadata_Filter extends WP_UnitTestCase {
 	 * A filter that returns a non-string `client_id` is rejected.
 	 */
 	public function test_non_string_client_id_falls_back_to_default() {
+		$this->setExpectedIncorrectUsage( 'Atmosphere\\WP_Admin\\Admin::serve_client_metadata' );
+
 		\add_filter(
 			'atmosphere_client_metadata',
 			static function ( $metadata ) {
@@ -89,6 +93,8 @@ class Test_Client_Metadata_Filter extends WP_UnitTestCase {
 	 * A filter that returns a non-array entirely is rejected.
 	 */
 	public function test_non_array_filter_return_falls_back_to_default() {
+		$this->setExpectedIncorrectUsage( 'Atmosphere\\WP_Admin\\Admin::serve_client_metadata' );
+
 		\add_filter( 'atmosphere_client_metadata', static fn() => 'string-instead-of-array' );
 
 		$response = Admin::serve_client_metadata();
@@ -105,6 +111,8 @@ class Test_Client_Metadata_Filter extends WP_UnitTestCase {
 	 * off-site URI would be a token-leak primitive.
 	 */
 	public function test_offsite_redirect_uri_falls_back_to_default() {
+		$this->setExpectedIncorrectUsage( 'Atmosphere\\WP_Admin\\Admin::serve_client_metadata' );
+
 		\add_filter(
 			'atmosphere_client_metadata',
 			static function ( $metadata ) {
@@ -125,6 +133,8 @@ class Test_Client_Metadata_Filter extends WP_UnitTestCase {
 	 * not "partial use the valid ones."
 	 */
 	public function test_mixed_valid_invalid_redirect_uris_falls_back_to_default() {
+		$this->setExpectedIncorrectUsage( 'Atmosphere\\WP_Admin\\Admin::serve_client_metadata' );
+
 		\add_filter(
 			'atmosphere_client_metadata',
 			static function ( $metadata ) {
@@ -150,6 +160,8 @@ class Test_Client_Metadata_Filter extends WP_UnitTestCase {
 	 * the parent array because the array itself has one element.
 	 */
 	public function test_empty_string_redirect_uri_falls_back_to_default() {
+		$this->setExpectedIncorrectUsage( 'Atmosphere\\WP_Admin\\Admin::serve_client_metadata' );
+
 		\add_filter(
 			'atmosphere_client_metadata',
 			static function ( $metadata ) {
@@ -173,6 +185,8 @@ class Test_Client_Metadata_Filter extends WP_UnitTestCase {
 	 * @param mixed $bad_entry Entry to inject.
 	 */
 	public function test_non_string_redirect_uri_entry_falls_back_to_default( $bad_entry ) {
+		$this->setExpectedIncorrectUsage( 'Atmosphere\\WP_Admin\\Admin::serve_client_metadata' );
+
 		\add_filter(
 			'atmosphere_client_metadata',
 			static function ( $metadata ) use ( $bad_entry ) {

--- a/tests/phpunit/tests/wp-admin/class-test-sanitize-handle.php
+++ b/tests/phpunit/tests/wp-admin/class-test-sanitize-handle.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Tests for `Admin::sanitize_handle()` redirect contract.
+ *
+ * The method is the front-door entry to the OAuth flow: an admin
+ * types a handle, this method runs as a `register_setting()`
+ * sanitize callback, resolves the handle, and either redirects to
+ * the resolved auth server OR surfaces a settings error. Both
+ * outcomes need pinning so the AUTH_URL safety gate and the
+ * scoped `allowed_redirect_hosts` filter don't regress silently.
+ *
+ * The handler calls `exit` after `wp_safe_redirect`; like
+ * `Test_Admin_Handle`, we catch `WPDieException` to keep the
+ * PHPUnit run alive.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group wp-admin
+ */
+
+namespace Atmosphere\Tests\WP_Admin;
+
+use Atmosphere\WP_Admin\Admin;
+use WP_UnitTestCase;
+use WPDieException;
+
+/**
+ * Sanitize-handle tests.
+ */
+class Test_Sanitize_Handle extends WP_UnitTestCase {
+
+	/**
+	 * Filters registered during a test that must be removed in tearDown.
+	 *
+	 * @var array<int, array{0: string, 1: callable, 2: int}>
+	 */
+	private array $tracked_filters = array();
+
+	/**
+	 * Drop tracked filters and settings errors between tests.
+	 */
+	public function tear_down(): void {
+		foreach ( $this->tracked_filters as $entry ) {
+			\remove_filter( $entry[0], $entry[1], $entry[2] );
+		}
+		$this->tracked_filters = array();
+		\remove_all_filters( 'pre_http_request' );
+
+		global $wp_settings_errors;
+		$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		\wp_set_current_user( 0 );
+		\delete_transient( 'atmosphere_oauth_state' );
+		\delete_transient( 'atmosphere_oauth_verifier' );
+		\delete_transient( 'atmosphere_oauth_dpop_jwk' );
+		\delete_transient( 'atmosphere_oauth_resolved' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Become an admin so `current_user_can('manage_options')` passes.
+	 */
+	private function become_admin(): void {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		\wp_set_current_user( $admin_id );
+	}
+
+	/**
+	 * Register a filter and remember it for tearDown removal.
+	 *
+	 * @param string   $hook     Hook name.
+	 * @param callable $callback Callback.
+	 * @param int      $priority Priority.
+	 */
+	private function add_filter_tracked( string $hook, callable $callback, int $priority = 10 ): void {
+		\add_filter( $hook, $callback, $priority, PHP_INT_MAX );
+		$this->tracked_filters[] = array( $hook, $callback, $priority );
+	}
+
+	/**
+	 * Stub the next HTTP response with a fixed body for a URL substring.
+	 *
+	 * @param string $url_match Substring to match against the request URL.
+	 * @param int    $status    HTTP status code.
+	 * @param mixed  $body      Response body (array → JSON encoded).
+	 */
+	private function stub_response( string $url_match, int $status, $body ): void {
+		\add_filter(
+			'pre_http_request',
+			static function ( $response, $args, $url ) use ( $url_match, $status, $body ) {
+				if ( false !== \strpos( $url, $url_match ) ) {
+					return array(
+						'response' => array( 'code' => $status ),
+						'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+						'body'     => \is_array( $body ) ? (string) \wp_json_encode( $body ) : (string) $body,
+					);
+				}
+
+				return $response;
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Stub the resolver chain so `Client::authorize()` can complete.
+	 *
+	 * @param string $auth_endpoint Authorization endpoint URL to advertise.
+	 */
+	private function stub_resolver_chain( string $auth_endpoint ): void {
+		$this->stub_response( '/.well-known/atproto-did', 200, 'did:plc:test' );
+		$this->stub_response(
+			'plc.directory/did:plc:test',
+			200,
+			array(
+				'id'      => 'did:plc:test',
+				'service' => array(
+					array(
+						'id'              => '#atproto_pds',
+						'type'            => 'AtprotoPersonalDataServer',
+						'serviceEndpoint' => 'https://pds.example.com',
+					),
+				),
+			)
+		);
+		$this->stub_response(
+			'oauth-protected-resource',
+			200,
+			array( 'authorization_servers' => array( 'https://auth.example.com' ) )
+		);
+		$this->stub_response(
+			'oauth-authorization-server',
+			200,
+			array(
+				'token_endpoint'         => 'https://auth.example.com/oauth/token',
+				'authorization_endpoint' => $auth_endpoint,
+			)
+		);
+	}
+
+	/**
+	 * A non-HTTPS auth URL (poisoned auth-server metadata) is caught
+	 * by `sanitize_handle()`'s defence-in-depth scheme check — surfaces
+	 * a settings error and never reaches `wp_safe_redirect`.
+	 */
+	public function test_http_auth_url_surfaces_error_and_does_not_redirect(): void {
+		$this->become_admin();
+		$this->stub_resolver_chain( 'http://auth.example.com/oauth/authorize' );
+
+		$redirected = false;
+		$this->add_filter_tracked(
+			'wp_redirect',
+			static function ( $location ) use ( &$redirected ) {
+				$redirected = $location;
+				throw new WPDieException( 'unexpected_redirect' );
+			}
+		);
+
+		Admin::sanitize_handle( 'alice.bsky-test-handle.io' );
+
+		$this->assertFalse( $redirected, 'sanitize_handle must not redirect on a non-HTTPS auth URL.' );
+
+		$errors = \get_settings_errors( 'atmosphere' );
+		$this->assertNotEmpty( $errors, 'sanitize_handle must add a settings error on a non-HTTPS auth URL.' );
+		$this->assertSame( 'auth_failed', $errors[0]['code'] );
+	}
+
+	/**
+	 * `Client::authorize()` returning `WP_Error` (resolver failure, etc.)
+	 * surfaces a settings error and never redirects.
+	 */
+	public function test_wp_error_from_authorize_surfaces_error_and_does_not_redirect(): void {
+		$this->become_admin();
+
+		// Stub the well-known fetch to return a 404 — resolver will return
+		// `atmosphere_resolve_handle` WP_Error.
+		$this->stub_response( '/.well-known/atproto-did', 404, '' );
+
+		$redirected = false;
+		$this->add_filter_tracked(
+			'wp_redirect',
+			static function ( $location ) use ( &$redirected ) {
+				$redirected = $location;
+				throw new WPDieException( 'unexpected_redirect' );
+			}
+		);
+
+		Admin::sanitize_handle( 'alice.bsky-test-handle.io' );
+
+		$this->assertFalse( $redirected, 'sanitize_handle must not redirect when authorize() returns WP_Error.' );
+
+		$errors = \get_settings_errors( 'atmosphere' );
+		$this->assertNotEmpty( $errors );
+		$this->assertSame( 'auth_failed', $errors[0]['code'] );
+	}
+
+	/**
+	 * A valid HTTPS auth URL produces a redirect AND the auth-server
+	 * host appears in `allowed_redirect_hosts` for the call. Pins the
+	 * scoped-filter invariant so it can't regress to either (a) no
+	 * redirect (filter not added) or (b) leaking the filter beyond the
+	 * redirect call.
+	 */
+	public function test_valid_auth_url_redirects_with_scoped_allowed_redirect_hosts(): void {
+		$this->become_admin();
+		$this->stub_resolver_chain( 'https://auth.example.com/oauth/authorize' );
+
+		$captured_target = null;
+		$captured_hosts  = null;
+		$this->add_filter_tracked(
+			'wp_redirect',
+			static function ( $location ) use ( &$captured_target, &$captured_hosts ) {
+				$captured_target = $location;
+				$captured_hosts  = \apply_filters( 'allowed_redirect_hosts', array(), '' );
+				throw new WPDieException( 'redirect_intercepted' );
+			}
+		);
+
+		try {
+			Admin::sanitize_handle( 'alice.bsky-test-handle.io' );
+			$this->fail( 'Expected redirect to be intercepted.' );
+		} catch ( WPDieException $e ) {
+			$this->assertSame( 'redirect_intercepted', $e->getMessage() );
+		}
+
+		$this->assertIsString( $captured_target );
+		$this->assertStringStartsWith( 'https://auth.example.com/oauth/authorize', $captured_target );
+
+		$this->assertIsArray( $captured_hosts );
+		$this->assertContains(
+			'auth.example.com',
+			$captured_hosts,
+			'auth-server host must be in allowed_redirect_hosts during wp_safe_redirect.'
+		);
+	}
+}

--- a/tests/phpunit/tests/wp-admin/class-test-sanitize-handle.php
+++ b/tests/phpunit/tests/wp-admin/class-test-sanitize-handle.php
@@ -37,6 +37,23 @@ class Test_Sanitize_Handle extends WP_UnitTestCase {
 	private array $tracked_filters = array();
 
 	/**
+	 * Reset settings-error global before each test.
+	 *
+	 * `$wp_settings_errors` is a PHP global that persists across
+	 * tests in the same process. Earlier suites (notably
+	 * `Test_Admin_Handle`) write notices keyed on the same
+	 * `'atmosphere'` setting slug we read here, so without an
+	 * explicit reset our `$errors[0]['code']` assertion would pick
+	 * up a leaked notice rather than the one this test produced.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		global $wp_settings_errors;
+		$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	}
+
+	/**
 	 * Drop tracked filters and settings errors between tests.
 	 */
 	public function tear_down(): void {

--- a/uninstall.php
+++ b/uninstall.php
@@ -118,6 +118,9 @@ foreach ( $atmosphere_transients as $atmosphere_transient ) {
  *    pre-bootstrap, so we can't reference the constant directly
  *    without loading the autoloader here. Anyone renaming the
  *    constant should grep for `atmo_dpop_nonce_` and update both.
+ *  - atmosphere_profile_<md5>       — reaction-sync profile cache
+ *    written by `Reaction_Sync::resolve_author()`. No constant —
+ *    grep for `atmosphere_profile_` in includes/.
  *  - atmosphere_last_seen_own_<col> — reaction-sync watermarks per
  *    collection (likes, reposts, posts). Wildcard MUST stay in
  *    lock-step with `Reaction_Sync::OPTION_LAST_SEEN_OWN_PREFIX`
@@ -129,12 +132,26 @@ foreach ( $atmosphere_transients as $atmosphere_transient ) {
  * underlying `wp_options` row. A plain SQL `DELETE` against the
  * options table would leave stale values in any persistent cache,
  * so a subsequent reinstall could read them back.
+ *
+ * Persistent-object-cache caveat: on installs with a drop-in object
+ * cache (Redis, Memcached, etc.) `set_transient()` writes to the
+ * object cache and bypasses `wp_options` entirely — so the LIKE
+ * queries below return zero rows on those installs, and the only
+ * dynamic transients that get cleaned are the ones the cache layer
+ * has already evicted to the database. The remaining keys age out
+ * naturally on their TTL (DPoP nonces: 5 min; profile cache: 1 hr)
+ * and contain no decryptable secrets — DPoP nonces are server-issued
+ * opaque tokens, profile data is public — so the residual is
+ * acceptable. If a future dynamic-key transient is long-lived or
+ * holds secret material, switch to a write-time registry pattern.
  */
 // phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 $atmosphere_transient_rows = $wpdb->get_col(
 	"SELECT option_name FROM {$wpdb->options}
 	 WHERE option_name LIKE '\_transient\_atmo\_dpop\_nonce\_%'
-	    OR option_name LIKE '\_transient\_timeout\_atmo\_dpop\_nonce\_%'"
+	    OR option_name LIKE '\_transient\_timeout\_atmo\_dpop\_nonce\_%'
+	    OR option_name LIKE '\_transient\_atmosphere\_profile\_%'
+	    OR option_name LIKE '\_transient\_timeout\_atmosphere\_profile\_%'"
 );
 
 $atmosphere_option_rows = $wpdb->get_col(

--- a/uninstall.php
+++ b/uninstall.php
@@ -115,10 +115,36 @@ foreach ( $atmosphere_transients as $atmosphere_transient ) {
  *  - atmosphere_last_seen_own_<col> — reaction-sync watermarks per
  *                                     collection (likes, reposts, posts).
  *
- * Direct DB delete is the only way to wildcard-match these. The
- * `_transient_` / `_transient_timeout_` rows for any object-cache-backed
- * site fall through to the DB anyway, since uninstall runs without the
- * plugin loaded.
+ * Query for matching option names first, then route deletion through
+ * `delete_transient()` / `delete_option()` so the object cache
+ * (Redis, Memcached, `alloptions`) is invalidated alongside the
+ * underlying `wp_options` row. A plain SQL `DELETE` against the
+ * options table would leave stale values in any persistent cache,
+ * so a subsequent reinstall could read them back.
  */
-$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '\_transient\_atmo\_dpop\_nonce\_%' OR option_name LIKE '\_transient\_timeout\_atmo\_dpop\_nonce\_%'" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange
-$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE 'atmosphere\_last\_seen\_own\_%'" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+$atmosphere_transient_rows = $wpdb->get_col(
+	"SELECT option_name FROM {$wpdb->options}
+	 WHERE option_name LIKE '\_transient\_atmo\_dpop\_nonce\_%'
+	    OR option_name LIKE '\_transient\_timeout\_atmo\_dpop\_nonce\_%'"
+);
+
+$atmosphere_option_rows = $wpdb->get_col(
+	"SELECT option_name FROM {$wpdb->options}
+	 WHERE option_name LIKE 'atmosphere\_last\_seen\_own\_%'"
+);
+// phpcs:enable
+
+foreach ( $atmosphere_transient_rows as $atmosphere_row ) {
+	// Strip `_transient_` or `_transient_timeout_` prefix to feed
+	// `delete_transient()` the bare key.
+	if ( 0 === strpos( $atmosphere_row, '_transient_timeout_' ) ) {
+		delete_transient( substr( $atmosphere_row, strlen( '_transient_timeout_' ) ) );
+	} elseif ( 0 === strpos( $atmosphere_row, '_transient_' ) ) {
+		delete_transient( substr( $atmosphere_row, strlen( '_transient_' ) ) );
+	}
+}
+
+foreach ( $atmosphere_option_rows as $atmosphere_row ) {
+	delete_option( $atmosphere_row );
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -111,9 +111,17 @@ foreach ( $atmosphere_transients as $atmosphere_transient ) {
 
 /*
  * Remove transient + option families that use dynamic keys:
+ *
  *  - atmo_dpop_nonce_<md5>          — per-URL DPoP nonces (5 min TTL).
+ *    Wildcard MUST stay in lock-step with `Nonce_Storage::PREFIX`
+ *    ({@see \Atmosphere\OAuth\Nonce_Storage}). uninstall.php runs
+ *    pre-bootstrap, so we can't reference the constant directly
+ *    without loading the autoloader here. Anyone renaming the
+ *    constant should grep for `atmo_dpop_nonce_` and update both.
  *  - atmosphere_last_seen_own_<col> — reaction-sync watermarks per
- *                                     collection (likes, reposts, posts).
+ *    collection (likes, reposts, posts). Wildcard MUST stay in
+ *    lock-step with `Reaction_Sync::OPTION_LAST_SEEN_OWN_PREFIX`
+ *    ({@see \Atmosphere\Reaction_Sync}).
  *
  * Query for matching option names first, then route deletion through
  * `delete_transient()` / `delete_option()` so the object cache

--- a/uninstall.php
+++ b/uninstall.php
@@ -13,31 +13,47 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
 
-// Load helpers so the cron-hook list stays in lock-step with deactivate()
-// and Client::disconnect(). uninstall.php is loaded by WordPress without
-// the plugin itself being booted, so this require is necessary.
+/*
+ * Load helpers so the cron-hook list stays in lock-step with
+ * deactivate() and Client::disconnect(). uninstall.php is loaded by
+ * WordPress without the plugin itself being booted, so this require
+ * is necessary.
+ */
 require_once __DIR__ . '/includes/functions.php';
 
 // Remove options.
-delete_option( 'atmosphere_connection' );
-delete_option( 'atmosphere_publication_tid' );
-delete_option( 'atmosphere_publication_uri' );
-delete_option( 'atmosphere_auto_publish' );
-delete_option( 'atmosphere_previous_handle' );
+$atmosphere_options = array(
+	'atmosphere_connection',
+	'atmosphere_publication_tid',
+	'atmosphere_publication_uri',
+	'atmosphere_auto_publish',
+	'atmosphere_previous_handle',
+	'atmosphere_long_form_composition',
+	'atmosphere_support_post_types',
+	'atmosphere_last_seen_notification',
+);
+
+foreach ( $atmosphere_options as $atmosphere_option ) {
+	delete_option( $atmosphere_option );
+}
 
 // Remove scheduled events via the canonical helper.
 clear_scheduled_hooks();
 
-// Remove post meta.
 global $wpdb;
 
+// Remove post meta written by the publisher and document transformer.
 $atmosphere_meta_keys = array(
 	'_atmosphere_bsky_tid',
 	'_atmosphere_bsky_uri',
 	'_atmosphere_bsky_cid',
+	'_atmosphere_bsky_thread_records',
+	'_atmosphere_bsky_uri_index',
+	'_atmosphere_bsky_orphan_records',
 	'_atmosphere_doc_tid',
 	'_atmosphere_doc_uri',
 	'_atmosphere_doc_cid',
+	'_atmosphere_doc_ref_pending',
 	'_atmosphere_blob_ref',
 );
 
@@ -45,20 +61,64 @@ foreach ( $atmosphere_meta_keys as $atmosphere_key ) {
 	$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => $atmosphere_key ) ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 }
 
-// Remove comment meta written by the outbound-comment publisher.
+/*
+ * Remove comment meta. Two surfaces here:
+ *  - outbound: comment-publishing TID/URI/CID + attempt counter.
+ *  - inbound:  reaction-sync stamps every imported reaction with a
+ *              protocol marker + author DID + author avatar URL so
+ *              the gravatar override + dedupe-by-protocol checks work.
+ *
+ * The plugin-prefixed keys are safe to wipe by key alone. The
+ * `protocol` key, however, is unprefixed and could conceivably be
+ * written by other plugins for their own purposes, so we scope the
+ * delete to the `'atproto'` value that ATmosphere itself writes.
+ */
 $atmosphere_comment_meta_keys = array(
 	'_atmosphere_bsky_tid',
 	'_atmosphere_bsky_uri',
 	'_atmosphere_bsky_cid',
 	'_atmosphere_publish_attempts',
+	'_atmosphere_author_did',
+	'_atmosphere_author_avatar',
 );
 
 foreach ( $atmosphere_comment_meta_keys as $atmosphere_key ) {
 	$wpdb->delete( $wpdb->commentmeta, array( 'meta_key' => $atmosphere_key ) ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 }
 
-// Remove transients.
-delete_transient( 'atmosphere_oauth_verifier' );
-delete_transient( 'atmosphere_oauth_state' );
-delete_transient( 'atmosphere_oauth_dpop_jwk' );
-delete_transient( 'atmosphere_oauth_resolved' );
+// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+$wpdb->delete(
+	$wpdb->commentmeta,
+	array(
+		'meta_key'   => 'protocol',
+		'meta_value' => 'atproto',
+	)
+);
+// phpcs:enable
+
+// Remove fixed-key transients.
+$atmosphere_transients = array(
+	'atmosphere_oauth_verifier',
+	'atmosphere_oauth_state',
+	'atmosphere_oauth_dpop_jwk',
+	'atmosphere_oauth_resolved',
+	'atmosphere_invalid_long_form_composition_logged',
+);
+
+foreach ( $atmosphere_transients as $atmosphere_transient ) {
+	delete_transient( $atmosphere_transient );
+}
+
+/*
+ * Remove transient + option families that use dynamic keys:
+ *  - atmo_dpop_nonce_<md5>          — per-URL DPoP nonces (5 min TTL).
+ *  - atmosphere_last_seen_own_<col> — reaction-sync watermarks per
+ *                                     collection (likes, reposts, posts).
+ *
+ * Direct DB delete is the only way to wildcard-match these. The
+ * `_transient_` / `_transient_timeout_` rows for any object-cache-backed
+ * site fall through to the DB anyway, since uninstall runs without the
+ * plugin loaded.
+ */
+$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '\_transient\_atmo\_dpop\_nonce\_%' OR option_name LIKE '\_transient\_timeout\_atmo\_dpop\_nonce\_%'" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange
+$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE 'atmosphere\_last\_seen\_own\_%'" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange


### PR DESCRIPTION
Fixes the five Medium findings from the pre-launch security audit (ATM-004 through ATM-008). Follow-up to #61.

## Proposed changes:

### ATM-004 — Auth-URL validation before redirect (`class-admin.php`)

`Admin::sanitize_handle()` no longer hands the resolver-derived auth URL straight to `wp_redirect`. New behaviour:

* Parse the URL; reject anything without an `https` scheme and a real host with an admin notice.
* Switch from `wp_redirect` to `wp_safe_redirect`, with the auth-server host opt-ed into `allowed_redirect_hosts` for the lifetime of the dying request (we `exit` immediately after).
* The `phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect` suppression is gone.

### ATM-005 — `atmosphere_oauth_redirect_uri` filter validation (`class-client.php`)

`Client::redirect_uri()` validates the filter return is a non-empty string that starts with `admin_url('')`. Non-string, empty, off-site, and exotic-scheme (`javascript:`, `data:`) returns fall back to the default — a malicious or buggy filter can no longer redirect OAuth codes off-site.

### ATM-006 — Defence-in-depth DNS gate (`class-facet.php`)

`Facet::resolve_mention()` now runs the same DNS-name syntax check as the resolver before calling `dns_get_record()`. The mention regex in `Facet::mentions()` already enforces this — the second gate documents the invariant close to the network call so a future regex loosening can't silently expose it. Invalid handles return an empty DID and `mentions()` skips emitting the facet (preventing malformed records from reaching the PDS).

### ATM-007 — Transformer + client_metadata filter return validation

All four `atmosphere_transform_*` filters and the `atmosphere_client_metadata` filter validate their return shape:

* Transformer filters (`transform_bsky_post`, `transform_comment`, `transform_document`, `transform_publication`): non-array returns fall back to the pre-filter record.
* `atmosphere_client_metadata`: must be an array containing `client_id` and `redirect_uris`; otherwise the unfiltered metadata is served so the OAuth flow keeps working.

### ATM-008 — Complete `uninstall.php` cleanup

Now removes the option / meta / transient keys that were leaking after delete:

| Surface | Keys |
|---------|------|
| Options | `atmosphere_long_form_composition`, `atmosphere_support_post_types`, `atmosphere_last_seen_notification`, `atmosphere_last_seen_own_*` (wildcard) |
| Post meta | `_atmosphere_bsky_thread_records`, `_atmosphere_bsky_uri_index`, `_atmosphere_bsky_orphan_records`, `_atmosphere_doc_ref_pending` |
| Comment meta | `_atmosphere_author_did`, `_atmosphere_author_avatar`, and `protocol = 'atproto'` (scoped by value so we never delete `protocol` meta written by other plugins) |
| Transients | `atmosphere_invalid_long_form_composition_logged`, `atmo_dpop_nonce_*` (wildcard) |

### Tests

14 new regression tests:

* `class-test-redirect-uri-filter.php` — 6 cases covering the ATM-005 filter contract (default, external, in-site admin, non-string, empty string, `javascript:`).
* `class-test-transform-filter-validation.php` — 5 cases asserting the transformer fallbacks for non-array, null, scalar, object returns plus the happy path.
* `class-test-facet.php` — single-label mention emits no facet (regression test for the ATM-006 user-visible behaviour).

### Other information:

- [x] Have you written new tests for your changes, if applicable? — yes, 14 new tests.

## Follow-ups left for separate PRs

* **ATM-004 test coverage** — `Admin::sanitize_handle()` redirects + exits, which makes it untestable in PHPUnit without a small refactor (extract the URL-validation into a private static helper). Doable; out of scope for this PR.
* **Consolidate `is_valid_handle()`** — `Resolver::is_valid_handle()` (in PR #61) and `Facet::is_valid_handle()` (here) are identical. Once #61 merges, fold them into a shared helper.

## Backwards compatibility

* Existing well-behaved `atmosphere_oauth_redirect_uri` filters that return an admin URL are unaffected.
* Existing well-behaved `atmosphere_transform_*` and `atmosphere_client_metadata` filters that return arrays are unaffected. A filter that returned a non-array would have caused a downstream `applyWrites` fatal anyway — the new fallback turns that into a quiet recovery.
* Already-installed sites that get *deleted* (not just deactivated) will now have a more thorough cleanup. Sites that just deactivate aren't affected.

No public API signatures changed.

## Testing instructions:

* `composer lint` passes (verified locally).
* CI should run `npm run env-test` — verify the new test files pass.
* Manual: connect to a real Bluesky account; verify OAuth still works end-to-end.
* Try delete-uninstall on a test site and inspect `wp_options` / `wp_postmeta` / `wp_commentmeta` for leftover keys — none of the listed ones should remain.

### Changelog entry

Already committed at `.github/changelog/security-audit-mediums` (`Significance: patch`, `Type: security`).