### PR TITLE
Skip outbound publish for comment replies whose parent has no bsky record

### DIFF
--- a/.github/changelog/skip-orphan-comment-publish
+++ b/.github/changelog/skip-orphan-comment-publish
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop publishing replies to local-only WordPress comments to Bluesky. Previously such replies were demoted to a top-level reply on the post; they are now skipped so the Bluesky thread only mirrors comments whose ancestors are also on Bluesky.

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -1236,6 +1236,21 @@ class Atmosphere {
 				if ( self::defer_when_parent_pending( $comment ) ) {
 					return;
 				}
+				if ( ! self::parent_has_bsky_representation( $comment ) ) {
+					/*
+					 * Parent is local-only: anonymous WP commenter, an
+					 * ineligible comment that will never publish, or a
+					 * federation source other than bsky. Publishing the
+					 * reply anyway would either fail at strongRef
+					 * construction or fall back to a top-level reply on
+					 * the post (losing the WP thread context). Skip
+					 * instead, and clear the deferral counter so a
+					 * future re-publish (e.g. if the parent gains a URI
+					 * later) gets a fresh budget.
+					 */
+					\delete_comment_meta( $comment_id, self::META_PUBLISH_ATTEMPTS );
+					return;
+				}
 				\delete_comment_meta( $comment_id, self::META_PUBLISH_ATTEMPTS );
 
 				$result = Publisher::publish_comment( $comment );
@@ -1340,8 +1355,12 @@ class Atmosphere {
 		}
 
 		if ( ! self::should_publish_comment( $parent ) ) {
-			// Parent is ineligible (anon, rejected, etc.); resolve_parent_ref
-			// will fall back to root, which is the correct behavior.
+			// Parent is ineligible (anon, rejected, etc.). No reason to
+			// defer — it will never gain a bsky URI. The subsequent
+			// `parent_has_bsky_representation()` check in the cron
+			// handler will skip the publish entirely so we don't
+			// promote a nested WP reply into a confusing top-level
+			// bsky reply on the post.
 			return false;
 		}
 
@@ -1354,8 +1373,12 @@ class Atmosphere {
 		$attempts   = (int) \get_comment_meta( $comment_id, self::META_PUBLISH_ATTEMPTS, true );
 
 		if ( $attempts >= self::PARENT_DEFER_MAX_ATTEMPTS ) {
-			// Give up and publish with root as parent; clear the counter
-			// so a future re-publish gets a fresh deferral budget.
+			// Give up on the deferral budget; clear the counter so a
+			// future re-publish gets a fresh budget. The subsequent
+			// `parent_has_bsky_representation()` check skips the publish
+			// rather than letting `build_reply_ref()` fall back to a
+			// top-level reply on the post, which would lose the WP
+			// thread context.
 			\delete_comment_meta( $comment_id, self::META_PUBLISH_ATTEMPTS );
 			return false;
 		}
@@ -1368,6 +1391,47 @@ class Atmosphere {
 		);
 
 		return true;
+	}
+
+	/**
+	 * Whether the comment's immediate WP parent has an AT Protocol
+	 * representation that the reply record can thread under.
+	 *
+	 * Returns true when:
+	 *
+	 * - The comment has no parent (top-level reply to the post). The
+	 *   post itself has a bsky record; the publish path threads against
+	 *   that root.
+	 * - The parent comment carries {@see Comment::META_URI} — the
+	 *   plugin already published the parent to the PDS.
+	 * - The parent comment is marked as ingested by
+	 *   {@see Reaction_Sync} (`META_PROTOCOL = atproto`) — it came in
+	 *   from the bsky side, and the bsky URI / CID needed for the
+	 *   reply strongRef are on the row.
+	 *
+	 * Otherwise the parent is local-only: an anonymous WP commenter, an
+	 * un-publishable comment, or a comment from a different federation
+	 * source. Publishing a reply to it would either fail at strongRef
+	 * construction or — worse — silently promote the nested reply to a
+	 * top-level post via the root fallback in
+	 * {@see Comment::build_reply_ref()}, severing the WP thread context.
+	 * The cron handler skips the publish in that case.
+	 *
+	 * @param \WP_Comment $comment Comment about to be published.
+	 * @return bool
+	 */
+	private static function parent_has_bsky_representation( \WP_Comment $comment ): bool {
+		$parent_id = (int) $comment->comment_parent;
+
+		if ( $parent_id <= 0 ) {
+			return true;
+		}
+
+		if ( ! empty( \get_comment_meta( $parent_id, Comment::META_URI, true ) ) ) {
+			return true;
+		}
+
+		return 'atproto' === \get_comment_meta( $parent_id, Reaction_Sync::META_PROTOCOL, true );
 	}
 
 	/**

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -70,8 +70,10 @@ class Atmosphere {
 	/**
 	 * Maximum re-schedule hops for a child comment waiting on a
 	 * not-yet-published parent. After this many deferrals the child
-	 * publishes as a top-level reply on the post (current fallback
-	 * behavior) so a stuck parent does not block it forever.
+	 * is skipped if the parent still lacks a threadable strongRef so a
+	 * stuck parent does not block it forever — see
+	 * {@see Atmosphere::parent_has_bsky_representation()} for the
+	 * skip rule.
 	 *
 	 * @var int
 	 */
@@ -1330,13 +1332,14 @@ class Atmosphere {
 	 *
 	 * Comments are scheduled as independent single events with no
 	 * dependency ordering: if a user approves a parent and its reply
-	 * together, the child's cron event can fire first, see
-	 * resolve_parent_ref() return null, and publish flat as a
-	 * top-level reply on the root post. This defers the child a short
-	 * interval (up to PARENT_DEFER_MAX_ATTEMPTS hops) to give the
-	 * parent time to publish first. After the cap the child publishes
-	 * anyway using the root fallback — a stuck parent must not block
-	 * the child forever.
+	 * together, the child's cron event can fire first and see
+	 * `resolve_parent_ref()` return null. This defers the child a
+	 * short interval (up to PARENT_DEFER_MAX_ATTEMPTS hops) so the
+	 * parent has time to publish first. After the cap the cron
+	 * handler's {@see Atmosphere::parent_has_bsky_representation()}
+	 * check skips the child entirely rather than letting
+	 * {@see Comment::build_reply_ref()} fall back to a top-level
+	 * reply on the post — losing the WP thread context.
 	 *
 	 * @param \WP_Comment $comment Comment being published.
 	 * @return bool True when the publish was deferred, false to proceed now.
@@ -1416,6 +1419,22 @@ class Atmosphere {
 	 * - The parent comment is marked as ingested by
 	 *   {@see Reaction_Sync} (`META_PROTOCOL = atproto`) AND carries
 	 *   both `META_SOURCE_ID` (URI) and `META_BSKY_CID`.
+	 *
+	 * Only the immediate parent is checked: any comment that passes
+	 * this gate was itself only publishable through the same gate, so
+	 * by induction every WP ancestor is also threadable.
+	 *
+	 * Known legacy edge case: sites that ran a pre-fix version of the
+	 * plugin may have "demoted" comments on bsky — comments whose
+	 * original WP parent was local-only but which the old root-fallback
+	 * still pushed to bsky as top-level replies under the post. Their
+	 * rows now carry valid `META_URI` / `META_CID`, so new replies to
+	 * them pass this gate even though the deeper WP ancestor chain is
+	 * incomplete. The strongRef itself is still valid (the demoted
+	 * comment is on bsky); the bsky-side view simply omits the
+	 * pre-existing local-only ancestor, which mirrors what the WP user
+	 * sees with the local-only commenter anyway. No further migration
+	 * is planned for those legacy rows.
 	 *
 	 * @param \WP_Comment $comment Comment about to be published.
 	 * @return bool

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -1395,27 +1395,27 @@ class Atmosphere {
 
 	/**
 	 * Whether the comment's immediate WP parent has an AT Protocol
-	 * representation that the reply record can thread under.
+	 * strongRef the reply record can thread under.
+	 *
+	 * Mirrors the exact requirements of {@see Comment::resolve_parent_ref()}:
+	 * a strongRef needs BOTH `uri` and `cid`. Half-state rows (URI
+	 * present but CID missing, or `META_PROTOCOL = atproto` without
+	 * the federated CID alongside) would let `resolve_parent_ref()`
+	 * fall through and `build_reply_ref()` substitute the post root,
+	 * silently promoting the nested reply to a top-level post — the
+	 * exact bug this check is here to prevent.
 	 *
 	 * Returns true when:
 	 *
 	 * - The comment has no parent (top-level reply to the post). The
 	 *   post itself has a bsky record; the publish path threads against
 	 *   that root.
-	 * - The parent comment carries {@see Comment::META_URI} — the
-	 *   plugin already published the parent to the PDS.
+	 * - The parent comment carries both {@see Comment::META_URI} and
+	 *   {@see Comment::META_CID} — the plugin already published the
+	 *   parent to the PDS.
 	 * - The parent comment is marked as ingested by
-	 *   {@see Reaction_Sync} (`META_PROTOCOL = atproto`) — it came in
-	 *   from the bsky side, and the bsky URI / CID needed for the
-	 *   reply strongRef are on the row.
-	 *
-	 * Otherwise the parent is local-only: an anonymous WP commenter, an
-	 * un-publishable comment, or a comment from a different federation
-	 * source. Publishing a reply to it would either fail at strongRef
-	 * construction or — worse — silently promote the nested reply to a
-	 * top-level post via the root fallback in
-	 * {@see Comment::build_reply_ref()}, severing the WP thread context.
-	 * The cron handler skips the publish in that case.
+	 *   {@see Reaction_Sync} (`META_PROTOCOL = atproto`) AND carries
+	 *   both `META_SOURCE_ID` (URI) and `META_BSKY_CID`.
 	 *
 	 * @param \WP_Comment $comment Comment about to be published.
 	 * @return bool
@@ -1427,11 +1427,20 @@ class Atmosphere {
 			return true;
 		}
 
-		if ( ! empty( \get_comment_meta( $parent_id, Comment::META_URI, true ) ) ) {
+		$local_uri = \get_comment_meta( $parent_id, Comment::META_URI, true );
+		$local_cid = \get_comment_meta( $parent_id, Comment::META_CID, true );
+		if ( ! empty( $local_uri ) && ! empty( $local_cid ) ) {
 			return true;
 		}
 
-		return 'atproto' === \get_comment_meta( $parent_id, Reaction_Sync::META_PROTOCOL, true );
+		if ( 'atproto' !== \get_comment_meta( $parent_id, Reaction_Sync::META_PROTOCOL, true ) ) {
+			return false;
+		}
+
+		$federated_uri = \get_comment_meta( $parent_id, Reaction_Sync::META_SOURCE_ID, true );
+		$federated_cid = \get_comment_meta( $parent_id, Reaction_Sync::META_BSKY_CID, true );
+
+		return ! empty( $federated_uri ) && ! empty( $federated_cid );
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -1830,4 +1830,228 @@ class Test_Atmosphere extends WP_UnitTestCase {
 			\wp_clear_scheduled_hook( 'atmosphere_sync_reactions' );
 		}
 	}
+
+	/**
+	 * Reply to a local-only parent comment (anonymous, never-published)
+	 * must not be published to the PDS. The previous behaviour would
+	 * silently demote the reply to a top-level post on the parent
+	 * article's bsky record after the deferral cap, losing the WP
+	 * thread context.
+	 */
+	public function test_publish_comment_skipped_when_parent_is_local_only() {
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post_id, Post::META_URI, 'at://did:plc:test123/app.bsky.feed.post/postroot' );
+		\update_post_meta( $post_id, Post::META_CID, 'bafypostroot' );
+
+		// Anonymous parent — `user_id = 0` makes the parent permanently
+		// ineligible for outbound publish, so it will never gain a
+		// bsky URI.
+		$parent_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_approved'     => '1',
+				'comment_type'         => 'comment',
+				'user_id'              => 0,
+				'comment_author'       => 'Anon',
+				'comment_author_email' => 'anon@example.com',
+				'comment_content'      => 'Anonymous comment.',
+			)
+		);
+
+		$child_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+				'comment_type'     => 'comment',
+				'user_id'          => self::factory()->user->create(),
+				'comment_content'  => 'Reply to anon.',
+				'comment_parent'   => $parent_id,
+			)
+		);
+
+		$apply_writes_calls = 0;
+		\add_filter(
+			'atmosphere_pre_apply_writes',
+			function () use ( &$apply_writes_calls ) {
+				++$apply_writes_calls;
+				return array(
+					'results' => array(
+						array(
+							'uri' => 'at://x',
+							'cid' => 'bafyx',
+						),
+					),
+				);
+			},
+			10,
+			2
+		);
+
+		\do_action( 'atmosphere_publish_comment', $child_id );
+
+		$this->assertSame( 0, $apply_writes_calls, 'No PDS call should be attempted when parent has no bsky representation.' );
+		$this->assertSame( '', (string) \get_comment_meta( $child_id, Comment::META_URI, true ), 'Child must not gain a bsky URI.' );
+		$this->assertSame( '', (string) \get_comment_meta( $child_id, '_atmosphere_publish_attempts', true ), 'Deferral counter must be cleared on skip.' );
+	}
+
+	/**
+	 * A reply whose parent comment was previously published to the PDS
+	 * (carries `Comment::META_URI`) IS published — that's the happy
+	 * thread-on-bsky path.
+	 */
+	public function test_publish_comment_proceeds_when_parent_has_bsky_uri() {
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post_id, Post::META_URI, 'at://did:plc:test123/app.bsky.feed.post/postroot' );
+		\update_post_meta( $post_id, Post::META_CID, 'bafypostroot' );
+
+		$parent_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+				'comment_type'     => 'comment',
+				'user_id'          => self::factory()->user->create(),
+				'comment_content'  => 'Already-published parent.',
+			)
+		);
+		\update_comment_meta( $parent_id, Comment::META_URI, 'at://did:plc:test123/app.bsky.feed.post/parent' );
+		\update_comment_meta( $parent_id, Comment::META_CID, 'bafyparent' );
+
+		$child_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+				'comment_type'     => 'comment',
+				'user_id'          => self::factory()->user->create(),
+				'comment_content'  => 'Reply.',
+				'comment_parent'   => $parent_id,
+			)
+		);
+
+		$apply_writes_calls = 0;
+		\add_filter(
+			'atmosphere_pre_apply_writes',
+			function ( $short, $writes ) use ( &$apply_writes_calls ) {
+				++$apply_writes_calls;
+				$results = array();
+				foreach ( $writes as $write ) {
+					$results[] = array(
+						'uri' => 'at://did:plc:test123/' . ( $write['collection'] ?? 'app.bsky.feed.post' ) . '/' . ( $write['rkey'] ?? 'tid' ),
+						'cid' => 'bafychild',
+					);
+				}
+				return array( 'results' => $results );
+			},
+			10,
+			2
+		);
+
+		\do_action( 'atmosphere_publish_comment', $child_id );
+
+		$this->assertSame( 1, $apply_writes_calls, 'Publish should proceed when parent has a bsky URI.' );
+	}
+
+	/**
+	 * A reply whose parent was imported from bsky (Reaction_Sync stamps
+	 * `META_PROTOCOL = atproto`) IS published — its bsky strongRef is
+	 * available even though the parent comment was never published
+	 * outbound by this site.
+	 */
+	public function test_publish_comment_proceeds_when_parent_was_imported_from_bsky() {
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post_id, Post::META_URI, 'at://did:plc:test123/app.bsky.feed.post/postroot' );
+		\update_post_meta( $post_id, Post::META_CID, 'bafypostroot' );
+
+		// Imported-from-bsky parent: no user_id (federation imports
+		// typically write `user_id = 0`), but `META_PROTOCOL = atproto`
+		// signals "this row has a bsky URI we can thread under".
+		$parent_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_approved'     => '1',
+				'comment_type'         => 'comment',
+				'user_id'              => 0,
+				'comment_author'       => 'Federated User',
+				'comment_author_email' => 'fed@example.com',
+				'comment_content'      => 'Imported reply.',
+			)
+		);
+		\update_comment_meta( $parent_id, Reaction_Sync::META_PROTOCOL, 'atproto' );
+		\update_comment_meta( $parent_id, Reaction_Sync::META_SOURCE_ID, 'at://did:plc:other/app.bsky.feed.post/fedparent' );
+
+		$child_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+				'comment_type'     => 'comment',
+				'user_id'          => self::factory()->user->create(),
+				'comment_content'  => 'Reply to federated.',
+				'comment_parent'   => $parent_id,
+			)
+		);
+
+		$apply_writes_calls = 0;
+		\add_filter(
+			'atmosphere_pre_apply_writes',
+			function ( $short, $writes ) use ( &$apply_writes_calls ) {
+				++$apply_writes_calls;
+				$results = array();
+				foreach ( $writes as $write ) {
+					$results[] = array(
+						'uri' => 'at://did:plc:test123/' . ( $write['collection'] ?? 'app.bsky.feed.post' ) . '/' . ( $write['rkey'] ?? 'tid' ),
+						'cid' => 'bafychild',
+					);
+				}
+				return array( 'results' => $results );
+			},
+			10,
+			2
+		);
+
+		\do_action( 'atmosphere_publish_comment', $child_id );
+
+		$this->assertSame( 1, $apply_writes_calls, 'Publish should proceed when parent was imported from bsky.' );
+	}
+
+	/**
+	 * A top-level comment (no `comment_parent`) always proceeds —
+	 * the post's own bsky record is the thread root, no per-comment
+	 * parent check applies.
+	 */
+	public function test_publish_comment_proceeds_for_top_level_comment() {
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post_id, Post::META_URI, 'at://did:plc:test123/app.bsky.feed.post/postroot' );
+		\update_post_meta( $post_id, Post::META_CID, 'bafypostroot' );
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+				'comment_type'     => 'comment',
+				'user_id'          => self::factory()->user->create(),
+				'comment_content'  => 'Top-level comment.',
+			)
+		);
+
+		$apply_writes_calls = 0;
+		\add_filter(
+			'atmosphere_pre_apply_writes',
+			function ( $short, $writes ) use ( &$apply_writes_calls ) {
+				++$apply_writes_calls;
+				$results = array();
+				foreach ( $writes as $write ) {
+					$results[] = array(
+						'uri' => 'at://did:plc:test123/' . ( $write['collection'] ?? 'app.bsky.feed.post' ) . '/' . ( $write['rkey'] ?? 'tid' ),
+						'cid' => 'bafytop',
+					);
+				}
+				return array( 'results' => $results );
+			},
+			10,
+			2
+		);
+
+		\do_action( 'atmosphere_publish_comment', $comment_id );
+
+		$this->assertSame( 1, $apply_writes_calls, 'Top-level comment publish should proceed unconditionally.' );
+	}
 }

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -1868,6 +1868,11 @@ class Test_Atmosphere extends WP_UnitTestCase {
 				'comment_parent'   => $parent_id,
 			)
 		);
