### PR TITLE
Docs: Update WordPress.org contributor username

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === ATmosphere ===
-Contributors: automattic, pfefferle, kraftbj, ryancowles
+Contributors: automattic, pfefferle, kraftbj, ryanc413
 Tags: at-protocol, bluesky, fediverse, atproto, crossposting
 Requires at least: 6.2
 Tested up to: 7.0


### PR DESCRIPTION
Fixes #

## Proposed changes:
* Updates the WordPress.org contributor username in the readme.txt Contributors header from ryancowles to ryanc413.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Not applicable; this is a metadata-only WordPress.org readme update.

## Testing instructions:
* Confirm readme.txt lists ryanc413 in the Contributors header.
* Run composer lint.
* Run npm run env-test.

### Changelog entry

No changelog entry is needed for this metadata-only update; apply the Skip Changelog label.

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

</details>