### PR TITLE
Fix publishing classifier, publication URI staleness, and handle-button hang after 1.0.0

### DIFF
--- a/.github/changelog/fix-publishing-and-handle-after-1-0-0
+++ b/.github/changelog/fix-publishing-and-handle-after-1-0-0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix posts not appearing on Bluesky after a frontend visit lazily stamped the post, restore standard.site verification after reconnecting to a different account, and let the "use my domain as my Bluesky handle" button complete reliably without timing out.

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -582,10 +582,28 @@ class Atmosphere {
 	 * @return bool
 	 */
 	private static function has_post_records( \WP_Post $post ): bool {
+		/*
+		 * Drop `Document::META_TID` from the "has records" signal,
+		 * keep everything else.
+		 *
+		 * `Document::META_TID` is the only meta key that can be
+		 * written speculatively: `output_document_link()` (frontend
+		 * `wp_head`) lazily mints it on the first singular pageview
+		 * so the `<link rel="site.standard.document">` tag has
+		 * something to point at — well before any publish to the
+		 * PDS. Treating that pre-publish TID stamp as "has records"
+		 * misclassifies every transition to publish as `is_update`,
+		 * the cron handler refuses because no URI/CID exists to
+		 * update against, and the publish silently no-ops.
+		 *
+		 * `Post::META_TID` is different: Publisher writes it only
+		 * after a successful `applyWrites`, alongside `META_URI` /
+		 * `META_CID`. It's an honest signal of an existing record
+		 * and remains a positive indicator here.
+		 */
 		return ! empty( \get_post_meta( $post->ID, Transformer\Post::META_TID, true ) )
 			|| ! empty( \get_post_meta( $post->ID, Transformer\Post::META_URI, true ) )
 			|| ! empty( \get_post_meta( $post->ID, Transformer\Post::META_THREAD_RECORDS, true ) )
-			|| ! empty( \get_post_meta( $post->ID, Transformer\Document::META_TID, true ) )
 			|| ! empty( \get_post_meta( $post->ID, Transformer\Document::META_URI, true ) );
 	}
 

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -518,14 +518,13 @@ class Atmosphere {
 				 FROM {$wpdb->posts} p
 				 INNER JOIN {$wpdb->postmeta} pm ON pm.post_id = p.ID
 				 WHERE p.ID > %d
-				   AND pm.meta_key IN (%s, %s, %s, %s, %s)
+				   AND pm.meta_key IN (%s, %s, %s, %s)
 				 ORDER BY p.ID ASC
 				 LIMIT %d",
 				$last_id,
 				Post::META_TID,
 				Post::META_URI,
 				Post::META_THREAD_RECORDS,
-				Document::META_TID,
 				Document::META_URI,
 				self::VISIBILITY_CLEANUP_BATCH_SIZE
 			)

--- a/includes/class-handle.php
+++ b/includes/class-handle.php
@@ -315,9 +315,22 @@ class Handle {
 			);
 		}
 
