### PR TITLE
Re-sync publication on theme and site-URL changes

### DIFF
--- a/.github/changelog/sync-publication-on-more-triggers
+++ b/.github/changelog/sync-publication-on-more-triggers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Refresh the site's publication record when the site URL, the active theme, or the theme's colours change, so the published record always reflects the current site state.

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -145,10 +145,27 @@ class Atmosphere {
 		\add_action( 'edit_comment', array( $this, 'on_comment_edit' ) );
 		\add_action( 'delete_comment', array( $this, 'on_comment_before_delete' ) );
 
-		// Auto-sync publication when site identity changes.
+		/*
+		 * Auto-sync the publication record whenever something the record
+		 * derives from changes. The record bakes in WordPress's site
+		 * identity (name, description, icon, home URL) and the active
+		 * theme's primary colours; keeping it in lockstep with those
+		 * sources avoids a stale publication on the PDS until the next
+		 * unrelated event happens to re-sync.
+		 *
+		 * Triggers cover both surfaces a site administrator can edit
+		 * theme colours from: classic-theme Customizer saves
+		 * (`customize_save_after`) and block-theme Site Editor saves
+		 * (the `wp_global_styles` post update).
+		 */
 		\add_action( 'update_option_blogname', array( $this, 'schedule_publication_sync' ) );
 		\add_action( 'update_option_blogdescription', array( $this, 'schedule_publication_sync' ) );
 		\add_action( 'update_option_site_icon', array( $this, 'schedule_publication_sync' ) );
+		\add_action( 'update_option_home', array( $this, 'schedule_publication_sync' ) );
+		\add_action( 'update_option_siteurl', array( $this, 'schedule_publication_sync' ) );
+		\add_action( 'switch_theme', array( $this, 'schedule_publication_sync' ) );
+		\add_action( 'save_post_wp_global_styles', array( $this, 'schedule_publication_sync' ) );
+		\add_action( 'customize_save_after', array( $this, 'schedule_publication_sync' ) );
 
 		// Token refresh cron.
 		\add_action( 'atmosphere_refresh_token', array( $this, 'cron_refresh_token' ) );

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -1612,8 +1612,6 @@ class Test_Atmosphere extends WP_UnitTestCase {
 	 * trigger set so a future refactor can't silently drop one.
 	 */
 	public function test_init_wires_publication_sync_triggers() {
-		$this->atmosphere->init();
-
 		$triggers = array(
 			'update_option_blogname',
 			'update_option_blogdescription',
@@ -1625,11 +1623,31 @@ class Test_Atmosphere extends WP_UnitTestCase {
 			'customize_save_after',
 		);
 
-		foreach ( $triggers as $trigger ) {
-			$this->assertNotFalse(
-				\has_action( $trigger, array( $this->atmosphere, 'schedule_publication_sync' ) ),
-				"{$trigger} must be wired to schedule_publication_sync."
-			);
+		$this->atmosphere->init();
+
+		try {
+			foreach ( $triggers as $trigger ) {
+				$this->assertNotFalse(
+					\has_action( $trigger, array( $this->atmosphere, 'schedule_publication_sync' ) ),
+					"{$trigger} must be wired to schedule_publication_sync."
+				);
+			}
+		} finally {
+			/*
+			 * `init()` writes to global hook + cron state that the WP test
+			 * framework does not roll back between tests. Roll back the
+			 * pieces our action triggers so a later test changing
+			 * `blogname` / `home` / etc. is not surprised by a spurious
+			 * `atmosphere_sync_publication` schedule, and clear the two
+			 * recurring crons `init()` queues so they do not survive
+			 * either.
+			 */
+			foreach ( $triggers as $trigger ) {
+				\remove_action( $trigger, array( $this->atmosphere, 'schedule_publication_sync' ) );
+			}
+			\wp_clear_scheduled_hook( 'atmosphere_sync_publication' );
+			\wp_clear_scheduled_hook( 'atmosphere_refresh_token' );
+			\wp_clear_scheduled_hook( 'atmosphere_sync_reactions' );
 		}
 	}
 }

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -1599,4 +1599,37 @@ class Test_Atmosphere extends WP_UnitTestCase {
 
 		\remove_all_filters( 'atmosphere_pre_apply_writes' );
 	}
+
+	/**
+	 * Every trigger that ought to schedule a publication re-sync is
+	 * wired up by `Atmosphere::init()`.
+	 *
+	 * The publication record bakes in WordPress's site identity (name,
+	 * description, icon, home URL) and the active theme's primary
+	 * colours; changing any of those sources without a re-sync would
+	 * leave the record on the PDS stale until the next unrelated
+	 * event happened to re-publish it. This test pins the full
+	 * trigger set so a future refactor can't silently drop one.
+	 */
+	public function test_init_wires_publication_sync_triggers() {
+		$this->atmosphere->init();
+
+		$triggers = array(
+			'update_option_blogname',
+			'update_option_blogdescription',
+			'update_option_site_icon',
+			'update_option_home',
+			'update_option_siteurl',
+			'switch_theme',
+			'save_post_wp_global_styles',
+			'customize_save_after',
+		);
+
+		foreach ( $triggers as $trigger ) {
+			$this->assertNotFalse(
+				\has_action( $trigger, array( $this->atmosphere, 'schedule_publication_sync' ) ),
+				"{$trigger} must be wired to schedule_publication_sync."
+			);
+		}
+	}
 }


### PR DESCRIPTION
## Proposed changes:

The publication record bakes in WordPress's site identity (name, description, icon, home URL) and the active theme's primary colours. The existing auto-sync trigger set covered name / description / icon but left several common change paths silent — the record would stay stale on the PDS until the next unrelated event happened to re-publish it.

Adds five additional triggers alongside the existing trio:

- **`update_option_home` / `update_option_siteurl`** — the publication's `url` field is `home_url('/')`. A moved-site without a re-sync leaves the record pointing at the old URL.
- **`switch_theme`** — a theme switch typically changes the primary colours the publication record reflects.
- **`save_post_wp_global_styles`** — block themes save Site Editor colour edits to a `wp_global_styles` post; the `update_option_*` hooks never fire for those edits.
- **`customize_save_after`** — classic-theme Customizer saves cover the surface block themes do not use.

`Atmosphere::schedule_publication_sync()` already guards on `is_connected()` and de-duplicates via `wp_next_scheduled()`, so over-firing on an unrelated Customizer save is a harmless no-op.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
  - One new test (`test_init_wires_publication_sync_triggers`) calls `Atmosphere::init()` and uses `has_action()` to assert all eight publication-sync triggers (existing three + new five) are wired to `schedule_publication_sync`. Pins the full set so a future refactor can't silently drop one.

## Testing instructions:

1. With the plugin connected, change Settings → General → Site Address (URL). Confirm an `atmosphere_sync_publication` cron event is scheduled (`wp cron event list | grep atmosphere_sync_publication`).
2. Switch the active theme (Appearance → Themes). Confirm the same event is scheduled.
3. On a classic theme: open the Customizer, change the background colour, click Publish. Confirm the event is scheduled.
4. On a block theme: open the Site Editor → Styles → change a colour token, click Save. Confirm the event is scheduled.
5. After the event fires (run cron with `wp cron event run atmosphere_sync_publication`), check the publication record on the PDS reflects the change.

`composer lint` clean. `npm run env-test` — 403/403 pass (+1 new).

### Changelog entry

Already added in `.github/changelog/sync-publication-on-more-triggers`.