### PR TITLE
Discard Bluesky replies whose parent we can't resolve

### DIFF
--- a/.github/changelog/fix-orphan-reply-discard
+++ b/.github/changelog/fix-orphan-reply-discard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop reinjecting replies into the moderation queue when the parent Bluesky message has been deleted or blocked.

--- a/includes/class-reaction-sync.php
+++ b/includes/class-reaction-sync.php
@@ -376,7 +376,6 @@ class Reaction_Sync {
 		}
 
 		$parent_uri = $record['reply']['parent']['uri'] ?? '';
-		$root_uri   = $record['reply']['root']['uri'] ?? '';
 
 		if ( empty( $parent_uri ) ) {
 			return false;
@@ -399,11 +398,27 @@ class Reaction_Sync {
 			}
 		}
 
-		if ( ! $post_id ) {
-			// Deep thread rooted at one of our posts.
-			$post_id = self::find_post_by_bsky_uri( $root_uri );
-		}
-
+		/*
+		 * Drop replies whose parent we can't resolve. A parent that
+		 * doesn't match a local WP post or a previously-synced WP
+		 * comment is either:
+		 *
+		 *   - Orphaned: the parent was deleted on Bluesky (e.g. blocked
+		 *     user, account deletion) or removed from our moderation
+		 *     queue. Falling back to the root post would re-attach
+		 *     every subsequent re-walk as a top-level orphan, looping
+		 *     the moderation queue indefinitely until the watermark
+		 *     advances past it.
+		 *
+		 *   - Out-of-order: a deep reply seen before its parent in the
+		 *     same `listNotifications`/`listRecords` page. Dropping
+		 *     here is recoverable: the parent gets synced in the same
+		 *     run, the child re-enters via the WATERMARK_GRACE window
+		 *     on the next run, and parent resolution succeeds.
+		 *
+		 * Direct replies (parent_uri is one of our WP posts) and
+		 * resolved nested replies are unaffected.
+		 */
 		if ( ! $post_id ) {
 			return false;
 		}

--- a/tests/phpunit/tests/class-test-reaction-sync.php
+++ b/tests/phpunit/tests/class-test-reaction-sync.php
@@ -190,13 +190,14 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that process_reply survives get_comment() returning null
-	 * for the found parent comment ID (race: comment deleted between
-	 * the meta lookup and the get_comment call). Should fall through
-	 * to the root-post fallback instead of fataling on a property
-	 * access against null.
+	 * Test that process_reply drops a reply when get_comment() returns
+	 * null for the resolved parent comment ID (race: comment deleted
+	 * between the meta lookup and the get_comment call). The previous
+	 * "fall back to the root post" behavior caused unresolvable replies
+	 * to be re-attached as top-level orphans on every sync run,
+	 * looping the moderation queue indefinitely.
 	 */
-	public function test_process_reply_handles_get_comment_returning_null() {
+	public function test_process_reply_drops_when_parent_comment_row_is_missing() {
 		$post_id  = self::factory()->post->create();
 		$post_uri = 'at://did:plc:me/app.bsky.feed.post/rootpost';
 		\update_post_meta( $post_id, BskyPost::META_URI, $post_uri );
@@ -236,17 +237,53 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 			),
 		);
 
-		$comment_id = $method->invoke( null, $notification );
+		try {
+			$result = $method->invoke( null, $notification );
+		} finally {
+			\remove_all_filters( 'get_comment' );
+		}
 
-		\remove_all_filters( 'get_comment' );
+		$this->assertFalse( $result );
+		$find_method = new \ReflectionMethod( Reaction_Sync::class, 'find_comment_by_source_id' );
+		$this->assertFalse( $find_method->invoke( null, 'at://did:plc:replier/app.bsky.feed.post/nested' ) );
+	}
 