-		$response = API::post(
+		/*
+		 * Called from the `atmosphere_set_handle` cron worker — no
+		 * synchronous PHP-FPM budget to honour. The auth server's
+		 * `/.well-known/atproto-did` verification routinely takes
+		 * 15-45 seconds; we give the HTTP call a 60s timeout so it
+		 * can complete without being killed by the default 30s
+		 * `wp_safe_remote_post` window. Cron has its own timeout
+		 * (~60s on most installs) which we live within.
+		 */
+		$response = API::request(
+			'POST',
 			'/xrpc/com.atproto.identity.updateHandle',
-			array( 'handle' => $handle )
+			array(
+				'body'    => array( 'handle' => $handle ),
+				'timeout' => 60,
+			)
 		);
 
 		if ( \is_wp_error( $response ) ) {

--- a/includes/class-handle.php
+++ b/includes/class-handle.php
@@ -316,13 +316,17 @@ class Handle {
 		}
 
 		/*
-		 * Called from the `atmosphere_set_handle` cron worker — no
-		 * synchronous PHP-FPM budget to honour. The auth server's
-		 * `/.well-known/atproto-did` verification routinely takes
-		 * 15-45 seconds; we give the HTTP call a 60s timeout so it
-		 * can complete without being killed by the default 30s
-		 * `wp_safe_remote_post` window. Cron has its own timeout
-		 * (~60s on most installs) which we live within.
+		 * Called synchronously from `Admin::maybe_set_domain_handle()`
+		 * on `admin_init`, so the submitting administrator waits on
+		 * this HTTP round-trip. The PDS asks the host's
+		 * `/.well-known/atproto-did` for the DID associated with the
+		 * domain; that lookup typically completes well under five
+		 * seconds in practice but can stretch to 15-45s for slow DNS
+		 * or slow-origin combinations. The 60s timeout (versus the
+		 * `wp_safe_remote_post` default of 30s) gives a slow-but-
+		 * eventual success room to land instead of failing the
+		 * verification mid-handshake. The wait is paid by an
+		 * administrator who explicitly clicked the button.
 		 */
 		$response = API::request(
 			'POST',

--- a/includes/class-publisher.php
+++ b/includes/class-publisher.php
@@ -1316,12 +1316,10 @@ class Publisher {
 
 		/*
 		 * A cron event queued just before `Client::disconnect()` can
-		 * still fire after the connection option is cleared. Without
-		 * this guard we would stamp `Publication::OPTION_URI` with an
-		 * AT-URI whose authority is empty
-		 * (`at:///site.standard.publication/<tid>`) and surface a
-		 * noisy "expected at://X/..., got at:///..." validation error
-		 * on the front-end until the next legitimate sync.
+		 * still fire after the connection option is cleared. Calling
+		 * `putRecord` with an empty `repo` would either malform the
+		 * request or — worse — land on whatever DID the auth layer
+		 * happened to cache. Bail before either can happen.
 		 */
 		if ( '' === $did ) {
 			return new \WP_Error(
@@ -1333,41 +1331,22 @@ class Publisher {
 		$pub = new Publication( null );
 
 		/*
-		 * Re-derive the canonical publication URI from the CURRENT DID
-		 * and the locally-persisted TID, then store it before we even
-		 * call the PDS. The well-known endpoint and the front-end
-		 * verification headers both read `Publication::OPTION_URI`, so
-		 * any drift between the stored URI and `get_did()` immediately
-		 * breaks standard.site validation — exactly the
-		 * disconnect-then-reconnect-to-different-DID failure the
-		 * validator surfaces as "Expected at://<new>/pub/<tid>, Got
-		 * at://<old>/pub/<tid>". Stamping it from current state on
-		 * every sync makes the local option always reflect the
-		 * current owner; the PDS write that follows is what makes
-		 * the record itself catch up.
-		 *
-		 * Inconsistency window: if the PDS call below fails, the
-		 * option transiently points at a URI whose record may not
-		 * yet exist on the PDS for the new owner. The next
-		 * `sync_publication` invocation re-derives and re-writes the
-		 * same URI after a successful PDS write, so the divergence
-		 * self-heals on retry rather than wedging.
-		 */
-		$canonical_uri = build_at_uri( $did, 'site.standard.publication', $pub->get_rkey() );
-		\update_option( Publication::OPTION_URI, $canonical_uri, false );
-
-		/*
 		 * Always `putRecord`. AT Protocol's `putRecord` is an upsert:
 		 * it creates the record when missing and overwrites when
-		 * present. The previous `createRecord`-vs-`putRecord` branch
-		 * picked between the two based on whether we already had a
-		 * URI locally, which broke after a manual option delete (the
-		 * fall-through to `createRecord` failed with "record already
-		 * exists" because the record was still on the PDS, just not
-		 * in our option). Using `putRecord` unconditionally avoids
-		 * that mismatch.
+		 * present. A previous version branched between `createRecord`
+		 * and `putRecord` based on a locally-persisted URI option;
+		 * after disconnect/reconnect-to-a-different-DID that branch
+		 * could pick `createRecord` against a repo that already had
+		 * the record (PDS replies "already exists") or `putRecord`
+		 * against a repo that did not (which `putRecord` handles
+		 * fine, but the inconsistency made the local state hard to
+		 * reason about). Using `putRecord` unconditionally collapses
+		 * both cases into a single upsert against the CURRENT DID +
+		 * locally-persisted TID — the rkey is stable across
+		 * reconnects, so the record always lands at the same address
+		 * for the active owner.
 		 */
-		$result = API::post(
+		return API::post(
 			'/xrpc/com.atproto.repo.putRecord',
 			array(
 				'repo'       => $did,
@@ -1376,21 +1355,6 @@ class Publisher {
 				'record'     => $pub->transform(),
 			)
 		);
-
-		if ( \is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		/*
-		 * Prefer the PDS-returned URI when available — it is the
-		 * authoritative form of the just-written record — and fall
-		 * back to the canonical URI we stamped above otherwise.
-		 */
-		if ( ! empty( $result['uri'] ) ) {
-			\update_option( Publication::OPTION_URI, (string) $result['uri'], false );
-		}
-
-		return $result;
 	}
 
 	/**

--- a/includes/class-publisher.php
+++ b/includes/class-publisher.php
@@ -1314,36 +1314,56 @@ class Publisher {
 	public static function sync_publication(): array|\WP_Error {
 		$pub = new Publication( null );
 
-		$existing_uri = \get_option( Publication::OPTION_URI );
+		/*
+		 * Re-derive the canonical publication URI from the CURRENT DID
+		 * and the locally-persisted TID, then store it before we even
+		 * call the PDS. The well-known endpoint and the front-end
+		 * verification headers both read `Publication::OPTION_URI`, so
+		 * any drift between the stored URI and `get_did()` immediately
+		 * breaks standard.site validation — exactly the
+		 * disconnect-then-reconnect-to-different-DID failure the
+		 * validator surfaces as "Expected at://<new>/pub/<tid>, Got
+		 * at://<old>/pub/<tid>". Stamping it from current state on
+		 * every sync makes the local option always reflect the
+		 * current owner; the PDS write that follows is what makes
+		 * the record itself catch up.
+		 */
+		$canonical_uri = build_at_uri( get_did(), 'site.standard.publication', $pub->get_rkey() );
+		\update_option( Publication::OPTION_URI, $canonical_uri, false );
 
-		if ( $existing_uri ) {
-			$result = API::post(
-				'/xrpc/com.atproto.repo.putRecord',
-				array(
-					'repo'       => get_did(),
-					'collection' => 'site.standard.publication',
-					'rkey'       => $pub->get_rkey(),
-					'record'     => $pub->transform(),
-				)
-			);
-		} else {
-			$result = API::post(
-				'/xrpc/com.atproto.repo.createRecord',
-				array(
-					'repo'       => get_did(),
-					'collection' => 'site.standard.publication',
-					'rkey'       => $pub->get_rkey(),
-					'record'     => $pub->transform(),
-				)
-			);
-		}
+		/*
+		 * Always `putRecord`. AT Protocol's `putRecord` is an upsert:
+		 * it creates the record when missing and overwrites when
+		 * present. The previous `createRecord`-vs-`putRecord` branch
+		 * picked between the two based on whether we already had a
+		 * URI locally, which broke after a manual option delete (the
+		 * fall-through to `createRecord` failed with "record already
+		 * exists" because the record was still on the PDS, just not
+		 * in our option). Using `putRecord` unconditionally avoids
+		 * that mismatch.
+		 */
+		$result = API::post(
+			'/xrpc/com.atproto.repo.putRecord',
+			array(
+				'repo'       => get_did(),
+				'collection' => 'site.standard.publication',
+				'rkey'       => $pub->get_rkey(),
+				'record'     => $pub->transform(),
+			)
+		);
 
 		if ( \is_wp_error( $result ) ) {
 			return $result;
 		}
 
-		$uri = $result['uri'] ?? $pub->get_uri();
-		\update_option( Publication::OPTION_URI, $uri, false );
+		/*
+		 * Prefer the PDS-returned URI when available — it is the
+		 * authoritative form of the just-written record — and fall
+		 * back to the canonical URI we stamped above otherwise.
+		 */
+		if ( ! empty( $result['uri'] ) ) {
+			\update_option( Publication::OPTION_URI, (string) $result['uri'], false );
+		}
 
 		return $result;
 	}

--- a/includes/class-publisher.php
+++ b/includes/class-publisher.php
@@ -1312,6 +1312,24 @@ class Publisher {
 	 * @return array|\WP_Error
 	 */
 	public static function sync_publication(): array|\WP_Error {
+		$did = get_did();
+
+		/*
+		 * A cron event queued just before `Client::disconnect()` can
+		 * still fire after the connection option is cleared. Without
+		 * this guard we would stamp `Publication::OPTION_URI` with an
+		 * AT-URI whose authority is empty
+		 * (`at:///site.standard.publication/<tid>`) and surface a
+		 * noisy "expected at://X/..., got at:///..." validation error
+		 * on the front-end until the next legitimate sync.
+		 */
+		if ( '' === $did ) {
+			return new \WP_Error(
+				'atmosphere_not_connected',
+				\__( 'Cannot sync the publication record: no active connection.', 'atmosphere' )
+			);
+		}
+
 		$pub = new Publication( null );
 
 		/*
@@ -1327,8 +1345,15 @@ class Publisher {
 		 * every sync makes the local option always reflect the
 		 * current owner; the PDS write that follows is what makes
 		 * the record itself catch up.
+		 *
+		 * Inconsistency window: if the PDS call below fails, the
+		 * option transiently points at a URI whose record may not
+		 * yet exist on the PDS for the new owner. The next
+		 * `sync_publication` invocation re-derives and re-writes the
+		 * same URI after a successful PDS write, so the divergence
+		 * self-heals on retry rather than wedging.
 		 */
-		$canonical_uri = build_at_uri( get_did(), 'site.standard.publication', $pub->get_rkey() );
+		$canonical_uri = build_at_uri( $did, 'site.standard.publication', $pub->get_rkey() );
 		\update_option( Publication::OPTION_URI, $canonical_uri, false );
 
 		/*
@@ -1345,7 +1370,7 @@ class Publisher {
 		$result = API::post(
 			'/xrpc/com.atproto.repo.putRecord',
 			array(
-				'repo'       => get_did(),
+				'repo'       => $did,
 				'collection' => 'site.standard.publication',
 				'rkey'       => $pub->get_rkey(),
 				'record'     => $pub->transform(),

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -12,6 +12,7 @@ namespace Atmosphere\OAuth;
 
 \defined( 'ABSPATH' ) || exit;
 
+use Atmosphere\Transformer\Publication;
 use function Atmosphere\clear_scheduled_hooks;
 use function Atmosphere\get_connection;
 
@@ -1126,6 +1127,22 @@ class Client {
 		\delete_option( 'atmosphere_connection' );
 		\delete_option( 'atmosphere_identity' );
 		\delete_option( self::REFRESH_LOCK_OPTION );
+
+		/*
+		 * Clear the cached publication AT-URI. The URI bakes in the
+		 * current DID (`at://<did>/site.standard.publication/<tid>`),
+		 * so a reconnect to a different AT Protocol account would
+		 * otherwise leave the well-known endpoint, the front-end
+		 * verification headers, and `Publisher::sync_publication()`'s
+		 * "exists, update it" branch all pointing at the previous
+		 * owner's repo. We keep `atmosphere_publication_tid` because
+		 * the TID is a stable site-level identifier that should
+		 * survive reconnects to the SAME account; the next
+		 * `Publisher::sync_publication()` call after reconnect
+		 * derives the new URI from the new DID + retained TID.
+		 */
+		\delete_option( Publication::OPTION_URI );
+
 		clear_scheduled_hooks();
 
 		if ( null !== $revoke_args ) {

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -12,7 +12,6 @@ namespace Atmosphere\OAuth;
 
 \defined( 'ABSPATH' ) || exit;
 
-use Atmosphere\Transformer\Publication;
 use function Atmosphere\clear_scheduled_hooks;
 use function Atmosphere\get_connection;
 
@@ -1129,19 +1128,16 @@ class Client {
 		\delete_option( self::REFRESH_LOCK_OPTION );
 
 		/*
-		 * Clear the cached publication AT-URI. The URI bakes in the
-		 * current DID (`at://<did>/site.standard.publication/<tid>`),
-		 * so a reconnect to a different AT Protocol account would
-		 * otherwise leave the well-known endpoint, the front-end
-		 * verification headers, and `Publisher::sync_publication()`'s
-		 * "exists, update it" branch all pointing at the previous
-		 * owner's repo. We keep `atmosphere_publication_tid` because
-		 * the TID is a stable site-level identifier that should
-		 * survive reconnects to the SAME account; the next
-		 * `Publisher::sync_publication()` call after reconnect
-		 * derives the new URI from the new DID + retained TID.
+		 * Sweep a stale option from 1.0.0 installs. `atmosphere_publication_uri`
+		 * was cached state that nothing in production ever read — the
+		 * well-known endpoint and the Document transformer's `site`
+		 * reference both derive the publication URI on demand from
+		 * `get_did()` + the publication TID. Drop the row so it does
+		 * not linger on disconnected installs. `atmosphere_publication_tid`
+		 * stays put because that TID is the stable site-level
+		 * identifier that survives reconnects to the same account.
 		 */
-		\delete_option( Publication::OPTION_URI );
+		\delete_option( 'atmosphere_publication_uri' );
 
 		clear_scheduled_hooks();
 

--- a/includes/transformer/class-publication.php
+++ b/includes/transformer/class-publication.php
@@ -27,13 +27,6 @@ class Publication extends Base {
 	public const OPTION_TID = 'atmosphere_publication_tid';
 
 	/**
-	 * Option key for the publication AT-URI.
-	 *
-	 * @var string
-	 */
-	public const OPTION_URI = 'atmosphere_publication_uri';
-
-	/**
 	 * Transform site settings into a publication record.
 	 *
 	 * @return array site.standard.publication record.

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -32,11 +32,11 @@ class Admin {
 		\add_action( 'admin_menu', array( self::class, 'add_menu' ) );
 		\add_action( 'admin_init', array( self::class, 'handle_oauth_callback' ) );
 		\add_action( 'admin_init', array( self::class, 'register_settings' ) );
+		\add_action( 'admin_init', array( self::class, 'maybe_set_domain_handle' ) );
 		\add_action( 'admin_enqueue_scripts', array( self::class, 'enqueue_assets' ) );
 		\add_action( 'admin_notices', array( self::class, 'maybe_render_reauth_notice' ) );
 
 		\add_action( 'admin_post_atmosphere_disconnect', array( self::class, 'handle_disconnect' ) );
-		\add_action( 'admin_post_atmosphere_set_domain_handle', array( self::class, 'handle_set_domain_handle' ) );
 
 		// Meta box on syncable post types.
 		\add_action( 'add_meta_boxes', array( self::class, 'add_meta_box' ) );
@@ -266,9 +266,8 @@ class Admin {
 	 * {@see Handle::should_offer()} agrees the offer is meaningful.
 	 */
 	public static function render_domain_handle_field(): void {
-		$current  = (string) ( get_connection()['handle'] ?? '' );
-		$target   = Handle::get_target_handle();
-		$post_url = \admin_url( 'admin-post.php?action=atmosphere_set_domain_handle' );
+		$current = (string) ( get_connection()['handle'] ?? '' );
+		$target  = Handle::get_target_handle();
 		?>
 		<p>
 			<?php
@@ -295,23 +294,26 @@ class Admin {
 		<p>
 			<?php
 			/*
-			 * The settings page wraps every field in a single outer
-			 * <form action="options.php" method="post">. A nested form
-			 * would be invalid HTML, so the submit button overrides the
-			 * outer form's destination via formaction/formmethod when —
-			 * and only when — this button is the one clicked. The Save
-			 * button at the bottom of the settings page still posts to
-			 * options.php as normal. This keeps the nonce in the request
-			 * body instead of leaking it through the URL / Referer
-			 * header / link prefetching, which an <a> with
-			 * wp_nonce_url() would do.
+			 * `name`/`value` mark the button so {@see
+			 * self::maybe_set_domain_handle()} (hooked on
+			 * `admin_init`) can detect this specific click. The
+			 * Save Changes button at the bottom of the page does
+			 * not carry this name, so a regular settings save lands
+			 * `$_POST['atmosphere_set_domain_handle']` as empty and
+			 * the trigger handler bails — only an explicit click on
+			 * THIS button reaches `Handle::set_handle()`.
+			 *
+			 * Stays inside the WP Settings form: the click rides on
+			 * the form's own nonce + capability gate and options.php
+			 * issues the normal redirect afterwards, so the settings
+			 * notice posted by `Handle::set_handle()` surfaces on the
+			 * next pageview without any custom redirect path.
 			 */
-			\wp_nonce_field( 'atmosphere_set_domain_handle', 'atmosphere_nonce', false );
 			?>
 			<button
 				type="submit"
-				formaction="<?php echo \esc_url( $post_url ); ?>"
-				formmethod="post"
+				name="atmosphere_set_domain_handle"
+				value="1"
 				class="button">
 				<?php
 				echo \esc_html(
@@ -696,23 +698,46 @@ class Admin {
 	}
 
 	/**
-	 * Handle the explicit "use my domain as my Bluesky handle" submission.
+	 * Trigger `Handle::set_handle()` when the settings form is
+	 * submitted with the "Use my domain as my Bluesky handle" button.
 	 *
-	 * Verifies capability + nonce, defers to {@see Handle::set_handle()} for
-	 * the actual call, then redirects back to the Settings page with a notice
-	 * already populated by Handle.
+	 * The button renders inside the WP Settings form and carries
+	 * `name="atmosphere_set_domain_handle" value="1"`. When clicked,
+	 * the form POSTs to `options.php` like any other settings save.
+	 * Routing the trigger through a dedicated `admin-post.php?action=…`
+	 * endpoint instead collides with `settings_fields()`'s hidden
+	 * `<input name="action" value="update">` field — POST wins in
+	 * `$_REQUEST['action']` and the click ends up dispatched to
+	 * `admin_post_update`. Detecting the field here on `admin_init`,
+	 * before options.php runs, keeps the action inside the same
+	 * form-submit lifecycle without conflicting concerns.
+	 *
+	 * Bails silently if the trigger field is absent (normal Save
+	 * Changes path) or if the request fails any of the standard
+	 * settings-form guards (capability, option group, nonce). On
+	 * success `Handle::set_handle()` posts its own settings notice;
+	 * options.php's own redirect surfaces the notice on the next
+	 * pageview without us having to intercept the redirect here.
 	 */
-	public static function handle_set_domain_handle(): void {
-		if ( ! \current_user_can( 'manage_options' ) ) {
-			\wp_die( \esc_html__( 'You do not have permission to do this.', 'atmosphere' ) );
+	public static function maybe_set_domain_handle(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Presence check only; nonce is verified below before any side effect.
+		if ( empty( $_POST['atmosphere_set_domain_handle'] ) ) {
+			return;
 		}
 
-		\check_admin_referer( 'atmosphere_set_domain_handle', 'atmosphere_nonce' );
+		if ( ! \current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Same as above; nonce verified on the next line.
+		$option_page = isset( $_POST['option_page'] ) ? \sanitize_key( \wp_unslash( $_POST['option_page'] ) ) : '';
+		if ( 'atmosphere' !== $option_page ) {
+			return;
+		}
+
+		\check_admin_referer( 'atmosphere-options' );
 
 		Handle::set_handle();
-
-		\wp_safe_redirect( \admin_url( 'options-general.php?page=atmosphere' ) );
-		exit;
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-admin-handle.php
+++ b/tests/phpunit/tests/class-test-admin-handle.php
@@ -97,13 +97,19 @@ class Test_Admin_Handle extends WP_UnitTestCase {
 	 * Install a spy on `Handle::FILTER_PRE_UPDATE` and return a
 	 * reference to its call counter.
 	 *
+	 * The spy short-circuits the filter with `true` (controlled
+	 * success) so `Handle::set_handle()` returns cleanly without
+	 * exercising the real DPoP / HTTP path — the integration test
+	 * only cares that the admin trigger reaches the handle service,
+	 * not that the auth layer succeeds.
+	 *
 	 * @param int $counter Call-count reference holder.
 	 */
 	private function spy_on_handle_update( int &$counter ): void {
 		$counter = 0;
-		$spy     = static function ( $value ) use ( &$counter ) {
+		$spy     = static function () use ( &$counter ) {
 			++$counter;
-			return $value;
+			return true;
 		};
 		$this->add_filter_tracked( Handle::FILTER_PRE_UPDATE, $spy );
 	}

--- a/tests/phpunit/tests/class-test-admin-handle.php
+++ b/tests/phpunit/tests/class-test-admin-handle.php
@@ -1,11 +1,13 @@
 <?php
 /**
- * Integration tests for the domain-handle admin-post handler.
+ * Integration tests for the in-form domain-handle trigger.
  *
- * Covers the two security gates on `Admin::handle_set_domain_handle`
- * (capability + nonce) and the happy-path redirect. The Handle service
- * itself has unit coverage in {@see Test_Handle}; this file pins the
- * front-door contract between an admin POST and the XRPC call.
+ * Covers the gates on `Admin::maybe_set_domain_handle()` (presence of
+ * the button's `name` field, capability, option-group, nonce) and
+ * confirms that `Handle::set_handle()` runs only when every gate
+ * passes. Handle service itself has unit coverage in
+ * {@see Test_Handle}; this file pins the front-door contract between
+ * the settings-form submission and the XRPC call.
  *
  * @package Atmosphere
  * @group atmosphere
@@ -20,7 +22,7 @@ use WP_UnitTestCase;
 use WPDieException;
 
 /**
- * Admin domain-handle handler tests.
+ * Domain-handle trigger tests.
  */
 class Test_Admin_Handle extends WP_UnitTestCase {
 
@@ -75,10 +77,6 @@ class Test_Admin_Handle extends WP_UnitTestCase {
 	 * Set up an eligible state where {@see Handle::set_handle()} would
 	 * reach the {@see Handle::FILTER_PRE_UPDATE} short-circuit if
 	 * called: root-install URLs and a connected, non-matching handle.
-	 *
-	 * Without this scaffolding, a `FILTER_PRE_UPDATE` spy can't tell the
-	 * difference between "the handler skipped Handle::set_handle()" and
-	 * "Handle::set_handle() ran but bailed early at !is_connected()".
 	 */
 	private function make_handle_call_observable(): void {
 		$home = static fn() => 'https://example.com';
@@ -96,89 +94,130 @@ class Test_Admin_Handle extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the handler dies when the current user lacks `manage_options`.
-	 */
-	public function test_dies_without_manage_options_cap(): void {
-		\wp_set_current_user( 0 );
-
-		$this->expectException( WPDieException::class );
-
-		Admin::handle_set_domain_handle();
-	}
-
-	/**
-	 * Test that the handler dies when no valid nonce is present, and that
-	 * the underlying `Handle::set_handle()` flow never runs.
+	 * Install a spy on `Handle::FILTER_PRE_UPDATE` and return a
+	 * reference to its call counter.
 	 *
-	 * Sets up an otherwise-eligible state (root install + connected,
-	 * non-matching handle) so the FILTER_PRE_UPDATE spy is meaningful:
-	 * if `Handle::set_handle()` *were* incorrectly reached, the filter
-	 * would fire and `$called` would be 1.
+	 * @param int $counter Call-count reference holder.
 	 */
-	public function test_dies_on_missing_nonce_and_skips_handle_call(): void {
-		$this->become_admin();
-		$this->make_handle_call_observable();
-
-		$called = 0;
-		$spy    = static function ( $value ) use ( &$called ) {
-			++$called;
+	private function spy_on_handle_update( int &$counter ): void {
+		$counter = 0;
+		$spy     = static function ( $value ) use ( &$counter ) {
+			++$counter;
 			return $value;
 		};
 		$this->add_filter_tracked( Handle::FILTER_PRE_UPDATE, $spy );
-
-		try {
-			Admin::handle_set_domain_handle();
-			$this->fail( 'Expected wp_die() from check_admin_referer.' );
-		} catch ( WPDieException $e ) {
-			// Expected.
-			unset( $e );
-		}
-
-		$this->assertSame( 0, $called, 'Handle::set_handle() must not run when the nonce check fails.' );
 	}
 
 	/**
-	 * Test that the handler redirects to the Atmosphere settings page when
-	 * both the capability and nonce gates pass.
+	 * Build a settings-form POST that carries the trigger button +
+	 * the standard `atmosphere-options` settings nonce.
 	 *
-	 * The browser-side panel posts to admin-post.php via a form, so the
-	 * nonce is delivered in `$_POST` rather than the URL — the test
-	 * mirrors that.
+	 * @return string The created nonce (for assertion convenience).
 	 */
-	public function test_redirects_to_settings_page_on_success(): void {
+	private function arrange_valid_form_post(): string {
+		$nonce = \wp_create_nonce( 'atmosphere-options' );
+
+		$_POST['atmosphere_set_domain_handle'] = '1';
+		$_POST['option_page']                  = 'atmosphere';
+		$_POST['_wpnonce']                     = $nonce;
+		$_REQUEST['_wpnonce']                  = $nonce;
+		$_REQUEST['option_page']               = 'atmosphere';
+
+		return $nonce;
+	}
+
+	/**
+	 * The trigger handler must NOT die when the current user lacks
+	 * `manage_options`. The button posts through the regular settings
+	 * form, and the rest of options.php still has work to do for the
+	 * other registered settings; bailing silently is the contract.
+	 */
+	public function test_bails_silently_without_manage_options_cap(): void {
+		\wp_set_current_user( 0 );
+		$this->make_handle_call_observable();
+		$this->arrange_valid_form_post();
+		$called = 0;
+		$this->spy_on_handle_update( $called );
+
+		Admin::maybe_set_domain_handle();
+
+		$this->assertSame( 0, $called, 'Handle::set_handle() must not run without manage_options.' );
+	}
+
+	/**
+	 * Without the trigger field in the POST (Save Changes path or any
+	 * unrelated admin pageview) the handler must return without
+	 * touching the Handle service.
+	 */
+	public function test_bails_silently_without_trigger_field(): void {
 		$this->become_admin();
+		$this->make_handle_call_observable();
+		$called = 0;
+		$this->spy_on_handle_update( $called );
 
-		$nonce = \wp_create_nonce( 'atmosphere_set_domain_handle' );
+		// Note: $_POST['atmosphere_set_domain_handle'] is intentionally absent.
+		Admin::maybe_set_domain_handle();
 
-		/*
-		 * In real requests PHP populates $_REQUEST from $_POST/$_GET on
-		 * script start; in tests we mutate the superglobals directly, so
-		 * mirror the value into $_REQUEST too — that is what
-		 * check_admin_referer() actually reads.
-		 */
-		$_POST['atmosphere_nonce']    = $nonce;
-		$_REQUEST['atmosphere_nonce'] = $nonce;
+		$this->assertSame( 0, $called, 'Handle::set_handle() must not run on a non-trigger admin_init pass.' );
+	}
 
-		/*
-		 * Short-circuit `wp_redirect` so the handler's `exit` is preempted
-		 * by an exception we can catch — without this the test would halt
-		 * the entire PHPUnit run.
-		 */
-		$captured = null;
-		$catcher  = static function ( $location ) use ( &$captured ) {
-			$captured = $location;
-			throw new WPDieException( 'redirect_intercepted' );
-		};
-		$this->add_filter_tracked( 'wp_redirect', $catcher );
+	/**
+	 * The handler must reject submissions whose `option_page` is not
+	 * the atmosphere group — that field is the only reliable signal
+	 * that the POST came from our settings form and not another
+	 * options.php submission that happens to carry a matching name.
+	 */
+	public function test_bails_silently_when_option_page_does_not_match(): void {
+		$this->become_admin();
+		$this->make_handle_call_observable();
+		$this->arrange_valid_form_post();
+		$_POST['option_page']    = 'something-else';
+		$_REQUEST['option_page'] = 'something-else';
+		$called                  = 0;
+		$this->spy_on_handle_update( $called );
+
+		Admin::maybe_set_domain_handle();
+
+		$this->assertSame( 0, $called, 'Handle::set_handle() must not run when option_page does not match.' );
+	}
+
+	/**
+	 * With the trigger field + cap + matching option_page but a
+	 * missing nonce, `check_admin_referer` must wp_die — guaranteeing
+	 * the side-effect cannot execute on a forged POST.
+	 */
+	public function test_dies_on_missing_nonce(): void {
+		$this->become_admin();
+		$this->make_handle_call_observable();
+		$_POST['atmosphere_set_domain_handle'] = '1';
+		$_POST['option_page']                  = 'atmosphere';
+		$_REQUEST['option_page']               = 'atmosphere';
+		$called                                = 0;
+		$this->spy_on_handle_update( $called );
+
+		$this->expectException( WPDieException::class );
 
 		try {
-			Admin::handle_set_domain_handle();
-			$this->fail( 'Expected redirect to be intercepted.' );
-		} catch ( WPDieException $e ) {
-			$this->assertSame( 'redirect_intercepted', $e->getMessage() );
+			Admin::maybe_set_domain_handle();
+		} finally {
+			$this->assertSame( 0, $called, 'Handle::set_handle() must not run on a nonce-failing POST.' );
 		}
+	}
 
-		$this->assertIsString( $captured );
-		$this->assertStringContainsString( 'page=atmosphere', $captured );
+	/**
+	 * Happy path: trigger field + cap + option_page + valid nonce →
+	 * `Handle::set_handle()` runs and the FILTER_PRE_UPDATE spy
+	 * observes exactly one short-circuit invocation.
+	 */
+	public function test_invokes_handle_set_when_all_gates_pass(): void {
+		$this->become_admin();
+		$this->make_handle_call_observable();
+		$this->arrange_valid_form_post();
+		$called = 0;
+		$this->spy_on_handle_update( $called );
+
+		Admin::maybe_set_domain_handle();
+
+		$this->assertSame( 1, $called, 'Handle::set_handle() must run when all gates pass.' );
 	}
 }

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -15,11 +15,9 @@ namespace Atmosphere\Tests;
 use WP_UnitTestCase;
 use Atmosphere\Atmosphere;
 use Atmosphere\Reaction_Sync;
-use Atmosphere\OAuth\Client;
 use Atmosphere\Transformer\Comment;
 use Atmosphere\Transformer\Document;
 use Atmosphere\Transformer\Post;
-use Atmosphere\Transformer\Publication;
 
 /**
  * Atmosphere tests.
@@ -1475,24 +1473,24 @@ class Test_Atmosphere extends WP_UnitTestCase {
 	}
 
 	/**
-	 * `Client::disconnect` clears `Publication::OPTION_URI`.
-	 *
-	 * Reconnecting to a different DID would otherwise leave the option
-	 * baked with the previous owner's AT-URI; the well-known endpoint
-	 * would keep serving the old authority and standard.site validation
-	 * would fail with "Expected at://<new>/pub/<tid>, Got at://<old>/...".
+	 * `Client::disconnect` sweeps the stale `atmosphere_publication_uri`
+	 * row that 1.0.0 used to write. Nothing in production consumes the
+	 * option (the well-known endpoint and Document transformer derive
+	 * the URI from `get_did()` + the publication TID), but a leftover
+	 * row on disconnected installs would still be confusing to operators
+	 * inspecting the options table.
 	 */
-	public function test_disconnect_clears_publication_uri() {
+	public function test_disconnect_sweeps_stale_publication_uri_option() {
 		\update_option(
-			Publication::OPTION_URI,
+			'atmosphere_publication_uri',
 			'at://did:plc:old-owner/site.standard.publication/3kpubtid000000'
 		);
 
-		Client::disconnect();
+		\Atmosphere\OAuth\Client::disconnect();
 
 		$this->assertFalse(
-			\get_option( Publication::OPTION_URI ),
-			'Client::disconnect must clear Publication::OPTION_URI so a reconnect to a different DID does not leak the previous authority through the well-known endpoint.'
+			\get_option( 'atmosphere_publication_uri' ),
+			'Client::disconnect must sweep the stale atmosphere_publication_uri row from 1.0.0 installs.'
 		);
 	}
 

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -15,9 +15,11 @@ namespace Atmosphere\Tests;
 use WP_UnitTestCase;
 use Atmosphere\Atmosphere;
 use Atmosphere\Reaction_Sync;
+use Atmosphere\OAuth\Client;
 use Atmosphere\Transformer\Comment;
 use Atmosphere\Transformer\Document;
 use Atmosphere\Transformer\Post;
+use Atmosphere\Transformer\Publication;
 
 /**
  * Atmosphere tests.
@@ -1470,6 +1472,28 @@ class Test_Atmosphere extends WP_UnitTestCase {
 				"Client::disconnect must clear scheduled hook: {$hook}"
 			);
 		}
+	}
+
+	/**
+	 * `Client::disconnect` clears `Publication::OPTION_URI`.
+	 *
+	 * Reconnecting to a different DID would otherwise leave the option
+	 * baked with the previous owner's AT-URI; the well-known endpoint
+	 * would keep serving the old authority and standard.site validation
+	 * would fail with "Expected at://<new>/pub/<tid>, Got at://<old>/...".
+	 */
+	public function test_disconnect_clears_publication_uri() {
+		\update_option(
+			Publication::OPTION_URI,
+			'at://did:plc:old-owner/site.standard.publication/3kpubtid000000'
+		);
+
+		Client::disconnect();
+
+		$this->assertFalse(
+			\get_option( Publication::OPTION_URI ),
+			'Client::disconnect must clear Publication::OPTION_URI so a reconnect to a different DID does not leak the previous authority through the well-known endpoint.'
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-publisher.php
+++ b/tests/phpunit/tests/class-test-publisher.php
@@ -20,7 +20,6 @@ use Atmosphere\OAuth\Encryption;
 use Atmosphere\Transformer\Comment;
 use Atmosphere\Transformer\Document;
 use Atmosphere\Transformer\Post;
-use Atmosphere\Transformer\Publication;
 
 /**
  * Publisher tests.
@@ -2353,74 +2352,22 @@ class Test_Publisher extends WP_UnitTestCase {
 	 * `sync_publication()` bails when the plugin is disconnected.
 	 *
 	 * A cron event queued before `Client::disconnect()` can still fire
-	 * after the connection option is cleared. Without the guard we'd
-	 * stamp `Publication::OPTION_URI` with an empty-authority AT-URI
-	 * (`at:///site.standard.publication/<tid>`) that breaks .well-known
-	 * validation until the next legitimate sync.
+	 * after the connection option is cleared. Without the guard,
+	 * `putRecord` would be called with an empty `repo`, either
+	 * malforming the request or landing on whatever DID the auth
+	 * layer happened to cache.
 	 */
 	public function test_sync_publication_bails_when_disconnected() {
 		\delete_option( 'atmosphere_connection' );
 		\delete_option( 'atmosphere_did' );
-		\delete_option( Publication::OPTION_URI );
+		// `get_did()` resolves through `get_identity()` which reads
+		// `atmosphere_identity` — without this delete the option can
+		// leak in from earlier tests and skip the guard under test.
+		\delete_option( 'atmosphere_identity' );
 
 		$result = Publisher::sync_publication();
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'atmosphere_not_connected', $result->get_error_code() );
-		$this->assertFalse(
-			\get_option( Publication::OPTION_URI ),
-			'OPTION_URI must not be written when the plugin is disconnected.'
-		);
-	}
-
-	/**
-	 * `sync_publication()` writes the canonical URI (current DID +
-	 * locally-persisted TID) to `Publication::OPTION_URI` BEFORE the
-	 * PDS call. This is what makes the well-known endpoint serve the
-	 * correct authority immediately after a reconnect to a different
-	 * DID — the PDS write catches up afterwards. Regression guard for
-	 * the disconnect→reconnect-to-different-DID standard.site
-	 * validation failure.
-	 */
-	public function test_sync_publication_writes_uri_before_pds_call() {
-		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
-		\delete_option( Publication::OPTION_URI );
-
-		$snapshot_at_request_time = null;
-
-		$intercept = function ( $response, array $args, string $url ) use ( &$snapshot_at_request_time ) {
-			if ( false === \strpos( $url, 'com.atproto.repo.putRecord' ) ) {
-				return $response;
-			}
-			$body = isset( $args['body'] ) && \is_string( $args['body'] ) ? \json_decode( $args['body'], true ) : array();
-			if ( ! isset( $body['collection'] ) || 'site.standard.publication' !== $body['collection'] ) {
-				return $response;
-			}
-
-			$snapshot_at_request_time = \get_option( Publication::OPTION_URI );
-
-			return array(
-				'response' => array( 'code' => 200 ),
-				'body'     => \wp_json_encode(
-					array(
-						'uri' => 'at://did:plc:test123/site.standard.publication/3kpubtid000000',
-						'cid' => 'bafyreibpubcid',
-					)
-				),
-			);
-		};
-		\add_filter( 'pre_http_request', $intercept, 5, 3 );
-
-		$result = Publisher::sync_publication();
-
-		\remove_filter( 'pre_http_request', $intercept, 5 );
-		\delete_option( 'atmosphere_publication_tid' );
-
-		$this->assertIsArray( $result );
-		$this->assertSame(
-			'at://did:plc:test123/site.standard.publication/3kpubtid000000',
-			$snapshot_at_request_time,
-			'OPTION_URI must be stamped with the current DID + TID BEFORE the PDS call.'
-		);
 	}
 }

--- a/tests/phpunit/tests/class-test-publisher.php
+++ b/tests/phpunit/tests/class-test-publisher.php
@@ -20,6 +20,7 @@ use Atmosphere\OAuth\Encryption;
 use Atmosphere\Transformer\Comment;
 use Atmosphere\Transformer\Document;
 use Atmosphere\Transformer\Post;
+use Atmosphere\Transformer\Publication;
 
 /**
  * Publisher tests.
@@ -2346,5 +2347,80 @@ class Test_Publisher extends WP_UnitTestCase {
 		$this->assertSame( (int) $comment_id, (int) $captured[0]['comment']->comment_ID );
 		$this->assertWPError( $captured[0]['result'] );
 		$this->assertSame( $result, $captured[0]['result'], 'hook receives the same result returned to the caller' );
+	}
+
+	/**
+	 * `sync_publication()` bails when the plugin is disconnected.
+	 *
+	 * A cron event queued before `Client::disconnect()` can still fire
+	 * after the connection option is cleared. Without the guard we'd
+	 * stamp `Publication::OPTION_URI` with an empty-authority AT-URI
+	 * (`at:///site.standard.publication/<tid>`) that breaks .well-known
+	 * validation until the next legitimate sync.
+	 */
+	public function test_sync_publication_bails_when_disconnected() {
+		\delete_option( 'atmosphere_connection' );
+		\delete_option( 'atmosphere_did' );
+		\delete_option( Publication::OPTION_URI );
+
+		$result = Publisher::sync_publication();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'atmosphere_not_connected', $result->get_error_code() );
+		$this->assertFalse(
+			\get_option( Publication::OPTION_URI ),
+			'OPTION_URI must not be written when the plugin is disconnected.'
+		);
+	}
+
+	/**
+	 * `sync_publication()` writes the canonical URI (current DID +
+	 * locally-persisted TID) to `Publication::OPTION_URI` BEFORE the
+	 * PDS call. This is what makes the well-known endpoint serve the
+	 * correct authority immediately after a reconnect to a different
+	 * DID — the PDS write catches up afterwards. Regression guard for
+	 * the disconnect→reconnect-to-different-DID standard.site
+	 * validation failure.
+	 */
+	public function test_sync_publication_writes_uri_before_pds_call() {
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+		\delete_option( Publication::OPTION_URI );
+
+		$snapshot_at_request_time = null;
+
+		$intercept = function ( $response, array $args, string $url ) use ( &$snapshot_at_request_time ) {
+			if ( false === \strpos( $url, 'com.atproto.repo.putRecord' ) ) {
+				return $response;
+			}
+			$body = isset( $args['body'] ) && \is_string( $args['body'] ) ? \json_decode( $args['body'], true ) : array();
+			if ( ! isset( $body['collection'] ) || 'site.standard.publication' !== $body['collection'] ) {
+				return $response;
+			}
+
+			$snapshot_at_request_time = \get_option( Publication::OPTION_URI );
+
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => \wp_json_encode(
+					array(
+						'uri' => 'at://did:plc:test123/site.standard.publication/3kpubtid000000',
+						'cid' => 'bafyreibpubcid',
+					)
+				),
+			);
+		};
+		\add_filter( 'pre_http_request', $intercept, 5, 3 );
+
+		$result = Publisher::sync_publication();
+
+		\remove_filter( 'pre_http_request', $intercept, 5 );
+		\delete_option( 'atmosphere_publication_tid' );
+
+		$this->assertIsArray( $result );
+		$this->assertSame(
+			'at://did:plc:test123/site.standard.publication/3kpubtid000000',
+			$snapshot_at_request_time,
+			'OPTION_URI must be stamped with the current DID + TID BEFORE the PDS call.'
+		);
 	}
 }


### PR DESCRIPTION
## Proposed changes:

Three production bugs surfaced after 1.0.0 went live, fixed atomically:

1. **Publishing silently no-ops when a post was viewed on the front-end before publishing.** `output_document_link()` lazily stamps `Document::META_TID` from `wp_head`. `has_post_records()` was treating that as a "post has records" signal, so the publish classifier misclassified fresh publishes as updates, and `Publisher::update_post()` returned an empty array silently. Fix: drop `Document::META_TID` from the gate — keep only honest, post-PDS-success signals (`Post::META_TID`, `Post::META_URI`, `Post::META_THREAD_RECORDS`, `Document::META_URI`). The historical visibility cleanup query's prefilter `meta_key IN (...)` list drops `Document::META_TID` symmetrically so posts with only the lazy stamp are no longer pulled into the batch just to be skipped.

2. **standard.site validator errors after disconnect/reconnect to a different DID.** Root cause: `Publisher::sync_publication()` branched between `createRecord` and `putRecord` based on a locally-persisted URI option. After disconnect/reconnect-to-a-different-DID, the branch could send `createRecord` against a repo that already had the record, or wedge in other ways that left local state and PDS state out of sync. Fix: use unconditional `putRecord` (upsert) against the current DID + locally-persisted TID — the rkey is stable across reconnects, so the record always lands at the same address for the active owner. A disconnected-state guard bails if `get_did()` is empty (a cron event queued just before disconnect would otherwise hit `putRecord` with an empty `repo`).

    The initial version of this PR also cleared `atmosphere_publication_uri` on disconnect and re-stamped it on every sync. Code review caught that the option is never consumed in production — both the well-known endpoint and the Document transformer's `site` reference derive the URI on demand from `get_did()` + the publication TID. The constant has been removed; `Client::disconnect()` now sweeps the stale row from 1.0.0 installs.

3. **"Use my domain as Bluesky handle" button hung at `admin-post.php` with an empty `wp_die` page.** Root cause: the button submitted through the WordPress Settings form, which carries a hidden `action=update` from `settings_fields()`. PHP merges `$_REQUEST` from GET then POST, so the POST value won the URL `?action=atmosphere_set_domain_handle`, and `admin-post.php` dispatched `admin_post_update` instead of our handler — empty page. Fix: leave the button inside the Settings form with a distinct `name="atmosphere_set_domain_handle" value="1"` field, and detect it on `admin_init` BEFORE `options.php` runs. The new handler validates trigger field → capability → option-group → nonce, then calls `Handle::set_handle()`. Removed the previous `admin_post_atmosphere_set_domain_handle` handler entirely.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
  - Full rewrite of `class-test-admin-handle.php` pinning the four gates (capability, trigger field, option_page match, nonce) plus the happy path.
  - Regression test for the disconnected-state guard in `sync_publication()`.
  - Regression test for `Client::disconnect()` sweeping the stale `atmosphere_publication_uri` row from 1.0.0 installs.

## Testing instructions:

**Publishing classifier (#1)**
1. Connect the plugin to a Bluesky account.
2. Create a new post in draft.
3. Preview the post (or otherwise trigger `wp_head` on its permalink) — this is what lazily writes `Document::META_TID`.
4. Publish the post.
5. Confirm the post lands on Bluesky and the document record is created. Before this fix, the publish would silently no-op.

**Publication sync after reconnect to a different DID (#2)**
1. Connect, then disconnect from the Settings page.
2. Reconnect to a *different* account (different DID).
3. Visit `https://your-domain/.well-known/site.standard.publication` and the standard.site validator — both should reflect the new DID's AT-URI. Before this fix, `sync_publication()` could send `createRecord` against a repo that already had a publication record, leaving local + PDS state inconsistent.

**Set-domain-handle button (#3)**
1. Configure WordPress to be installed at a root URL (`https://example.com`, not `https://example.com/blog`).
2. From the ATmosphere Settings page, click **Use my domain as my Bluesky handle**.
3. The page should return to the Settings page with the handle updated (admin pays a synchronous wait while the PDS verifies the well-known DID — typically <5s, allow up to ~60s on slow DNS). Before this fix, the button rendered an empty `wp_die` page at `admin-post.php`.

Lint clean. 389 unit tests pass.

### Changelog entry

Already added in `.github/changelog/fix-publishing-and-handle-after-1-0-0`.