+		// Seed a non-empty deferral counter so the post-skip assertion
+		// distinguishes "the cron handler cleared it" from "no value
+		// was ever written" — comment meta defaults to '' otherwise
+		// and the assertion would be trivially true.
+		\update_comment_meta( $child_id, '_atmosphere_publish_attempts', 2 );
 
 		$apply_writes_calls = 0;
 		\add_filter(

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -1977,6 +1977,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 		);
 		\update_comment_meta( $parent_id, Reaction_Sync::META_PROTOCOL, 'atproto' );
 		\update_comment_meta( $parent_id, Reaction_Sync::META_SOURCE_ID, 'at://did:plc:other/app.bsky.feed.post/fedparent' );
+		\update_comment_meta( $parent_id, Reaction_Sync::META_BSKY_CID, 'bafyfedparent' );
 
 		$child_id = self::factory()->comment->create(
 			array(
@@ -2053,5 +2054,68 @@ class Test_Atmosphere extends WP_UnitTestCase {
 		\do_action( 'atmosphere_publish_comment', $comment_id );
 
 		$this->assertSame( 1, $apply_writes_calls, 'Top-level comment publish should proceed unconditionally.' );
+	}
+
+	/**
+	 * Half-state guard: a parent that has `Comment::META_URI` but no
+	 * matching `META_CID` must NOT count as having a bsky
+	 * representation. `Comment::resolve_parent_ref()` requires both
+	 * fields for the reply strongRef and would otherwise fall back to
+	 * the post root — reintroducing the top-level-fallback bug the
+	 * cron-handler gate is here to prevent. Symmetric check on the
+	 * federated path (atproto protocol flag without `META_BSKY_CID`)
+	 * is exercised by the existing tests via shared code paths.
+	 */
+	public function test_publish_comment_skipped_when_parent_has_uri_but_no_cid() {
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post_id, Post::META_URI, 'at://did:plc:test123/app.bsky.feed.post/postroot' );
+		\update_post_meta( $post_id, Post::META_CID, 'bafypostroot' );
+
+		$parent_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+				'comment_type'     => 'comment',
+				'user_id'          => self::factory()->user->create(),
+				'comment_content'  => 'Half-published parent.',
+			)
+		);
+		// URI present but CID missing — a half-state row that would
+		// previously slip past the parent_has_bsky_representation
+		// gate yet still fall back to root in build_reply_ref().
+		\update_comment_meta( $parent_id, Comment::META_URI, 'at://did:plc:test123/app.bsky.feed.post/parent' );
+
+		$child_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+				'comment_type'     => 'comment',
+				'user_id'          => self::factory()->user->create(),
+				'comment_content'  => 'Reply to half-state.',
+				'comment_parent'   => $parent_id,
+			)
+		);
+
+		$apply_writes_calls = 0;
+		\add_filter(
+			'atmosphere_pre_apply_writes',
+			function () use ( &$apply_writes_calls ) {
+				++$apply_writes_calls;
+				return array(
+					'results' => array(
+						array(
+							'uri' => 'at://x',
+							'cid' => 'bafyx',
+						),
+					),
+				);
+			},
+			10,
+			2
+		);
+
+		\do_action( 'atmosphere_publish_comment', $child_id );
+
+		$this->assertSame( 0, $apply_writes_calls, 'Publish must be skipped when parent has URI but no CID.' );
 	}
 }


