### PR TITLE
Fix ATMOSPHERE_VERSION constant and release-script regex

### DIFF
--- a/.github/changelog/fix-version-constant
+++ b/.github/changelog/fix-version-constant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Refresh admin assets after updating, so the latest styles and scripts load correctly.

--- a/atmosphere.php
+++ b/atmosphere.php
@@ -19,7 +19,7 @@ namespace Atmosphere;
 
 \defined( 'ABSPATH' ) || exit;
 
-\define( 'ATMOSPHERE_VERSION', '1.0.0' );
+\define( 'ATMOSPHERE_VERSION', '1.1.0' );
 \define( 'ATMOSPHERE_PLUGIN_DIR', \plugin_dir_path( __FILE__ ) );
 \define( 'ATMOSPHERE_PLUGIN_URL', \plugin_dir_url( __FILE__ ) );
 \define( 'ATMOSPHERE_PLUGIN_FILE', __FILE__ );

--- a/bin/release.js
+++ b/bin/release.js
@@ -221,8 +221,8 @@ async function createRelease() {
 			replace: `Version: ${ version }`,
 		},
 		{
-			search: /ATMOSPHERE_PLUGIN_VERSION', '\d+\.\d+\.\d+/,
-			replace: `ATMOSPHERE_PLUGIN_VERSION', '${ version }`,
+			search: /ATMOSPHERE_VERSION', '\d+\.\d+\.\d+/,
+			replace: `ATMOSPHERE_VERSION', '${ version }`,
 		},
 	] );
 


### PR DESCRIPTION
Fixes #

## Proposed changes:

* Bump the runtime `ATMOSPHERE_VERSION` constant in `atmosphere.php` from `1.0.0` to `1.1.0` so it matches the `Version:` header shipped in 1.1.0.
* Fix the regex in `bin/release.js` that was supposed to bump that constant on every release — it searched for `ATMOSPHERE_PLUGIN_VERSION`, a name the codebase never uses, so the bump never matched. The next release will now keep the header and the constant in sync automatically.

### Why this matters

`ATMOSPHERE_VERSION` is used in two end-user-visible places:

* `Atmosphere\WP_Admin\Admin::enqueue_*` — asset version for cache-busting admin CSS/JS. Sites upgrading to 1.1.0 kept serving stale assets.
* `Atmosphere\Reaction_Sync::sync_*` — `comment_agent` string sent to the PDS as `ATmosphere/{version}`. Sites running 1.1.0 advertised themselves as 1.0.0 to remote services.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

No new tests — the change is a one-character constant value and a one-word regex fix. Verifying the next release bumps the constant correctly will be observable on the release PR itself.

## Testing instructions:

1. Check out this branch.
2. Open `atmosphere.php` and confirm line 22 reads `\define( 'ATMOSPHERE_VERSION', '1.1.0' );`.
3. Confirm the file header still says `Version: 1.1.0` on line 6.
4. Dry-check the release script regex against the file content:
   ```bash
   node -e "console.log(/ATMOSPHERE_VERSION', '\d+\.\d+\.\d+/.test(require('fs').readFileSync('atmosphere.php','utf8')))"
   ```
   Should print `true`. (The previous regex with `ATMOSPHERE_PLUGIN_VERSION` would have printed `false`.)
5. Optional: in a wp-env environment, load any admin screen and confirm enqueued asset URLs include `?ver=1.1.0`.

### Changelog entry

Already added at `.github/changelog/fix-version-constant`.