### PR TITLE
Add: WordPress.org deploy workflow and release tooling scaffolding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,6 +19,10 @@
 /package-lock.json export-ignore
 /phpcs.xml        export-ignore
 /phpunit.xml.dist export-ignore
+/CHANGELOG.md     export-ignore
 /CLAUDE.md        export-ignore
 /AGENTS.md        export-ignore
 /README.md        export-ignore
+
+# GitHub linguist attributes
+/docs/**           linguist-documentation

--- a/.github/changelog/liftoff
+++ b/.github/changelog/liftoff
@@ -1,0 +1,4 @@
+Significance: major
+Type: added
+
+Liftoff! ATmosphere has cleared the troposphere — version 1.0 is now generally available.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Deploy to WordPress.org
+on:
+  release:
+    types: [released]
+jobs:
+  deploy_to_wp_repository:
+    name: Deploy to WP.org
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install SVN
+        run: |
+          sudo apt-get update
+          sudo apt-get install subversion
+      - name: WordPress Plugin Deploy
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SLUG: atmosphere

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 composer.lock
 package-lock.json
 *.zip
+.phpunit.cache
 .phpunit.result.cache
+.wp-env.override.json
 /docs/superpowers/
+.idea/
+.vscode/
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,7 +3,7 @@
 	<description>WordPress ATmosphere Standards</description>
 
 	<file>.</file>
-	<exclude-pattern>.(git|github|vscode|idea)</exclude-pattern>
+	<exclude-pattern>.(git|github|vscode|idea|wordpress-org)</exclude-pattern>
 	<exclude-pattern>*\.(inc|css|js|svg)</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>


### PR DESCRIPTION
## Proposed changes:

* Add `.github/workflows/deploy.yml` to publish releases to WordPress.org SVN. Mirrors `wordpress-activitypub`'s workflow: triggers on the GitHub `released` event and uses `10up/action-wordpress-plugin-deploy@stable` with `SLUG: atmosphere`. Requires `SVN_USERNAME` and `SVN_PASSWORD` repo secrets to be configured before the next release.
* Scaffold `CHANGELOG.md` with the Keep-a-Changelog header block. Subsequent release sections are appended by `composer changelog:write`.
* Add `.github/changelog/liftoff` with `Significance: major` so the next `npm run release` bumps `0.x` → `1.0.0`.
* Tighten supporting configs to match `wordpress-activitypub`:
  - `.gitattributes`: `export-ignore` for `/CHANGELOG.md`; mark `/docs/**` as `linguist-documentation`.
  - `.gitignore`: ignore `.phpunit.cache`, `.wp-env.override.json`, `.idea/`, `.vscode/`.
  - `phpcs.xml`: exclude `wordpress-org` alongside the existing dotfile ignores.

### Other information:

- [x] Have you written new tests for your changes, if applicable? — N/A, infrastructure only.

## Testing instructions:

* `composer lint` — passes locally.
* `npm run env-test` — passes locally.
* Inspect `.github/workflows/deploy.yml` on the PR; GitHub will validate the YAML on push. Confirm `SVN_USERNAME` / `SVN_PASSWORD` exist as repo secrets before the next release tag is published.
* On the next `npm run release`, confirm the new version is `1.0.0` (driven by the `liftoff` entry's `Significance: major`).