### PR DESCRIPTION
Fixes #77.

## Proposed changes:

A WP comment replying to a **local-only** parent (anonymous commenter, permanently-ineligible comment, federation source other than bsky) had no AT Protocol representation to thread under. The previous behaviour deferred the publish up to three times (`PARENT_DEFER_MAX_ATTEMPTS`), then gave up and published the reply as a **top-level** reply on the post's bsky record via `Comment::build_reply_ref()`'s root fallback. That promoted a nested WP discussion into a confusing top-level bsky post and severed the WP thread context.

This PR moves the gate into the cron handler. A new `Atmosphere::parent_has_bsky_representation()` helper returns true when:

- The comment is top-level (no `comment_parent`).
- The parent comment carries `Comment::META_URI` (the plugin already published it).
- The parent comment was ingested by `Reaction_Sync` (`META_PROTOCOL = 'atproto'`).

Otherwise the cron handler clears the deferral counter and returns — no PDS call. The immediate-parent check is sufficient by induction: a parent that's on bsky was itself only publishable because its own ancestors were also on bsky (or it's top-level).

`defer_when_parent_pending()` keeps its existing role of giving an eligible-but-not-yet-published parent time to land. The new check kicks in only after the deferral budget is spent or when the parent was permanently ineligible. Comments in two of its branches that previously claimed "fall back to root, which is the correct behavior" have been updated — that fallback was the bug being fixed.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
  - Skip path: anonymous (local-only) parent → no PDS call, no bsky URI on child, deferral counter cleared.
  - Proceed path: parent has `Comment::META_URI` (already published).
  - Proceed path: parent has `Reaction_Sync::META_PROTOCOL = 'atproto'` (imported).
  - Proceed path: top-level comment (no parent).

## Testing instructions:

1. Connect the plugin to a Bluesky account.
2. As an anonymous (or logged-out) visitor, post a comment on a published WordPress post.
3. As an administrator, reply to that anonymous comment.
4. Confirm the reply does **not** appear on Bluesky. Before this fix, after ~90 seconds the reply landed on Bluesky as a top-level reply to the post.
5. Sanity check: in a separate post, a registered-user comment replying to another registered-user comment that already exists on Bluesky should still publish as a nested reply (existing behaviour).

`composer lint` clean. `npm run env-test` — 414/414 pass (+4 new).

### Changelog entry

Already added in `.github/changelog/skip-orphan-comment-publish`.