-		$this->assertIsInt( $comment_id );
-		$this->assertGreaterThan( 0, $comment_id );
+	/**
+	 * Test that process_reply drops a reply whose parent record is
+	 * neither a local WP post nor a previously-synced WP comment, even
+	 * when the thread root resolves to one of our posts. Reproduces the
+	 * "blocked user / deleted parent" loop: previously, the reply would
+	 * be re-attached as a top-level comment on the root post on every
+	 * sync run, reinjecting it into the moderation queue indefinitely.
+	 */
+	public function test_process_reply_drops_orphan_when_parent_is_unresolved() {
+		$post_id  = self::factory()->post->create();
+		$post_uri = 'at://did:plc:me/app.bsky.feed.post/threadroot';
+		\update_post_meta( $post_id, BskyPost::META_URI, $post_uri );
 
-		$comment = \get_comment( $comment_id );
-		$this->assertSame( (string) $post_id, $comment->comment_post_ID );
-		// Parent resolution failed, so the reply attaches at the root.
-		$this->assertSame( '0', $comment->comment_parent );
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'process_reply' );
+
+		// Parent is a Bluesky reply that was never synced (e.g. blocked
+		// user's reply was deleted). Root is our own WP post.
+		$notification = array(
+			'uri'    => 'at://did:plc:me/app.bsky.feed.post/myreplytoblocked',
+			'cid'    => 'bafyreioauth',
+			'record' => array(
+				'text'      => 'Replying to a now-deleted parent.',
+				'createdAt' => '2026-04-23T12:00:00.000Z',
+				'reply'     => array(
+					'parent' => array( 'uri' => 'at://did:plc:blocked/app.bsky.feed.post/gone' ),
+					'root'   => array( 'uri' => $post_uri ),
+				),
+			),
+			'author' => array(
+				'did'    => 'did:plc:me',
+				'handle' => 'me.bsky.social',
+			),
+		);
+
+		$this->assertFalse( $method->invoke( null, $notification ) );
+		$this->assertSame( array(), \get_comments( array( 'post_id' => $post_id ) ) );
 	}
 
 	/**


### PR DESCRIPTION
> [!NOTE]
> Fixes CM-794
> This was reported here: https://wordpress.org/support/topic/blocked-users-deleted-posts-cause-reply-loop-in-moderation-queue/#post-18919693

## Proposed changes:

* `Reaction_Sync::process_reply()` no longer falls back to attaching a reply as a top-level comment on the thread root when the reply's `parent.uri` matches neither a local WordPress post nor a previously-synced WordPress comment. The reply is dropped instead.
* This stops the moderation-queue reinjection loop reported for replies whose Bluesky parent message has been deleted (blocked user, account deletion) or removed from the WordPress moderation queue.
* The intra-run race case (a child notification arriving before its parent in the same `listNotifications`/`listRecords` page) recovers on the next run via `WATERMARK_GRACE`: the child re-walks once the parent has been synced, and parent resolution then succeeds.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Flipped the existing race-test `test_process_reply_handles_get_comment_returning_null` → `test_process_reply_drops_when_parent_comment_row_is_missing` to assert the drop, and added a new `test_process_reply_drops_orphan_when_parent_is_unresolved` covering the blocked-user-with-deleted-parent scenario.

### Trade-off (behavior change worth flagging)

The root-post fallback being removed has been there since the original reaction-sync commit (#6), where it was framed as step 3 of a three-step walk: direct → parent comment → root fallback. PR #6 also shipped with `comment_approved => 1` for inbound replies, so orphans silently auto-attached to the root — visible but non-disruptive. The moderation pipeline added in #65 changed that: orphan-attached replies now land in the moderation queue, which is what makes the loop user-visible.

Removing the fallback affects two regimes:

* **Improved:** Intra-run races (child notification processed before its parent on the same page) previously orphan-attached both child and parent as top-level on the root post — wrong threading. Now the child drops this run and re-walks next run via `WATERMARK_GRACE`, finds its newly-synced parent, and attaches correctly nested.
* **Regressed:** Replies whose parent is more than `MAX_PAGES * 50 = 250` items older than the child fall outside any future paginate window. Previously they were orphan-attached to the root post (visible but mis-threaded). Now they're permanently lost. PR #6's review thread already acknowledged this regime as best-effort ("Not a hard guarantee on very busy accounts that can exceed 10 reactions/run.").

The trade-off looks favorable: case 1 is the common path, case 2 was already broken threading, and the loop bug being fixed here was a real, reproducible support issue. But if we want to preserve the deep-parent case properly, the right shape is probably the "rescan from epoch" admin button that #6 already flagged as the eventual follow-up — or an explicit `getRecord` lookup against the PDS to differentiate "transient race" from "permanently gone."

## Testing instructions:

1. Connect a WordPress site to a Bluesky account via Atmosphere.
2. Publish a WordPress post; confirm it lands on Bluesky.
3. From a second Bluesky account, reply to the post.
4. From your connected Bluesky account, reply to that second account's reply.
5. Confirm both replies show up in the WordPress moderation queue, threaded correctly.
6. From the second account: delete the reply on Bluesky (or have the account blocked / deleted, which has the same effect).
7. In WordPress, delete the second account's now-orphan comment from the moderation queue.
8. Wait for the reaction-sync cron to run (or trigger it manually).
9. **Before this fix:** your own reply (originally nested under the deleted parent) gets re-inserted into the moderation queue as a top-level comment on the post, and reappears every sync run until newer items push it out of the watermark grace window.
10. **With this fix:** the orphan reply is dropped silently; nothing reappears in the moderation queue.

Also: `composer lint` is clean and `npm run env-test` passes (416 tests, 1252 assertions).

### Changelog entry

Already committed in `.github/changelog/fix-orphan-reply-discard`.