### PR TITLE
Add publication link tag for standard.site discovery

### DIFF
--- a/.github/changelog/add-publication-link-tag
+++ b/.github/changelog/add-publication-link-tag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Advertise the site's standard.site publication record from the front page and from each published post via a new `<link rel="site.standard.publication">` tag, alongside the existing document link.

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -109,6 +109,7 @@ class Atmosphere {
 
 		// Frontend verification headers.
 		\add_action( 'wp_head', array( $this, 'output_document_link' ) );
+		\add_action( 'wp_head', array( $this, 'output_publication_link' ) );
 
 		// Well-known endpoints.
 		\add_action( 'init', array( $this, 'register_wellknown_rewrite' ) );
@@ -223,6 +224,55 @@ class Atmosphere {
 
 		\printf(
 			'<link rel="site.standard.document" href="%s" />' . "\n",
+			\esc_attr( $uri )
+		);
+	}
+
+	/**
+	 * Output `<link rel="site.standard.publication">` on the URLs that
+	 * map to the publication record's `url` field.
+	 *
+	 * Emitted on:
+	 *
+	 * - Singular publishable posts, so a resolver landing on an article
+	 *   URL can find the parent publication directly without first
+	 *   fetching the document record.
+	 * - The WordPress front page, since the publication record's `url`
+	 *   field is `home_url('/')`. Lets a resolver verify the page <->
+	 *   publication binding by matching AT-URIs, sparing the
+	 *   `.well-known/site.standard.publication` round-trip.
+	 *
+	 * Gated on `has_identity()` (not `is_connected()`) so the
+	 * verification link survives transient OAuth refresh failures, in
+	 * lockstep with {@see Atmosphere::output_document_link()}.
+	 */
+	public function output_publication_link(): void {
+		if ( ! has_identity() ) {
+			return;
+		}
+
+		$pub_tid = \get_option( Publication::OPTION_TID );
+
+		if ( ! $pub_tid ) {
+			return;
+		}
+
+		if ( \is_singular() ) {
+			$post = \get_queried_object();
+			if ( ! $post instanceof \WP_Post ) {
+				return;
+			}
+			if ( ! is_post_publishable( $post ) ) {
+				return;
+			}
+		} elseif ( ! \is_front_page() ) {
+			return;
+		}
+
+		$uri = build_at_uri( get_did(), 'site.standard.publication', $pub_tid );
+
+		\printf(
+			'<link rel="site.standard.publication" href="%s" />' . "\n",
 			\esc_attr( $uri )
 		);
 	}

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -257,15 +257,7 @@ class Atmosphere {
 			return;
 		}
 
-		if ( \is_singular() ) {
-			$post = \get_queried_object();
-			if ( ! $post instanceof \WP_Post ) {
-				return;
-			}
-			if ( ! is_post_publishable( $post ) ) {
-				return;
-			}
-		} elseif ( ! \is_front_page() ) {
+		if ( ! self::is_publication_url() ) {
 			return;
 		}
 
@@ -275,6 +267,33 @@ class Atmosphere {
 			'<link rel="site.standard.publication" href="%s" />' . "\n",
 			\esc_attr( $uri )
 		);
+	}
+
+	/**
+	 * Whether the current request URL maps to the publication record's
+	 * `url` field — i.e. a URL where the `<link rel="site.standard.publication">`
+	 * tag belongs.
+	 *
+	 * - The WordPress front page always qualifies, regardless of
+	 *   whether it shows posts or a static page (a static page set
+	 *   as front is both `is_front_page()` AND `is_singular('page')`;
+	 *   checking the front-page condition first is what keeps the
+	 *   tag emitting in that configuration).
+	 * - A publishable singular post qualifies because its document
+	 *   record carries a reference back to the publication.
+	 */
+	private static function is_publication_url(): bool {
+		if ( \is_front_page() ) {
+			return true;
+		}
+
+		if ( ! \is_singular() ) {
+			return false;
+		}
+
+		$post = \get_queried_object();
+
+		return $post instanceof \WP_Post && is_post_publishable( $post );
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -55,6 +55,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 	public function tear_down(): void {
 		\delete_option( 'atmosphere_connection' );
 		\delete_option( 'atmosphere_identity' );
+		\delete_option( 'atmosphere_publication_tid' );
 
 		\wp_clear_scheduled_hook( 'atmosphere_publish_post' );
 		\wp_clear_scheduled_hook( 'atmosphere_update_post' );
@@ -1598,5 +1599,140 @@ class Test_Atmosphere extends WP_UnitTestCase {
 		);
 
 		\remove_all_filters( 'atmosphere_pre_apply_writes' );
+	}
+
+	/**
+	 * Capture what `output_publication_link()` prints to stdout.
+	 *
+	 * @return string Output (empty when the method bails before emit).
+	 */
+	private function capture_publication_link(): string {
+		\ob_start();
+		$this->atmosphere->output_publication_link();
+		return (string) \ob_get_clean();
+	}
+
+	/**
+	 * Drive the WP query into a state where `is_singular()` resolves to
+	 * a real post object — `go_to()` is the supported way to drop the
+	 * unit-test request into the singular branch of template_redirect.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	private function go_to_post( int $post_id ): void {
+		$this->go_to( (string) \get_permalink( $post_id ) );
+		// Belt-and-suspenders: `is_singular()` reads from $wp_query.
+		global $wp_query;
+		$wp_query->queried_object    = \get_post( $post_id );
+		$wp_query->queried_object_id = $post_id;
+	}
+
+	/**
+	 * Drive the WP query into the front-page state.
+	 */
+	private function go_to_front_page(): void {
+		$this->go_to( \home_url( '/' ) );
+	}
+
+	/**
+	 * Publication link tag fires on a singular publishable post whenever
+	 * the site has minted its publication TID — that's the URL a third-
+	 * party resolver would land on after following a permalink from a
+	 * federated post, so they can find the parent publication without
+	 * fetching the document first.
+	 */
+	public function test_output_publication_link_emits_on_singular_publishable_post() {
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$this->go_to_post( $post_id );
+
+		$output = $this->capture_publication_link();
+
+		$this->assertStringContainsString(
+			'<link rel="site.standard.publication" href="at://did:plc:test123/site.standard.publication/3kpubtid000000" />',
+			$output
+		);
+	}
+
+	/**
+	 * Publication link tag fires on the WordPress front page, since the
+	 * publication record's `url` field is `home_url('/')`. Lets a
+	 * resolver verify the page-to-publication binding by matching
+	 * AT-URIs instead of round-tripping through `.well-known`.
+	 */
+	public function test_output_publication_link_emits_on_front_page() {
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+		$this->go_to_front_page();
+
+		$output = $this->capture_publication_link();
+
+		$this->assertStringContainsString(
+			'<link rel="site.standard.publication" href="at://did:plc:test123/site.standard.publication/3kpubtid000000" />',
+			$output
+		);
+	}
+
+	/**
+	 * No emission when the site has not yet minted a publication TID
+	 * (fresh install, pre-sync). Without a TID there is no AT-URI to
+	 * point a resolver at, so emitting an empty `href` would be worse
+	 * than silence.
+	 */
+	public function test_output_publication_link_bails_without_publication_tid() {
+		\delete_option( 'atmosphere_publication_tid' );
+		$this->go_to_front_page();
+
+		$output = $this->capture_publication_link();
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * No emission when the plugin is disconnected (no persisted
+	 * identity). The gate mirrors {@see Atmosphere::output_document_link()}
+	 * so the two link tags appear and disappear together.
+	 */
+	public function test_output_publication_link_bails_without_identity() {
+		\delete_option( 'atmosphere_connection' );
+		\delete_option( 'atmosphere_identity' );
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+		$this->go_to_front_page();
+
+		$output = $this->capture_publication_link();
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * No emission on archive / category / search / 404 pages — only the
+	 * front page or a publishable singular qualifies.
+	 */
+	public function test_output_publication_link_bails_on_non_singular_non_front_page() {
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+		$this->go_to( \home_url( '/?s=anything' ) );
+
+		$output = $this->capture_publication_link();
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * Singular posts that fail the publishability gate (e.g.
+	 * password-protected) get no publication tag either — it would
+	 * advertise a record we have not published and would not publish.
+	 */
+	public function test_output_publication_link_bails_on_non_publishable_singular() {
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+			)
+		);
+		$this->go_to_post( $post_id );
+
+		$output = $this->capture_publication_link();
+
+		$this->assertSame( '', $output );
 	}
 }

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -1673,6 +1673,50 @@ class Test_Atmosphere extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Publication link tag fires on a static front page too — the
+	 * common "Settings → Reading → A static page" configuration.
+	 *
+	 * `is_front_page()` and `is_singular('page')` are BOTH true in
+	 * that scenario; the publishability gate would otherwise reject
+	 * the request because `page` is not in the default supported
+	 * post type list. The tag must still emit because `home_url('/')`
+	 * — which the publication record's `url` field points at — is
+	 * the static page's permalink.
+	 */
+	public function test_output_publication_link_emits_on_static_front_page() {
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		$page_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Home',
+			)
+		);
+		\update_option( 'show_on_front', 'page' );
+		\update_option( 'page_on_front', $page_id );
+
+		// `?page_id=N` is the plain-permalink form WordPress uses to
+		// reach a singular page; with `page_on_front` set above,
+		// `WP_Query::is_front_page()` will recognise the queried page
+		// and flip both `is_singular()` and `is_front_page()` on.
+		$this->go_to( '?page_id=' . $page_id );
+
+		$this->assertTrue( \is_front_page(), 'Sanity check: static page must be the front page.' );
+		$this->assertTrue( \is_singular(), 'Sanity check: the static front page is also singular.' );
+
+		$output = $this->capture_publication_link();
+
+		\delete_option( 'show_on_front' );
+		\delete_option( 'page_on_front' );
+
+		$this->assertStringContainsString(
+			'<link rel="site.standard.publication" href="at://did:plc:test123/site.standard.publication/3kpubtid000000" />',
+			$output
+		);
+	}
+
+	/**
 	 * No emission when the site has not yet minted a publication TID
 	 * (fresh install, pre-sync). Without a TID there is no AT-URI to
 	 * point a resolver at, so emitting an empty `href` would be worse


### PR DESCRIPTION
## Proposed changes:

Adds a `<link rel="site.standard.publication">` head tag on the URLs where third-party resolvers expect to find the site's publication record, in lockstep with the existing `<link rel="site.standard.document">` discovery tag:

- **Singular publishable posts** — emitted alongside the document tag, so a resolver landing on an article URL can find the parent publication record directly instead of having to fetch the document record first to learn the publication's AT-URI.
- **WordPress front page** — the publication record's `url` field is `home_url('/')`, so a tag at that URL lets a resolver verify the page-to-publication binding by matching AT-URIs and skip the `.well-known/site.standard.publication` round-trip entirely.

Gates mirror `Atmosphere::output_document_link()`:

- `has_identity()` rather than `is_connected()`, so the verification link survives transient OAuth refresh failures.
- Bails if `Publication::OPTION_TID` has not been minted yet (fresh install, pre-sync).
- On singulars, bails when the post is not publishable (password-protected, unsupported post type, draft, etc.). On the front page, no per-post check is needed.

No emission on archives, search, 404 pages, or the blog index when a static front page is configured — those URLs do not match the publication's `url` field.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
  - Six tests cover: emission on singular publishable posts, emission on the front page, bail without identity, bail without a minted publication TID, bail on non-singular non-front pages, bail on non-publishable singulars.

## Testing instructions:

1. With the plugin connected and a publication already synced, visit a published post in the browser and View Source. Confirm both link tags appear in `<head>`:
   ```html
   <link rel="site.standard.document" href="at://did:plc:.../site.standard.document/..." />
   <link rel="site.standard.publication" href="at://did:plc:.../site.standard.publication/..." />
   ```
2. Visit the site's front page. Confirm only the publication tag is present (no document tag — there is no document at that URL).
3. Visit an archive (category or date archive). Confirm neither tag is present.
4. Disconnect the plugin. Re-visit either URL. Confirm neither tag is present.

`composer lint` clean. `npm run env-test` — 408/408 pass (+6 new).

### Changelog entry

Already added in `.github/changelog/add-publication-link-tag`.