### PR TITLE
Bound DPoP proof lifetime and harden OAuth JSON parsing

### DIFF
--- a/.github/changelog/harden-dpop-exp-and-json-guards
+++ b/.github/changelog/harden-dpop-exp-and-json-guards
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Tighten DPoP proof lifetime when talking to the AT Protocol auth server and PDS, and harden the OAuth and PDS HTTP paths against malformed server responses.

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -81,6 +81,9 @@ class API {
 
 		$status = \wp_remote_retrieve_response_code( $response );
 		$body   = \json_decode( \wp_remote_retrieve_body( $response ), true );
+		if ( ! \is_array( $body ) ) {
+			$body = array();
+		}
 
 		// Persist any nonce the server sends back.
 		$response_nonce = \wp_remote_retrieve_header( $response, 'dpop-nonce' );

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -238,6 +238,9 @@ class Client {
 
 		$status = \wp_remote_retrieve_response_code( $response );
 		$data   = \json_decode( \wp_remote_retrieve_body( $response ), true );
+		if ( ! \is_array( $data ) ) {
+			$data = array();
+		}
 
 		// Retry once with nonce on use_dpop_nonce error.
 		if ( \in_array( $status, array( 400, 401 ), true )
@@ -273,6 +276,9 @@ class Client {
 
 			$status = \wp_remote_retrieve_response_code( $response );
 			$data   = \json_decode( \wp_remote_retrieve_body( $response ), true );
+			if ( ! \is_array( $data ) ) {
+				$data = array();
+			}
 		}
 
 		if ( $status >= 400 || empty( $data['request_uri'] ) ) {
@@ -381,6 +387,9 @@ class Client {
 		$nonce  = \wp_remote_retrieve_header( $response, 'dpop-nonce' );
 		$status = \wp_remote_retrieve_response_code( $response );
 		$data   = \json_decode( \wp_remote_retrieve_body( $response ), true );
+		if ( ! \is_array( $data ) ) {
+			$data = array();
+		}
 
 		if ( $nonce ) {
 			DPoP::persist_nonce( $dpop_jwk, $token_endpoint, $nonce );
@@ -413,6 +422,9 @@ class Client {
 
 			$status = \wp_remote_retrieve_response_code( $response );
 			$data   = \json_decode( \wp_remote_retrieve_body( $response ), true );
+			if ( ! \is_array( $data ) ) {
+				$data = array();
+			}
 		}
 
 		if ( $status >= 400 || empty( $data['access_token'] ) ) {
@@ -493,6 +505,9 @@ class Client {
 		$nonce  = \wp_remote_retrieve_header( $response, 'dpop-nonce' );
 		$status = \wp_remote_retrieve_response_code( $response );
 		$data   = \json_decode( \wp_remote_retrieve_body( $response ), true );
+		if ( ! \is_array( $data ) ) {
+			$data = array();
+		}
 
 		if ( $nonce ) {
 			DPoP::persist_nonce( $dpop_jwk, $token_endpoint, $nonce );
@@ -526,6 +541,9 @@ class Client {
 
 			$status = \wp_remote_retrieve_response_code( $response );
 			$data   = \json_decode( \wp_remote_retrieve_body( $response ), true );
+			if ( ! \is_array( $data ) ) {
+				$data = array();
+			}
 		}
 
 		if ( $status >= 400 || empty( $data['access_token'] ) ) {

--- a/includes/oauth/class-dpop.php
+++ b/includes/oauth/class-dpop.php
@@ -79,11 +79,20 @@ class DPoP {
 				'jwk' => $public_jwk,
 			);
 
+			$iat = \time();
+
+			/*
+			 * `exp` is OPTIONAL in RFC 9449 but bounds the replay window
+			 * regardless of how lenient the receiving server is about
+			 * proof age. Sixty seconds matches common server-side caps
+			 * and leaves room for clock skew + transport latency.
+			 */
 			$payload = array(
 				'jti' => self::base64url( \random_bytes( 16 ) ),
 				'htm' => \strtoupper( $method ),
 				'htu' => $url,
-				'iat' => \time(),
+				'iat' => $iat,
+				'exp' => $iat + 60,
 			);
 
 			if ( null !== $nonce ) {

--- a/tests/phpunit/tests/class-test-dpop.php
+++ b/tests/phpunit/tests/class-test-dpop.php
@@ -67,6 +67,8 @@ class Test_DPoP extends WP_UnitTestCase {
 		$this->assertSame( 'test-nonce', $payload['nonce'] );
 		$this->assertArrayHasKey( 'jti', $payload );
 		$this->assertArrayHasKey( 'iat', $payload );
+		$this->assertArrayHasKey( 'exp', $payload );
+		$this->assertSame( $payload['iat'] + 60, $payload['exp'] );
 
 		// Verify the ES256 signature with OpenSSL.
 		$signing_input = $parts[0] . '.' . $parts[1];


### PR DESCRIPTION
## Proposed changes

Addresses the two high-severity findings from the most recent security audit. Both are defensive hardening with no behaviour change on the happy path.

- **DPOP-1** — `DPoP::create_proof()` now emits an `exp` claim set to `iat + 60`. RFC 9449 §4.2 makes `exp` optional, but adding it caps the replay window regardless of how lenient the receiving server is about proof age. Sixty seconds matches common PDS enforcement caps and leaves room for clock skew + transport latency.
- **JSON-1** — every `json_decode( wp_remote_retrieve_body(), true )` in the OAuth PAR / token exchange / refresh paths (`OAuth\Client`) and in the PDS request helper (`Api::request()`) now normalises non-array results to `array()` before offset access. A hostile or broken auth server / PDS returning a scalar (`"foo"`, `null`, `42`) no longer triggers PHP 8.1+ array-offset warnings. Matches the pattern already in `OAuth\Resolver`.

### Other information

- [x] Have you written new tests for your changes, if applicable?

`tests/phpunit/tests/class-test-dpop.php::test_create_proof_produces_verifiable_jwt` now asserts `payload['exp'] === payload['iat'] + 60`.

## Testing instructions

1. `composer lint` — clean.
2. `npm run env-test -- --filter=DPoP` — 6 tests / 31 assertions pass.
3. `npm run env-test` — full suite (348 tests, 1050 assertions) passes.
4. Manually inspect a DPoP proof emitted during a fresh connect (decode the middle segment of the `DPoP:` header value): payload should now include both `iat` and `exp = iat + 60`.

### Changelog entry

Already committed at `.github/changelog/harden-dpop-exp-and-json-guards`.