### PR TITLE
Fix unreliable well-known rewrite flush causing domain handle verification failures

### DIFF
--- a/.github/changelog/fix-wellknown-rewrite-flush
+++ b/.github/changelog/fix-wellknown-rewrite-flush
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix domain handle verification failing on some sites when using your site's domain as your Bluesky handle.

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -318,12 +318,13 @@ class Atmosphere {
 	/**
 	 * Regex patterns of the well-known rewrite rules this plugin owns.
 	 *
-	 * Kept as a single source of truth so {@see register_wellknown_rewrite()}
-	 * and {@see maybe_flush_wellknown_rewrites()} stay in lockstep — if a
+	 * Maps each pattern to its `index.php` query target. Kept as a single
+	 * source of truth so {@see register_wellknown_rewrite()} and
+	 * {@see maybe_flush_wellknown_rewrites()} stay in lockstep — if a
 	 * future rule is added or renamed, both surfaces pick it up without
 	 * a separate edit, and the persisted-rules check still detects drift.
 	 *
-	 * @var string[]
+	 * @var array<string, string>
 	 */
 	private const WELLKNOWN_REWRITE_PATTERNS = array(
 		'^\.well-known/atproto-did$'                 => 'index.php?atmosphere_wellknown=atproto-did',
@@ -389,17 +390,26 @@ class Atmosphere {
 	 * our rules take effect without touching the webserver config.
 	 */
 	public static function maybe_flush_wellknown_rewrites(): void {
+		global $wp_rewrite;
+
 		/*
-		 * Plain permalinks (the WordPress default `?p=N` scheme, where
-		 * `permalink_structure` is empty) keep `rewrite_rules` empty and
-		 * route every request through the query string. Our
-		 * `^\.well-known/...$` patterns can never appear in the persisted
-		 * array on such a site, and the endpoints cannot resolve via
-		 * rewrite there regardless. Bail before the missing-pattern check
-		 * so we do not read an always-empty array as "patterns missing"
-		 * and burn an `update_option` write on every call.
+		 * Plain permalinks (the WordPress default `?p=N` scheme) keep
+		 * `rewrite_rules` empty and route every request through the query
+		 * string. Our `^\.well-known/...$` patterns can never appear in
+		 * the persisted array on such a site, and the endpoints cannot
+		 * resolve via rewrite there regardless. Bail before the
+		 * missing-pattern check so we do not read an always-empty array
+		 * as "patterns missing" and burn an `update_option` write on
+		 * every call.
+		 *
+		 * Read the state from `$wp_rewrite` rather than the
+		 * `permalink_structure` option: `flush_rewrite_rules()` rebuilds
+		 * from `$wp_rewrite`'s in-memory structure, so gating on the same
+		 * source keeps the guard and the flush in agreement even if
+		 * something wrote the option directly after `WP_Rewrite::init()`
+		 * ran this request.
 		 */
-		if ( '' === (string) \get_option( 'permalink_structure', '' ) ) {
+		if ( ! $wp_rewrite instanceof \WP_Rewrite || ! $wp_rewrite->using_permalinks() ) {
 			return;
 		}
 

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -444,8 +444,8 @@ class Atmosphere {
 		$rules = \get_option( 'rewrite_rules' );
 
 		if ( \is_array( $rules ) ) {
-			foreach ( \array_keys( self::WELLKNOWN_REWRITE_PATTERNS ) as $pattern ) {
-				if ( ! isset( $rules[ $pattern ] ) ) {
+			foreach ( self::WELLKNOWN_REWRITE_PATTERNS as $pattern => $target ) {
+				if ( ! isset( $rules[ $pattern ] ) || $rules[ $pattern ] !== $target ) {
 					\flush_rewrite_rules( false );
 					return;
 				}

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -316,20 +316,27 @@ class Atmosphere {
 	}
 
 	/**
+	 * Regex patterns of the well-known rewrite rules this plugin owns.
+	 *
+	 * Kept as a single source of truth so {@see register_wellknown_rewrite()}
+	 * and {@see maybe_flush_wellknown_rewrites()} stay in lockstep — if a
+	 * future rule is added or renamed, both surfaces pick it up without
+	 * a separate edit, and the persisted-rules check still detects drift.
+	 *
+	 * @var string[]
+	 */
+	private const WELLKNOWN_REWRITE_PATTERNS = array(
+		'^\.well-known/atproto-did$'                 => 'index.php?atmosphere_wellknown=atproto-did',
+		'^\.well-known/site\.standard\.publication$' => 'index.php?atmosphere_wellknown=publication',
+	);
+
+	/**
 	 * Register rewrite rules for well-known endpoints.
 	 */
 	public function register_wellknown_rewrite(): void {
-		\add_rewrite_rule(
-			'^\.well-known/atproto-did$',
-			'index.php?atmosphere_wellknown=atproto-did',
-			'top'
-		);
-
-		\add_rewrite_rule(
-			'^\.well-known/site\.standard\.publication$',
-			'index.php?atmosphere_wellknown=publication',
-			'top'
-		);
+		foreach ( self::WELLKNOWN_REWRITE_PATTERNS as $pattern => $target ) {
+			\add_rewrite_rule( $pattern, $target, 'top' );
+		}
 
 		\add_filter(
 			'query_vars',
@@ -338,6 +345,67 @@ class Atmosphere {
 				return $vars;
 			}
 		);
+	}
+
+	/**
+	 * Ensure the well-known rewrite rules are present in the persisted
+	 * `rewrite_rules` option, and flush them in if not.
+	 *
+	 * The activation hook flushes once, but the rule set can drift away
+	 * from the persisted array later for several real install paths:
+	 *
+	 * - Programmatic loads (FOSSE bundle, `require_once`, mu-plugin,
+	 *   etc.) never fire `register_activation_hook`, so the initial
+	 *   flush never runs.
+	 * - Some plugins or hosts wipe `wp_options.rewrite_rules` outside
+	 *   of activation. WP then rebuilds the array from whatever rules
+	 *   happen to be registered at that moment, which may or may not
+	 *   include ours.
+	 * - Another plugin that flushes earlier on `init` than our rule
+	 *   registration produces a persisted array missing our patterns.
+	 *
+	 * In all three cases the runtime registration in
+	 * {@see register_wellknown_rewrite()} keeps happening on every
+	 * request but is functionally inert, because WP routes from the
+	 * persisted array, not the in-memory one. The user-facing symptom
+	 * is "External handle did not resolve to DID" when the PDS fetches
+	 * `/.well-known/atproto-did` and WP serves the normal 404 template
+	 * instead of our handler.
+	 *
+	 * Called surgically from the moments that matter so this is not
+	 * paid on every request:
+	 *
+	 * - After a successful OAuth handshake persists an identity —
+	 *   {@see \Atmosphere\OAuth\Client::handle_callback()}.
+	 * - When an administrator loads the Atmosphere settings page —
+	 *   {@see \Atmosphere\WP_Admin\Admin::add_menu()}.
+	 * - Before the `updateHandle` XRPC call, which triggers the PDS to
+	 *   fetch the well-known endpoint immediately —
+	 *   {@see \Atmosphere\Handle::set_handle()}.
+	 *
+	 * Uses a soft flush (no `.htaccess` rewrite): WordPress's default
+	 * rewrite fallback already routes unmatched URLs to `index.php`, so
+	 * refreshing the persisted `rewrite_rules` option is enough to make
+	 * our rules take effect without touching the webserver config.
+	 */
+	public static function maybe_flush_wellknown_rewrites(): void {
+		$rules = \get_option( 'rewrite_rules' );
+
+		if ( \is_array( $rules ) ) {
+			$missing = false;
+			foreach ( \array_keys( self::WELLKNOWN_REWRITE_PATTERNS ) as $pattern ) {
+				if ( ! isset( $rules[ $pattern ] ) ) {
+					$missing = true;
+					break;
+				}
+			}
+
+			if ( ! $missing ) {
+				return;
+			}
+		}
+
+		\flush_rewrite_rules( false );
 	}
 
 	/**

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -389,20 +389,31 @@ class Atmosphere {
 	 * our rules take effect without touching the webserver config.
 	 */
 	public static function maybe_flush_wellknown_rewrites(): void {
+		/*
+		 * Plain permalinks (the WordPress default `?p=N` scheme, where
+		 * `permalink_structure` is empty) keep `rewrite_rules` empty and
+		 * route every request through the query string. Our
+		 * `^\.well-known/...$` patterns can never appear in the persisted
+		 * array on such a site, and the endpoints cannot resolve via
+		 * rewrite there regardless. Bail before the missing-pattern check
+		 * so we do not read an always-empty array as "patterns missing"
+		 * and burn an `update_option` write on every call.
+		 */
+		if ( '' === (string) \get_option( 'permalink_structure', '' ) ) {
+			return;
+		}
+
 		$rules = \get_option( 'rewrite_rules' );
 
 		if ( \is_array( $rules ) ) {
-			$missing = false;
 			foreach ( \array_keys( self::WELLKNOWN_REWRITE_PATTERNS ) as $pattern ) {
 				if ( ! isset( $rules[ $pattern ] ) ) {
-					$missing = true;
-					break;
+					\flush_rewrite_rules( false );
+					return;
 				}
 			}
 
-			if ( ! $missing ) {
-				return;
-			}
+			return;
 		}
 
 		\flush_rewrite_rules( false );

--- a/includes/class-handle.php
+++ b/includes/class-handle.php
@@ -190,15 +190,12 @@ class Handle {
 		}
 
 		/*
-		 * Self-heal the well-known rewrite before the XRPC call. The PDS
-		 * fetches `/.well-known/atproto-did` on this domain within
-		 * milliseconds of `updateHandle`, and on installs where the
-		 * persisted `rewrite_rules` option never picked up our pattern
-		 * (FOSSE bundle, mu-plugin load, rules wiped by another plugin)
-		 * that fetch returns the default WP 404 template — the PDS then
-		 * replies with "External handle did not resolve to DID" while
-		 * the admin's settings UI still shows a healthy connection.
-		 * Flushing here closes the bug at its actual failure surface.
+		 * Self-heal the well-known rewrite before the XRPC call: the PDS
+		 * fetches `/.well-known/atproto-did` within milliseconds of
+		 * `updateHandle`, so the persisted rule must be in place by then.
+		 * This is the exact failure surface from issue 90. See
+		 * {@see Atmosphere::maybe_flush_wellknown_rewrites()} for why the
+		 * activation-time flush alone is not enough.
 		 */
 		Atmosphere::maybe_flush_wellknown_rewrites();
 

--- a/includes/class-handle.php
+++ b/includes/class-handle.php
@@ -189,6 +189,19 @@ class Handle {
 			\update_option( self::OPTION_PREVIOUS_HANDLE, $current, false );
 		}
 
+		/*
+		 * Self-heal the well-known rewrite before the XRPC call. The PDS
+		 * fetches `/.well-known/atproto-did` on this domain within
+		 * milliseconds of `updateHandle`, and on installs where the
+		 * persisted `rewrite_rules` option never picked up our pattern
+		 * (FOSSE bundle, mu-plugin load, rules wiped by another plugin)
+		 * that fetch returns the default WP 404 template — the PDS then
+		 * replies with "External handle did not resolve to DID" while
+		 * the admin's settings UI still shows a healthy connection.
+		 * Flushing here closes the bug at its actual failure surface.
+		 */
+		Atmosphere::maybe_flush_wellknown_rewrites();
+
 		$result = self::call_update_handle( $target );
 
 		if ( \is_wp_error( $result ) ) {

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -12,6 +12,7 @@ namespace Atmosphere\OAuth;
 
 \defined( 'ABSPATH' ) || exit;
 
+use Atmosphere\Atmosphere;
 use function Atmosphere\clear_scheduled_hooks;
 use function Atmosphere\get_connection;
 
@@ -532,6 +533,19 @@ class Client {
 		 * existing autoloaded rows flip on the next reconnect.
 		 */
 		\update_option( 'atmosphere_connection', $connection, false );
+
+		/*
+		 * Connecting is the moment our well-known endpoints become
+		 * meaningful — the PDS will start fetching
+		 * `/.well-known/atproto-did` to verify any domain handle, and
+		 * resolvers can hit `/.well-known/site.standard.publication`.
+		 * Ensure both patterns are present in the persisted
+		 * `rewrite_rules` array; install paths that bypass
+		 * `register_activation_hook` (FOSSE bundles, mu-plugin loads,
+		 * etc.) otherwise serve the default WP 404 here even though
+		 * the OAuth handshake just succeeded.
+		 */
+		Atmosphere::maybe_flush_wellknown_rewrites();
 
 		return true;
 	}

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -536,14 +536,12 @@ class Client {
 
 		/*
 		 * Connecting is the moment our well-known endpoints become
-		 * meaningful — the PDS will start fetching
-		 * `/.well-known/atproto-did` to verify any domain handle, and
-		 * resolvers can hit `/.well-known/site.standard.publication`.
-		 * Ensure both patterns are present in the persisted
-		 * `rewrite_rules` array; install paths that bypass
-		 * `register_activation_hook` (FOSSE bundles, mu-plugin loads,
-		 * etc.) otherwise serve the default WP 404 here even though
-		 * the OAuth handshake just succeeded.
+		 * meaningful — the PDS starts fetching `/.well-known/atproto-did`
+		 * to verify a domain handle, and resolvers hit
+		 * `/.well-known/site.standard.publication`. Make sure the
+		 * persisted rewrite rules serve them on the very next request.
+		 * See {@see Atmosphere::maybe_flush_wellknown_rewrites()} for the
+		 * install paths that need this beyond activation.
 		 */
 		Atmosphere::maybe_flush_wellknown_rewrites();
 

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -66,14 +66,11 @@ class Admin {
 
 		/*
 		 * Self-heal the well-known rewrite rules whenever an
-		 * administrator loads our settings page. This is the surface
-		 * where the rewrite-flush bug is most likely to be discovered
-		 * (admin checks settings after a downstream report that
-		 * domain-handle resolution is failing), so it is also the right
-		 * surface to silently fix it. Hooked on `load-{suffix}` so the
-		 * check runs before the page renders, but only on our page —
-		 * the cost is one extra option read per Atmosphere settings
-		 * pageview, not per admin request.
+		 * administrator loads our settings page — the surface where this
+		 * bug surfaces, and so the right place to silently fix it.
+		 * Hooked on `load-{suffix}` so it runs before the page renders
+		 * and only on our page, not on every admin request. See
+		 * {@see Atmosphere::maybe_flush_wellknown_rewrites()} for detail.
 		 */
 		\add_action( "load-{$hook}", array( Atmosphere::class, 'maybe_flush_wellknown_rewrites' ) );
 	}

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -52,13 +52,30 @@ class Admin {
 	 * Register the settings page under Settings.
 	 */
 	public static function add_menu(): void {
-		\add_options_page(
+		$hook = \add_options_page(
 			\__( 'ATmosphere', 'atmosphere' ),
 			\__( 'ATmosphere', 'atmosphere' ),
 			'manage_options',
 			'atmosphere',
 			array( self::class, 'render_page' )
 		);
+
+		if ( ! $hook ) {
+			return;
+		}
+
+		/*
+		 * Self-heal the well-known rewrite rules whenever an
+		 * administrator loads our settings page. This is the surface
+		 * where the rewrite-flush bug is most likely to be discovered
+		 * (admin checks settings after a downstream report that
+		 * domain-handle resolution is failing), so it is also the right
+		 * surface to silently fix it. Hooked on `load-{suffix}` so the
+		 * check runs before the page renders, but only on our page —
+		 * the cost is one extra option read per Atmosphere settings
+		 * pageview, not per admin request.
+		 */
+		\add_action( "load-{$hook}", array( Atmosphere::class, 'maybe_flush_wellknown_rewrites' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-wellknown-rewrite.php
+++ b/tests/phpunit/tests/class-test-wellknown-rewrite.php
@@ -23,19 +23,23 @@ use WP_UnitTestCase;
 class Test_Wellknown_Rewrite extends WP_UnitTestCase {
 
 	/**
-	 * Pattern keys the persisted `rewrite_rules` option must contain.
+	 * Pattern => query-target map the persisted `rewrite_rules` option
+	 * must contain after a heal.
 	 *
 	 * Lifted from {@see Atmosphere::WELLKNOWN_REWRITE_PATTERNS}; the
 	 * constant is private so the tests carry their own copy to assert
 	 * against. Keeping these in lockstep is part of what the assertions
-	 * here actually verify — if the production constant gains a new
-	 * pattern, these tests fail until the new pattern is added.
+	 * here actually verify — if the production constant gains, renames,
+	 * or re-targets a pattern, these tests fail until the copy matches.
+	 * Asserting the target (not just key presence) catches a regression
+	 * where the rule resolves to the wrong query var, which would
+	 * silently break verification even with the key present.
 	 *
-	 * @var string[]
+	 * @var array<string, string>
 	 */
 	private const WELLKNOWN_PATTERNS = array(
-		'^\.well-known/atproto-did$',
-		'^\.well-known/site\.standard\.publication$',
+		'^\.well-known/atproto-did$'                 => 'index.php?atmosphere_wellknown=atproto-did',
+		'^\.well-known/site\.standard\.publication$' => 'index.php?atmosphere_wellknown=publication',
 	);
 
 	/**
@@ -111,6 +115,20 @@ class Test_Wellknown_Rewrite extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Assert the persisted rules contain every well-known pattern
+	 * resolving to its expected query target.
+	 *
+	 * @param mixed $rules The `rewrite_rules` option value after a heal.
+	 */
+	private function assertWellknownPatternsResolved( $rules ): void {
+		$this->assertIsArray( $rules );
+		foreach ( self::WELLKNOWN_PATTERNS as $pattern => $target ) {
+			$this->assertArrayHasKey( $pattern, $rules );
+			$this->assertSame( $target, $rules[ $pattern ] );
+		}
+	}
+
+	/**
 	 * No-op when both well-known patterns are already in the option.
 	 *
 	 * Asserts byte-identical state after the call so even a flush that
@@ -140,11 +158,7 @@ class Test_Wellknown_Rewrite extends WP_UnitTestCase {
 
 		Atmosphere::maybe_flush_wellknown_rewrites();
 
-		$rules = \get_option( 'rewrite_rules' );
-		$this->assertIsArray( $rules );
-		foreach ( self::WELLKNOWN_PATTERNS as $pattern ) {
-			$this->assertArrayHasKey( $pattern, $rules );
-		}
+		$this->assertWellknownPatternsResolved( \get_option( 'rewrite_rules' ) );
 	}
 
 	/**
@@ -163,11 +177,7 @@ class Test_Wellknown_Rewrite extends WP_UnitTestCase {
 
 		Atmosphere::maybe_flush_wellknown_rewrites();
 
-		$rules = \get_option( 'rewrite_rules' );
-		$this->assertIsArray( $rules );
-		foreach ( self::WELLKNOWN_PATTERNS as $pattern ) {
-			$this->assertArrayHasKey( $pattern, $rules );
-		}
+		$this->assertWellknownPatternsResolved( \get_option( 'rewrite_rules' ) );
 	}
 
 	/**
@@ -182,11 +192,70 @@ class Test_Wellknown_Rewrite extends WP_UnitTestCase {
 
 		Atmosphere::maybe_flush_wellknown_rewrites();
 
-		$rules = \get_option( 'rewrite_rules' );
-		$this->assertIsArray( $rules );
-		foreach ( self::WELLKNOWN_PATTERNS as $pattern ) {
-			$this->assertArrayHasKey( $pattern, $rules );
+		$this->assertWellknownPatternsResolved( \get_option( 'rewrite_rules' ) );
+	}
+
+	/**
+	 * No flush on a plain-permalink install.
+	 *
+	 * Without a permalink structure WordPress keeps `rewrite_rules`
+	 * empty and routes everything through the query string, so our
+	 * patterns can never be persisted and the well-known endpoints
+	 * cannot resolve via rewrite anyway. The helper must bail rather
+	 * than read the always-empty array as "patterns missing" and burn
+	 * an `update_option` write on every call (the re-flush loop a code
+	 * review flagged). Asserts the option is untouched.
+	 */
+	public function test_no_flush_on_plain_permalinks(): void {
+		\update_option( 'permalink_structure', '' );
+
+		global $wp_rewrite;
+		$wp_rewrite->init();
+
+		$sentinel = array( 'some/other/rule' => 'index.php?other=1' );
+		\update_option( 'rewrite_rules', $sentinel );
+
+		Atmosphere::maybe_flush_wellknown_rewrites();
+
+		$this->assertSame( $sentinel, \get_option( 'rewrite_rules' ) );
+	}
+
+	/**
+	 * `Admin::add_menu()` wires the self-heal onto the settings page
+	 * load hook. A cheap assertion guards against the wiring being
+	 * removed, renamed, or mis-targeted — the OAuth and `set_handle`
+	 * sites have behavioural coverage, this one would otherwise have
+	 * none.
+	 *
+	 * The exact `load-{suffix}` hook name depends on how far the admin
+	 * menu is bootstrapped (`settings_page_atmosphere` in a real admin
+	 * request, `admin_page_atmosphere` in the bare test harness), so the
+	 * assertion scans `$wp_filter` for whichever `load-*` hook the call
+	 * registered our callback on rather than hard-coding the suffix.
+	 */
+	public function test_add_menu_wires_self_heal_on_settings_page_load(): void {
+		$admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		\wp_set_current_user( $admin );
+
+		\Atmosphere\WP_Admin\Admin::add_menu();
+
+		global $wp_filter;
+		$callback  = array( Atmosphere::class, 'maybe_flush_wellknown_rewrites' );
+		$load_hook = '';
+		foreach ( \array_keys( $wp_filter ) as $hook_name ) {
+			if ( \str_starts_with( $hook_name, 'load-' ) && false !== \has_action( $hook_name, $callback ) ) {
+				$load_hook = $hook_name;
+				break;
+			}
 		}
+
+		$this->assertNotSame(
+			'',
+			$load_hook,
+			'add_menu() should wire maybe_flush_wellknown_rewrites onto a settings-page load hook.'
+		);
+
+		\remove_action( $load_hook, $callback );
 	}
 
 	/**
@@ -222,11 +291,6 @@ class Test_Wellknown_Rewrite extends WP_UnitTestCase {
 		$result = Handle::set_handle();
 
 		$this->assertTrue( $result );
-
-		$rules = \get_option( 'rewrite_rules' );
-		$this->assertIsArray( $rules );
-		foreach ( self::WELLKNOWN_PATTERNS as $pattern ) {
-			$this->assertArrayHasKey( $pattern, $rules );
-		}
+		$this->assertWellknownPatternsResolved( \get_option( 'rewrite_rules' ) );
 	}
 }

--- a/tests/phpunit/tests/class-test-wellknown-rewrite.php
+++ b/tests/phpunit/tests/class-test-wellknown-rewrite.php
@@ -98,6 +98,11 @@ class Test_Wellknown_Rewrite extends WP_UnitTestCase {
 		\delete_option( 'atmosphere_connection' );
 		\delete_option( 'atmosphere_identity' );
 
+		\update_option( 'permalink_structure', '' );
+
+		global $wp_rewrite;
+		$wp_rewrite->init();
+
 		parent::tear_down();
 	}
 
@@ -171,6 +176,24 @@ class Test_Wellknown_Rewrite extends WP_UnitTestCase {
 			array(
 				'^\.well-known/atproto-did$' => 'index.php?atmosphere_wellknown=atproto-did',
 				'some/other/rule'            => 'index.php?other=1',
+			)
+		);
+
+		Atmosphere::maybe_flush_wellknown_rewrites();
+
+		$this->assertWellknownPatternsResolved( \get_option( 'rewrite_rules' ) );
+	}
+
+	/**
+	 * Flushes when a well-known pattern resolves to the wrong target.
+	 */
+	public function test_flushes_when_target_is_wrong(): void {
+		$pattern = \array_key_first( self::WELLKNOWN_PATTERNS );
+
+		\update_option(
+			'rewrite_rules',
+			array(
+				$pattern => 'index.php?atmosphere_wellknown=wrong',
 			)
 		);
 

--- a/tests/phpunit/tests/class-test-wellknown-rewrite.php
+++ b/tests/phpunit/tests/class-test-wellknown-rewrite.php
@@ -181,6 +181,26 @@ class Test_Wellknown_Rewrite extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Second consecutive call is a no-op once the patterns are present.
+	 *
+	 * This is the loop-prevention property: the helper fires from
+	 * surfaces that can recur (every settings pageview), so a healthy
+	 * site must not re-flush each time. The first call heals; the second
+	 * must leave the persisted array byte-identical.
+	 */
+	public function test_second_call_is_a_noop_once_healed(): void {
+		\delete_option( 'rewrite_rules' );
+
+		Atmosphere::maybe_flush_wellknown_rewrites();
+		$healed = \get_option( 'rewrite_rules' );
+		$this->assertWellknownPatternsResolved( $healed );
+
+		Atmosphere::maybe_flush_wellknown_rewrites();
+
+		$this->assertSame( $healed, \get_option( 'rewrite_rules' ) );
+	}
+
+	/**
 	 * Defensive: flush when the option holds a non-array value.
 	 *
 	 * Some caches or hosts can stash an empty string or other scalar

--- a/tests/phpunit/tests/class-test-wellknown-rewrite.php
+++ b/tests/phpunit/tests/class-test-wellknown-rewrite.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Tests for the well-known rewrite self-heal helper.
+ *
+ * Covers the {@see Atmosphere::maybe_flush_wellknown_rewrites()} behaviour
+ * and the call-site wiring that fires it when an administrator triggers
+ * a domain-handle change.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group wellknown
+ */
+
+namespace Atmosphere\Tests;
+
+use Atmosphere\Atmosphere;
+use Atmosphere\Handle;
+use WP_UnitTestCase;
+
+/**
+ * Well-known rewrite self-heal tests.
+ */
+class Test_Wellknown_Rewrite extends WP_UnitTestCase {
+
+	/**
+	 * Pattern keys the persisted `rewrite_rules` option must contain.
+	 *
+	 * Lifted from {@see Atmosphere::WELLKNOWN_REWRITE_PATTERNS}; the
+	 * constant is private so the tests carry their own copy to assert
+	 * against. Keeping these in lockstep is part of what the assertions
+	 * here actually verify — if the production constant gains a new
+	 * pattern, these tests fail until the new pattern is added.
+	 *
+	 * @var string[]
+	 */
+	private const WELLKNOWN_PATTERNS = array(
+		'^\.well-known/atproto-did$',
+		'^\.well-known/site\.standard\.publication$',
+	);
+
+	/**
+	 * Closures registered during a test that must be removed in tearDown.
+	 *
+	 * @var array<int, array{0: string, 1: callable, 2: int}>
+	 */
+	private array $tracked_filters = array();
+
+	/**
+	 * Ensure the rules are registered in the in-memory `$wp_rewrite`
+	 * before each test so a real flush produces an array that contains
+	 * our patterns.
+	 *
+	 * `plugins_loaded` already wires `register_wellknown_rewrite` onto
+	 * `init`, so the rules should be present after bootstrap, but the
+	 * test framework can reset state between tests on some hosts —
+	 * re-registering is cheap and idempotent.
+	 *
+	 * Also primes a permalink structure: with no structure set,
+	 * `WP_Rewrite::rewrite_rules()` early-returns an empty array
+	 * regardless of how many `add_rewrite_rule()` calls happened, so
+	 * `flush_rewrite_rules()` writes nothing useful and our patterns
+	 * never land in the persisted option.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		/*
+		 * Force both the persisted option and the in-memory state to a
+		 * known permalink structure. `set_permalink_structure()` is a
+		 * no-op when the in-memory value already matches, which leaves
+		 * a previous test's transactional rollback (which restores the
+		 * empty `permalink_structure` option) reflected by the next
+		 * `init()` read. Writing the option first and then calling
+		 * `init()` makes the prime independent of test ordering.
+		 */
+		\update_option( 'permalink_structure', '/%postname%/' );
+
+		global $wp_rewrite;
+		$wp_rewrite->init();
+
+		( new Atmosphere() )->register_wellknown_rewrite();
+	}
+
+	/**
+	 * Detach any tracked filters and drop options touched here.
+	 */
+	public function tear_down(): void {
+		foreach ( $this->tracked_filters as $entry ) {
+			\remove_filter( $entry[0], $entry[1], $entry[2] );
+		}
+		$this->tracked_filters = array();
+
+		\delete_option( 'rewrite_rules' );
+		\delete_option( 'atmosphere_connection' );
+		\delete_option( 'atmosphere_identity' );
+		\delete_option( Handle::OPTION_PREVIOUS_HANDLE );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Register a filter and remember it for tearDown removal.
+	 *
+	 * @param string   $hook     Hook name.
+	 * @param callable $callback Callback.
+	 * @param int      $priority Priority.
+	 */
+	private function add_filter_tracked( string $hook, callable $callback, int $priority = 10 ): void {
+		\add_filter( $hook, $callback, $priority );
+		$this->tracked_filters[] = array( $hook, $callback, $priority );
+	}
+
+	/**
+	 * No-op when both well-known patterns are already in the option.
+	 *
+	 * Asserts byte-identical state after the call so even a flush that
+	 * happened to produce the same result would fail this test — what
+	 * we are verifying is that no flush ran at all.
+	 */
+	public function test_no_flush_when_both_patterns_present(): void {
+		$original = array(
+			'^\.well-known/atproto-did$'                 => 'index.php?atmosphere_wellknown=atproto-did',
+			'^\.well-known/site\.standard\.publication$' => 'index.php?atmosphere_wellknown=publication',
+			'some/other/rule'                            => 'index.php?other=1',
+		);
+		\update_option( 'rewrite_rules', $original );
+
+		Atmosphere::maybe_flush_wellknown_rewrites();
+
+		$this->assertSame( $original, \get_option( 'rewrite_rules' ) );
+	}
+
+	/**
+	 * Flushes when the `rewrite_rules` option is entirely absent —
+	 * the install-never-activated case (FOSSE bundle, mu-plugin load,
+	 * etc.) and the rules-wiped-after-activation case.
+	 */
+	public function test_flushes_when_option_is_missing(): void {
+		\delete_option( 'rewrite_rules' );
+
+		Atmosphere::maybe_flush_wellknown_rewrites();
+
+		$rules = \get_option( 'rewrite_rules' );
+		$this->assertIsArray( $rules );
+		foreach ( self::WELLKNOWN_PATTERNS as $pattern ) {
+			$this->assertArrayHasKey( $pattern, $rules );
+		}
+	}
+
+	/**
+	 * Flushes when one of the patterns is present but the other is
+	 * missing — catches the hook-ordering case where another plugin
+	 * flushed mid-init after only some of our rules had registered.
+	 */
+	public function test_flushes_when_patterns_partially_missing(): void {
+		\update_option(
+			'rewrite_rules',
+			array(
+				'^\.well-known/atproto-did$' => 'index.php?atmosphere_wellknown=atproto-did',
+				'some/other/rule'            => 'index.php?other=1',
+			)
+		);
+
+		Atmosphere::maybe_flush_wellknown_rewrites();
+
+		$rules = \get_option( 'rewrite_rules' );
+		$this->assertIsArray( $rules );
+		foreach ( self::WELLKNOWN_PATTERNS as $pattern ) {
+			$this->assertArrayHasKey( $pattern, $rules );
+		}
+	}
+
+	/**
+	 * Defensive: flush when the option holds a non-array value.
+	 *
+	 * Some caches or hosts can stash an empty string or other scalar
+	 * here. The helper must treat that as "rules missing" rather than
+	 * silently passing the check.
+	 */
+	public function test_flushes_when_option_value_is_not_array(): void {
+		\update_option( 'rewrite_rules', '' );
+
+		Atmosphere::maybe_flush_wellknown_rewrites();
+
+		$rules = \get_option( 'rewrite_rules' );
+		$this->assertIsArray( $rules );
+		foreach ( self::WELLKNOWN_PATTERNS as $pattern ) {
+			$this->assertArrayHasKey( $pattern, $rules );
+		}
+	}
+
+	/**
+	 * `Handle::set_handle()` self-heals the persisted rewrite rules
+	 * before the PDS round-trip. This is the exact failure surface
+	 * the original bug report ("External handle did not resolve to
+	 * DID") was caught on, so the wiring here is load-bearing.
+	 */
+	public function test_set_handle_flushes_wellknown_rewrites_before_xrpc(): void {
+		$admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		\wp_set_current_user( $admin );
+
+		$home = static fn() => 'https://example.com';
+		$this->add_filter_tracked( 'home_url', $home );
+		$this->add_filter_tracked( 'site_url', $home );
+
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'handle'       => 'alice.bsky.social',
+				'did'          => 'did:plc:test',
+				'access_token' => 'tok',
+			)
+		);
+
+		// Short-circuit the actual PDS call.
+		$short_circuit = static fn() => true;
+		$this->add_filter_tracked( Handle::FILTER_PRE_UPDATE, $short_circuit );
+
+		// Wipe the persisted rules so the helper has something to fix.
+		\delete_option( 'rewrite_rules' );
+
+		$result = Handle::set_handle();
+
+		$this->assertTrue( $result );
+
+		$rules = \get_option( 'rewrite_rules' );
+		$this->assertIsArray( $rules );
+		foreach ( self::WELLKNOWN_PATTERNS as $pattern ) {
+			$this->assertArrayHasKey( $pattern, $rules );
+		}
+	}
+}


### PR DESCRIPTION
Fixes #90

## Proposed changes:

Atmosphere only flushed rewrite rules from `register_activation_hook`, so the `/.well-known/atproto-did` and `/.well-known/site.standard.publication` rules never reached the persisted `wp_options.rewrite_rules` array on several real install paths:

- Programmatic / bundled loads (FOSSE, `require_once`, mu-plugin) that never fire the activation hook.
- Hosts or plugins that wipe `rewrite_rules` after activation.
- Plugins that flush earlier on `init` than our rule registration.

When that happens, `register_wellknown_rewrite()` keeps running every request but is inert — WordPress routes from the persisted array, so the well-known endpoint serves the normal 404 template. The visible symptom is "External handle did not resolve to DID" when switching to a domain handle, even though the admin UI shows a healthy connection.

This adds `Atmosphere::maybe_flush_wellknown_rewrites()`, which checks the persisted rules for our patterns and soft-flushes only when one is missing. It is called surgically from the three moments that matter, so it is not paid on every request:

- After a successful OAuth handshake persists an identity (`OAuth\Client::handle_callback()`).
- When an administrator loads the Atmosphere settings page (`WP_Admin\Admin::add_menu()` via `load-{hook}`) — already-stuck installs self-heal here.
- Immediately before the `updateHandle` XRPC call (`Handle::set_handle()`) — the exact failure surface from the issue.

The helper bails on plain-permalink installs (gated on `$wp_rewrite->using_permalinks()`, the same source `flush_rewrite_rules()` rebuilds from) since our rules cannot persist there and the endpoints cannot resolve via rewrite anyway — this avoids a pointless re-flush on every call.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

New `tests/phpunit/tests/class-test-wellknown-rewrite.php` covers the helper's no-op, missing, partial, non-array, plain-permalink, and idempotency paths, the `set_handle` call-site behaviour, and the settings-page `load-{hook}` wiring.

## Testing instructions:

* Set the site to pretty permalinks (Settings → Permalinks → Post name).
* Simulate the stuck state: in `wp_options`, clear the `rewrite_rules` value (or `wp option delete rewrite_rules`) so the well-known pattern is absent.
* Confirm the bug first: `curl -sI https://YOURSITE/.well-known/atproto-did` returns a full HTML 404.
* Visit Settings → ATmosphere (or trigger the domain-handle action / reconnect). The `load-{hook}` self-heal fires.
* Re-run `curl -sI https://YOURSITE/.well-known/atproto-did` — it now returns the persisted DID as `text/plain`.
* On a plain-permalink site, confirm visiting the settings page does **not** write `rewrite_rules` repeatedly (the guard bails).

Automated:
* `composer lint`
* `npm run env-test` (full suite: 423 passing; `--filter Wellknown_Rewrite` for the new tests)

### Changelog entry

A changelog entry is already committed on this branch at `.github/changelog/fix-wellknown-rewrite-flush` (Patch / Fixed), so the automatic creation box below is intentionally left unchecked.

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fix domain handle verification failing on some sites when using your site's domain as your Bluesky handle.

</details>