### PR TITLE
Fix: short-form posts now include images when published to Bluesky

### DIFF
--- a/.github/changelog/fix-short-form-image-embed
+++ b/.github/changelog/fix-short-form-image-embed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Aside, status, and other short-form posts now include their images when published to Bluesky.

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -410,6 +410,13 @@ class Post extends Base {
 	 * out of scope; consumers needing those can wire them in via the
 	 * `atmosphere_post_embed` filter.
 	 *
+	 * The walker stops collecting once 32 IDs have been gathered — well
+	 * above the 4-image AT Protocol cap, but enough headroom that dedupe
+	 * still preserves document order on realistic posts. Bounds the
+	 * memory profile so an attacker-controlled `post_content` packed with
+	 * thousands of `core/image` blocks can't grow the working array
+	 * past a constant ceiling.
+	 *
 	 * @return int[]
 	 */
 	private function collect_image_attachment_ids(): array {
@@ -422,8 +429,17 @@ class Post extends Base {
 		$blocks = \parse_blocks( $content );
 		$ids    = array();
 
-		$walker = static function ( array $blocks ) use ( &$walker, &$ids ): void {
+		// Generous ceiling: well above the 4-image cap, enough that
+		// dedupe still preserves document order on realistic posts,
+		// small enough to bound attacker-controlled memory growth.
+		$max_ids = 32;
+
+		$walker = static function ( array $blocks ) use ( &$walker, &$ids, $max_ids ): void {
 			foreach ( $blocks as $block ) {
+				if ( \count( $ids ) >= $max_ids ) {
+					return;
+				}
+
 				if ( ( $block['blockName'] ?? '' ) === 'core/image'
 					&& isset( $block['attrs']['id'] )
 					&& (int) $block['attrs']['id'] > 0
@@ -635,7 +651,9 @@ class Post extends Base {
 	 * applyWrites batch from a malformed embed.
 	 *
 	 * @param array|null $embed    Default embed for this strategy
-	 *                             (null for short-form, an
+	 *                             (an `app.bsky.embed.images` record for
+	 *                             short-form posts with images, null for
+	 *                             short-form posts without images, an
 	 *                             `app.bsky.embed.external` card for the
 	 *                             link-card and teaser-thread strategies).
 	 * @param string     $strategy Composition strategy: 'short-form',
@@ -646,15 +664,16 @@ class Post extends Base {
 		/**
 		 * Filters the embed attached to a Bluesky post record.
 		 *
-		 * Fires for every composition strategy, including short-form
-		 * (where the default is `null` — short-form posts ship without
-		 * an embed unless something opts in). Consumers can:
+		 * Fires for every composition strategy. The default for short-form
+		 * posts is an `app.bsky.embed.images` record when the post has
+		 * images (in-body `core/image` blocks, or the featured image as a
+		 * fallback), and `null` otherwise. Consumers can:
 		 *
 		 *   - Replace the default external link card with a richer
 		 *     embed type (`app.bsky.embed.images`, `app.bsky.embed.video`,
 		 *     `app.bsky.embed.record`).
 		 *   - Attach an embed to a short-form post that would otherwise
-		 *     ship plain.
+		 *     ship plain (e.g. an image-free aside).
 		 *   - Suppress the default embed by returning null.
 		 *
 		 * Valid returns are `null` or an array with a non-empty string
@@ -675,9 +694,12 @@ class Post extends Base {
 		 * post object to embed filters would leak the protected payload.
 		 *
 		 * @param array|null $embed    Default embed for this strategy
-		 *                             (null for short-form, an
-		 *                             `app.bsky.embed.external` card
-		 *                             otherwise).
+		 *                             (an `app.bsky.embed.images` record
+		 *                             for short-form posts with images,
+		 *                             null for short-form posts without
+		 *                             images, an `app.bsky.embed.external`
+		 *                             card for the link-card and
+		 *                             teaser-thread strategies).
 		 * @param \WP_Post   $post     The post being transformed.
 		 * @param string     $strategy Composition strategy: 'short-form',
 		 *                             'link-card', or 'teaser-thread'.

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -156,9 +156,13 @@ class Post extends Base {
 		$text  = $redacted ? '' : ( $is_short ? $this->build_short_form_text() : '' );
 		$embed = null;
 
-		if ( ! $redacted && '' === $text ) {
-			$text  = $this->build_text();
-			$embed = $this->build_embed();
+		if ( ! $redacted ) {
+			if ( '' === $text ) {
+				$text  = $this->build_text();
+				$embed = $this->build_embed();
+			} elseif ( $is_short ) {
+				$embed = $this->build_images_embed();
+			}
 		}
 
 		if ( ! $redacted ) {
@@ -323,6 +327,132 @@ class Post extends Base {
 		$prose = truncate_text( $prose, $available );
 
 		return $prose . "\n\n" . $permalink;
+	}
+
+	/**
+	 * Build an `app.bsky.embed.images` record from the post's images.
+	 *
+	 * Source priority:
+	 *   1. `core/image` blocks parsed from `post_content` (deduped,
+	 *      document order, capped at 4).
+	 *   2. Featured image (`get_post_thumbnail_id`) when no in-body
+	 *      images are found.
+	 *
+	 * Returns null when neither source yields an image, when every
+	 * attempted blob upload fails, or for redacted posts. Used by the
+	 * short-form `transform()` path so aside/status/quote posts that
+	 * contain images actually ship them to Bluesky instead of silently
+	 * dropping them with the post content's HTML.
+	 *
+	 * @return array|null app.bsky.embed.images record or null.
+	 */
+	private function build_images_embed(): ?array {
+		if ( $this->is_redacted() ) {
+			return null;
+		}
+
+		$attachment_ids = $this->collect_image_attachment_ids();
+
+		if ( empty( $attachment_ids ) ) {
+			$thumb_id = \get_post_thumbnail_id( $this->object );
+			if ( $thumb_id ) {
+				$attachment_ids[] = (int) $thumb_id;
+			}
+		}
+
+		if ( empty( $attachment_ids ) ) {
+			return null;
+		}
+
+		// AT Protocol `app.bsky.embed.images` caps at 4 images.
+		$attachment_ids = \array_slice( $attachment_ids, 0, 4 );
+
+		$images = array();
+		foreach ( $attachment_ids as $attachment_id ) {
+			$blob = self::upload_image_blob( $attachment_id );
+			if ( ! $blob ) {
+				continue;
+			}
+
+			$image = array(
+				'image' => $blob,
+				'alt'   => $this->image_alt_text( $attachment_id ),
+			);
+
+			$aspect_ratio = self::get_attachment_aspect_ratio( $attachment_id );
+			if ( null !== $aspect_ratio ) {
+				$image['aspectRatio'] = $aspect_ratio;
+			}
+
+			$images[] = $image;
+		}
+
+		if ( empty( $images ) ) {
+			return null;
+		}
+
+		return array(
+			'$type'  => 'app.bsky.embed.images',
+			'images' => $images,
+		);
+	}
+
+	/**
+	 * Collect attachment IDs from `core/image` blocks in post_content.
+	 *
+	 * Walks the block tree recursively (into `innerBlocks`) so an image
+	 * nested in a group, column, or cover block is still picked up.
+	 * Order is document order; duplicates are removed; non-positive IDs
+	 * are skipped.
+	 *
+	 * @return int[]
+	 */
+	private function collect_image_attachment_ids(): array {
+		$content = (string) $this->object->post_content;
+
+		if ( '' === $content || ! \has_blocks( $content ) ) {
+			return array();
+		}
+
+		$blocks = \parse_blocks( $content );
+		$ids    = array();
+
+		$walker = static function ( array $blocks ) use ( &$walker, &$ids ): void {
+			foreach ( $blocks as $block ) {
+				if ( ( $block['blockName'] ?? '' ) === 'core/image'
+					&& isset( $block['attrs']['id'] )
+					&& (int) $block['attrs']['id'] > 0
+				) {
+					$ids[] = (int) $block['attrs']['id'];
+				}
+
+				if ( ! empty( $block['innerBlocks'] ) && \is_array( $block['innerBlocks'] ) ) {
+					$walker( $block['innerBlocks'] );
+				}
+			}
+		};
+
+		$walker( $blocks );
+
+		return \array_values( \array_unique( $ids ) );
+	}
+
+	/**
+	 * Resolve the alt text for an attachment.
+	 *
+	 * Uses the WordPress canonical attachment alt meta key
+	 * (`_wp_attachment_image_alt`). Returns an empty string when the meta
+	 * is missing or non-string — AT Protocol's `app.bsky.embed.images`
+	 * requires the `alt` field to be present, and an empty string is a
+	 * valid value.
+	 *
+	 * @param int $attachment_id Attachment ID.
+	 * @return string
+	 */
+	private function image_alt_text( int $attachment_id ): string {
+		$alt = \get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+
+		return \is_string( $alt ) ? $alt : '';
 	}
 
 	/**

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -477,7 +477,7 @@ class Post extends Base {
 	private function image_alt_text( int $attachment_id ): string {
 		$alt = \get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
 
-		return \is_string( $alt ) ? $alt : '';
+		return \is_string( $alt ) ? truncate_text( sanitize_text( $alt ), 1000 ) : '';
 	}
 
 	/**

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -157,11 +157,15 @@ class Post extends Base {
 		$embed = null;
 
 		if ( ! $redacted ) {
-			if ( '' === $text ) {
+			if ( $is_short ) {
+				$embed = $this->build_images_embed();
+				if ( '' === $text && null === $embed ) {
+					$text  = $this->build_text();
+					$embed = $this->build_embed();
+				}
+			} else {
 				$text  = $this->build_text();
 				$embed = $this->build_embed();
-			} elseif ( $is_short ) {
-				$embed = $this->build_images_embed();
 			}
 		}
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -339,7 +339,9 @@ class Post extends Base {
 	 *      images are found.
 	 *
 	 * Returns null when neither source yields an image, when every
-	 * attempted blob upload fails, or for redacted posts. Used by the
+	 * attempted blob upload fails, or for redacted posts. Partial upload
+	 * failures are silently skipped; the record ships with whatever
+	 * uploaded successfully. Used by the
 	 * short-form `transform()` path so aside/status/quote posts that
 	 * contain images actually ship them to Bluesky instead of silently
 	 * dropping them with the post content's HTML.
@@ -403,7 +405,10 @@ class Post extends Base {
 	 * Walks the block tree recursively (into `innerBlocks`) so an image
 	 * nested in a group, column, or cover block is still picked up.
 	 * Order is document order; duplicates are removed; non-positive IDs
-	 * are skipped.
+	 * are skipped. Only `core/image` blocks are inspected — `core/cover`
+	 * background images and `core/media-text` images are intentionally
+	 * out of scope; consumers needing those can wire them in via the
+	 * `atmosphere_post_embed` filter.
 	 *
 	 * @return int[]
 	 */

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -421,6 +421,15 @@ class Post extends Base {
 	 * thousands of `core/image` blocks can't grow the working array
 	 * past a constant ceiling.
 	 *
+	 * Recursion is also depth-capped at 16 levels. The 32-ID breadth cap
+	 * only protects against wide trees: a deeply-nested input with no
+	 * images (e.g. 500 nested `core/group` wrappers) would never
+	 * accumulate IDs and never trip the breadth guard, but each level
+	 * still costs a PHP frame on the C stack. 16 leaves ample headroom
+	 * over realistic theme/block nesting (cover → group → columns →
+	 * column → group → image is six) while keeping the worst-case stack
+	 * use bounded against an adversarial `post_content`.
+	 *
 	 * @return int[]
 	 */
 	private function collect_image_attachment_ids(): array {
@@ -436,9 +445,14 @@ class Post extends Base {
 		// Generous ceiling: well above the 4-image cap, enough that
 		// dedupe still preserves document order on realistic posts,
 		// small enough to bound attacker-controlled memory growth.
-		$max_ids = 32;
+		$max_ids   = 32;
+		$max_depth = 16;
 
-		$walker = static function ( array $blocks ) use ( &$walker, &$ids, $max_ids ): void {
+		$walker = static function ( array $blocks, int $depth ) use ( &$walker, &$ids, $max_ids, $max_depth ): void {
+			if ( $depth > $max_depth ) {
+				return;
+			}
+
 			foreach ( $blocks as $block ) {
 				if ( \count( $ids ) >= $max_ids ) {
 					return;
@@ -452,12 +466,12 @@ class Post extends Base {
 				}
 
 				if ( ! empty( $block['innerBlocks'] ) && \is_array( $block['innerBlocks'] ) ) {
-					$walker( $block['innerBlocks'] );
+					$walker( $block['innerBlocks'], $depth + 1 );
 				}
 			}
 		};
 
-		$walker( $blocks );
+		$walker( $blocks, 0 );
 
 		return \array_values( \array_unique( $ids ) );
 	}

--- a/tests/phpunit/tests/transformer/class-test-post.php
+++ b/tests/phpunit/tests/transformer/class-test-post.php
@@ -2374,4 +2374,26 @@ class Test_Post extends WP_UnitTestCase {
 		$this->assertIsArray( $seen );
 		$this->assertSame( 'app.bsky.embed.images', $seen['$type'] );
 	}
+
+	/**
+	 * A short-form post with neither an in-body image block nor a
+	 * featured image still ships without an embed — the default doesn't
+	 * synthesize one out of nothing.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_short_form_without_any_image_has_no_embed() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Aside no image',
+				'post_content' => 'Just words.',
+			)
+		);
+		\set_post_format( $post_id, 'aside' );
+		$post = \get_post( $post_id );
+
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertArrayNotHasKey( 'embed', $record );
+	}
 }

--- a/tests/phpunit/tests/transformer/class-test-post.php
+++ b/tests/phpunit/tests/transformer/class-test-post.php
@@ -2440,4 +2440,110 @@ class Test_Post extends WP_UnitTestCase {
 
 		$this->assertArrayNotHasKey( 'embed', $record );
 	}
+
+	/**
+	 * `core/image` blocks with non-positive or missing IDs are skipped by
+	 * the collector. Locks the `> 0` and `isset` guards so a future
+	 * refactor that drops them surfaces in CI rather than shipping
+	 * placeholder/template blocks to Bluesky.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_short_form_skips_image_blocks_with_invalid_ids() {
+		$featured_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'fallback.jpg',
+				'post_mime_type' => 'image/jpeg',
+			),
+			0,
+			array( 'post_title' => 'Fallback attachment' )
+		);
+		\update_post_meta(
+			$featured_id,
+			'_atmosphere_blob_ref',
+			array(
+				'cid'      => 'bafyfallback',
+				'mimeType' => 'image/jpeg',
+				'size'     => 1,
+			)
+		);
+
+		/*
+		 * Paragraph keeps the post on the short-form path (otherwise
+		 * `build_short_form_text()` returns empty and we fall back to
+		 * long-form). Three image blocks that should all be skipped:
+		 * id=0 (non-positive), missing id, and id="foo" (cast to int
+		 * yields 0).
+		 */
+		$content = '<!-- wp:paragraph --><p>Aside body.</p><!-- /wp:paragraph -->'
+			. '<!-- wp:image {"id":0} --><figure></figure><!-- /wp:image -->'
+			. '<!-- wp:image {"sizeSlug":"large"} --><figure></figure><!-- /wp:image -->'
+			. '<!-- wp:image {"id":"foo"} --><figure></figure><!-- /wp:image -->';
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Aside with invalid ids',
+				'post_content' => $content,
+			)
+		);
+		\set_post_format( $post_id, 'aside' );
+		\set_post_thumbnail( $post_id, $featured_id );
+		$post = \get_post( $post_id );
+
+		$record = ( new Post( $post ) )->transform();
+
+		// Featured-image fallback applies because no valid in-body IDs
+		// were collected. The single image is the featured image, not
+		// any of the placeholder blocks.
+		$this->assertArrayHasKey( 'embed', $record );
+		$this->assertSame( 'app.bsky.embed.images', $record['embed']['$type'] );
+		$this->assertCount( 1, $record['embed']['images'] );
+		$this->assertSame( 'bafyfallback', $record['embed']['images'][0]['image']['cid'] );
+	}
+
+	/**
+	 * When the attachment has no `_wp_attachment_image_alt` meta set at
+	 * all, the embed still includes an `alt` field with an empty string —
+	 * the Lexicon requires `alt` to be present on every image entry.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_short_form_image_embed_alt_is_empty_string_when_meta_missing() {
+		$attachment_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'no-alt.jpg',
+				'post_mime_type' => 'image/jpeg',
+			),
+			0,
+			array( 'post_title' => 'No-alt attachment' )
+		);
+		\update_post_meta(
+			$attachment_id,
+			'_atmosphere_blob_ref',
+			array(
+				'cid'      => 'bafynoalt',
+				'mimeType' => 'image/jpeg',
+				'size'     => 1,
+			)
+		);
+		// Intentionally do not set `_wp_attachment_image_alt`.
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Aside no alt',
+				'post_content' => 'Words.',
+			)
+		);
+		\set_post_format( $post_id, 'aside' );
+		\set_post_thumbnail( $post_id, $attachment_id );
+		$post = \get_post( $post_id );
+
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertArrayHasKey( 'embed', $record );
+		$this->assertSame( 'app.bsky.embed.images', $record['embed']['$type'] );
+		$this->assertCount( 1, $record['embed']['images'] );
+		$this->assertArrayHasKey( 'alt', $record['embed']['images'][0] );
+		$this->assertSame( '', $record['embed']['images'][0]['alt'] );
+	}
 }

--- a/tests/phpunit/tests/transformer/class-test-post.php
+++ b/tests/phpunit/tests/transformer/class-test-post.php
@@ -2396,4 +2396,48 @@ class Test_Post extends WP_UnitTestCase {
 
 		$this->assertArrayNotHasKey( 'embed', $record );
 	}
+
+	/**
+	 * A redacted (password-protected) short-form post with a featured
+	 * image must not ship the image — mirrors the existing redaction
+	 * posture for text and tags. Protects against leaking protected
+	 * attachments to Bluesky.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_short_form_with_password_does_not_attach_images_embed() {
+		$attachment_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'protected.jpg',
+				'post_mime_type' => 'image/jpeg',
+			),
+			0,
+			array( 'post_title' => 'Protected attachment' )
+		);
+		\update_post_meta(
+			$attachment_id,
+			'_atmosphere_blob_ref',
+			array(
+				'cid'      => 'bafyprotected',
+				'mimeType' => 'image/jpeg',
+				'size'     => 1,
+			)
+		);
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_title'    => 'Protected aside',
+				'post_content'  => 'Secret body.',
+				'post_password' => 'secret',
+			)
+		);
+		\set_post_format( $post_id, 'aside' );
+		\set_post_thumbnail( $post_id, $attachment_id );
+		$post = \get_post( $post_id );
+
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertArrayNotHasKey( 'embed', $record );
+	}
 }

--- a/tests/phpunit/tests/transformer/class-test-post.php
+++ b/tests/phpunit/tests/transformer/class-test-post.php
@@ -2546,4 +2546,171 @@ class Test_Post extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'alt', $record['embed']['images'][0] );
 		$this->assertSame( '', $record['embed']['images'][0]['alt'] );
 	}
+
+	/**
+	 * The walker stops collecting at 32 IDs even when the post contains
+	 * far more `core/image` blocks. Locks the breadth ceiling that
+	 * protects an attacker-controlled `post_content` from growing the
+	 * working array linearly. The downstream 4-image cap then trims
+	 * what ships in the embed, so this guards the intermediate working
+	 * set rather than the public Bluesky record.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_short_form_image_collector_stops_at_breadth_cap() {
+		$valid_ids = array();
+		for ( $i = 0; $i < 4; $i++ ) {
+			$id = self::factory()->attachment->create_object(
+				array(
+					'file'           => "first{$i}.jpg",
+					'post_mime_type' => 'image/jpeg',
+				),
+				0,
+				array( 'post_title' => "First {$i}" )
+			);
+			\update_post_meta(
+				$id,
+				'_atmosphere_blob_ref',
+				array(
+					'cid'      => "bafyfirst{$i}",
+					'mimeType' => 'image/jpeg',
+					'size'     => $i + 1,
+				)
+			);
+			$valid_ids[] = $id;
+		}
+
+		// Tail attachment that sits at position 33+ in document order
+		// — past the breadth cap. Its blob ref is fully valid; what
+		// proves the cap held is its absence from the working set.
+		$tail_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'tail.jpg',
+				'post_mime_type' => 'image/jpeg',
+			),
+			0,
+			array( 'post_title' => 'Tail attachment' )
+		);
+		\update_post_meta(
+			$tail_id,
+			'_atmosphere_blob_ref',
+			array(
+				'cid'      => 'bafytail',
+				'mimeType' => 'image/jpeg',
+				'size'     => 99,
+			)
+		);
+
+		$content = '<!-- wp:paragraph --><p>Lots of images aside.</p><!-- /wp:paragraph -->' . "\n\n";
+
+		// First four valid IDs at the head, then 30 placeholder blocks
+		// with synthetic IDs so the breadth cap fires before the tail
+		// attachment is seen. The tail then sits at position 35.
+		foreach ( $valid_ids as $id ) {
+			$content .= '<!-- wp:image {"id":' . $id . '} --><figure></figure><!-- /wp:image -->';
+		}
+		for ( $i = 0; $i < 30; $i++ ) {
+			$synthetic_id = 90000 + $i;
+			$content     .= '<!-- wp:image {"id":' . $synthetic_id . '} --><figure></figure><!-- /wp:image -->';
+		}
+		$content .= '<!-- wp:image {"id":' . $tail_id . '} --><figure></figure><!-- /wp:image -->';
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Aside with many images',
+				'post_content' => $content,
+			)
+		);
+		\set_post_format( $post_id, 'aside' );
+		$post = \get_post( $post_id );
+
+		$record = ( new Post( $post ) )->transform();
+
+		// AT Protocol cap trims to 4. Order in the embed is the first
+		// four document-order IDs we wrote — proves the head wasn't
+		// displaced by anything past the cap.
+		$this->assertCount( 4, $record['embed']['images'] );
+		$cids = \array_map( static fn( $img ) => $img['image']['cid'], $record['embed']['images'] );
+		$this->assertSame(
+			array( 'bafyfirst0', 'bafyfirst1', 'bafyfirst2', 'bafyfirst3' ),
+			$cids
+		);
+
+		// The tail attachment was never collected — its blob ref would
+		// have surfaced as a fifth-position CID if the walker had
+		// continued past 32.
+		$this->assertNotContains( 'bafytail', $cids );
+	}
+
+	/**
+	 * The walker is depth-capped so a pathologically nested block tree
+	 * — many wrapper levels with no images — cannot blow PHP's stack
+	 * before the breadth guard ever fires. We construct a tree past the
+	 * 16-level cap with an image at the bottom; the image is dropped
+	 * because the walker bails before reaching it, and the call returns
+	 * cleanly without a fatal.
+	 *
+	 * Mirror test confirms an image at depth ≤ 16 IS still collected,
+	 * so the cap is a true upper bound rather than a regression of the
+	 * legitimate nested-image case already covered by
+	 * `test_short_form_collects_nested_image_blocks`.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_short_form_image_collector_stops_at_depth_cap() {
+		$deep_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'deep.jpg',
+				'post_mime_type' => 'image/jpeg',
+			),
+			0,
+			array( 'post_title' => 'Too-deep attachment' )
+		);
+		\update_post_meta(
+			$deep_id,
+			'_atmosphere_blob_ref',
+			array(
+				'cid'      => 'bafydeep',
+				'mimeType' => 'image/jpeg',
+				'size'     => 1,
+			)
+		);
+
+		// Build a 30-level deep nesting of `core/group` blocks wrapping
+		// a single `core/image` at the bottom. Anything beyond the
+		// walker's 16-level cap should be invisible to the collector.
+		$nesting = 30;
+		$open    = '';
+		$close   = '';
+		for ( $i = 0; $i < $nesting; $i++ ) {
+			$open  .= '<!-- wp:group --><div class="wp-block-group">';
+			$close .= '</div><!-- /wp:group -->';
+		}
+
+		$content = '<!-- wp:paragraph --><p>Deeply nested aside.</p><!-- /wp:paragraph -->'
+			. $open
+			. '<!-- wp:image {"id":' . $deep_id . '} -->'
+			. '<figure class="wp-block-image"><img class="wp-image-' . $deep_id . '"/></figure>'
+			. '<!-- /wp:image -->'
+			. $close;
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Deeply nested image aside',
+				'post_content' => $content,
+			)
+		);
+		\set_post_format( $post_id, 'aside' );
+		$post = \get_post( $post_id );
+
+		// Past-cap image must be silently dropped and the call must
+		// return cleanly (no fatal, no PHP warning).
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertArrayNotHasKey(
+			'embed',
+			$record,
+			'Image past the 16-level depth cap must not surface in the embed.'
+		);
+	}
 }

--- a/tests/phpunit/tests/transformer/class-test-post.php
+++ b/tests/phpunit/tests/transformer/class-test-post.php
@@ -2280,4 +2280,98 @@ class Test_Post extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'embed', $record );
 		$this->assertSame( 'bafynested', $record['embed']['images'][0]['image']['cid'] );
 	}
+
+	/**
+	 * `atmosphere_post_embed` returning null suppresses the new default
+	 * image embed on short-form posts — preserves the existing override
+	 * contract.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_post_embed_filter_returning_null_suppresses_short_form_images_embed() {
+		$attachment_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'img.jpg',
+				'post_mime_type' => 'image/jpeg',
+			),
+			0,
+			array( 'post_title' => 'Attachment' )
+		);
+		\update_post_meta(
+			$attachment_id,
+			'_atmosphere_blob_ref',
+			array(
+				'cid'      => 'bafy',
+				'mimeType' => 'image/jpeg',
+				'size'     => 1,
+			)
+		);
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Aside with image',
+				'post_content' => 'Body text.',
+			)
+		);
+		\set_post_format( $post_id, 'aside' );
+		\set_post_thumbnail( $post_id, $attachment_id );
+		$post = \get_post( $post_id );
+
+		\add_filter( 'atmosphere_post_embed', '__return_null' );
+
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertArrayNotHasKey( 'embed', $record );
+	}
+
+	/**
+	 * The `atmosphere_post_embed` filter receives the new image embed as
+	 * the default value (not `null`) on a short-form post with an image,
+	 * so listeners that want to inspect / augment the default can.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_post_embed_filter_receives_images_default_on_short_form() {
+		$attachment_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'img.jpg',
+				'post_mime_type' => 'image/jpeg',
+			),
+			0,
+			array( 'post_title' => 'Attachment' )
+		);
+		\update_post_meta(
+			$attachment_id,
+			'_atmosphere_blob_ref',
+			array(
+				'cid'      => 'bafy',
+				'mimeType' => 'image/jpeg',
+				'size'     => 1,
+			)
+		);
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Aside with image',
+				'post_content' => 'Body text.',
+			)
+		);
+		\set_post_format( $post_id, 'aside' );
+		\set_post_thumbnail( $post_id, $attachment_id );
+		$post = \get_post( $post_id );
+
+		$seen = null;
+		\add_filter(
+			'atmosphere_post_embed',
+			static function ( $embed ) use ( &$seen ) {
+				$seen = $embed;
+				return $embed;
+			}
+		);
+
+		( new Post( $post ) )->transform();
+
+		$this->assertIsArray( $seen );
+		$this->assertSame( 'app.bsky.embed.images', $seen['$type'] );
+	}
 }

--- a/tests/phpunit/tests/transformer/class-test-post.php
+++ b/tests/phpunit/tests/transformer/class-test-post.php
@@ -2104,4 +2104,180 @@ class Test_Post extends WP_UnitTestCase {
 			$record['embed']['images'][0]['aspectRatio']
 		);
 	}
+
+	/**
+	 * A short-form post with an in-body `core/image` block uses that
+	 * image — not the featured image — in the embed.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_short_form_with_inbody_image_block_uses_inbody_image() {
+		// Featured image — should be ignored when an in-body image exists.
+		$featured_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'featured.jpg',
+				'post_mime_type' => 'image/jpeg',
+			),
+			0,
+			array( 'post_title' => 'Featured attachment' )
+		);
+		\update_post_meta(
+			$featured_id,
+			'_atmosphere_blob_ref',
+			array(
+				'cid'      => 'bafyfeatured',
+				'mimeType' => 'image/jpeg',
+				'size'     => 1,
+			)
+		);
+
+		// In-body image.
+		$inbody_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'inbody.jpg',
+				'post_mime_type' => 'image/jpeg',
+			),
+			0,
+			array( 'post_title' => 'In-body attachment' )
+		);
+		\update_post_meta(
+			$inbody_id,
+			'_atmosphere_blob_ref',
+			array(
+				'cid'      => 'bafyinbody',
+				'mimeType' => 'image/jpeg',
+				'size'     => 2,
+			)
+		);
+		\update_post_meta( $inbody_id, '_wp_attachment_image_alt', 'An in-body image' );
+
+		$content = '<!-- wp:paragraph --><p>Just an aside.</p><!-- /wp:paragraph -->'
+			. "\n\n"
+			. '<!-- wp:image {"id":' . $inbody_id . ',"sizeSlug":"large"} -->'
+			. '<figure class="wp-block-image size-large"><img src="" alt="" class="wp-image-' . $inbody_id . '"/></figure>'
+			. '<!-- /wp:image -->';
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Aside with inline image',
+				'post_content' => $content,
+			)
+		);
+		\set_post_format( $post_id, 'aside' );
+		\set_post_thumbnail( $post_id, $featured_id );
+		$post = \get_post( $post_id );
+
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertArrayHasKey( 'embed', $record );
+		$this->assertSame( 'app.bsky.embed.images', $record['embed']['$type'] );
+		$this->assertCount( 1, $record['embed']['images'] );
+		$this->assertSame( 'An in-body image', $record['embed']['images'][0]['alt'] );
+		$this->assertSame( 'bafyinbody', $record['embed']['images'][0]['image']['cid'] );
+	}
+
+	/**
+	 * Up to 4 in-body images attach; duplicates are removed in document
+	 * order; the 5th and beyond are dropped.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_short_form_with_many_inbody_images_caps_at_four() {
+		$ids = array();
+		for ( $i = 0; $i < 5; $i++ ) {
+			$id = self::factory()->attachment->create_object(
+				array(
+					'file'           => "img{$i}.jpg",
+					'post_mime_type' => 'image/jpeg',
+				),
+				0,
+				array( 'post_title' => "Image {$i}" )
+			);
+			\update_post_meta(
+				$id,
+				'_atmosphere_blob_ref',
+				array(
+					'cid'      => "bafy{$i}",
+					'mimeType' => 'image/jpeg',
+					'size'     => $i + 1,
+				)
+			);
+			$ids[] = $id;
+		}
+
+		// Sequence: id0, id1, id2, id0 (dup), id3, id4 — after dedup we
+		// expect [ id0, id1, id2, id3, id4 ], capped to first 4.
+		$sequence = array( $ids[0], $ids[1], $ids[2], $ids[0], $ids[3], $ids[4] );
+		$content  = '<!-- wp:paragraph --><p>Look at these images.</p><!-- /wp:paragraph -->' . "\n\n";
+		foreach ( $sequence as $id ) {
+			$content .= '<!-- wp:image {"id":' . $id . '} -->'
+				. '<figure class="wp-block-image"><img class="wp-image-' . $id . '"/></figure>'
+				. "<!-- /wp:image -->\n";
+		}
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Many images aside',
+				'post_content' => $content,
+			)
+		);
+		\set_post_format( $post_id, 'aside' );
+		$post = \get_post( $post_id );
+
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertCount( 4, $record['embed']['images'] );
+		$cids = \array_map( static fn( $img ) => $img['image']['cid'], $record['embed']['images'] );
+		$this->assertSame( array( 'bafy0', 'bafy1', 'bafy2', 'bafy3' ), $cids );
+	}
+
+	/**
+	 * `core/image` blocks nested inside `core/group` (and other container
+	 * blocks via `innerBlocks`) are picked up by the recursive walk.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_short_form_collects_nested_image_blocks() {
+		$inner_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'nested.jpg',
+				'post_mime_type' => 'image/jpeg',
+			),
+			0,
+			array( 'post_title' => 'Nested attachment' )
+		);
+		\update_post_meta(
+			$inner_id,
+			'_atmosphere_blob_ref',
+			array(
+				'cid'      => 'bafynested',
+				'mimeType' => 'image/jpeg',
+				'size'     => 1,
+			)
+		);
+
+		$content = '<!-- wp:paragraph --><p>Nested image aside.</p><!-- /wp:paragraph -->'
+			. "\n\n"
+			. '<!-- wp:group -->'
+			. '<div class="wp-block-group">'
+			. '<!-- wp:image {"id":' . $inner_id . '} -->'
+			. '<figure class="wp-block-image"><img class="wp-image-' . $inner_id . '"/></figure>'
+			. '<!-- /wp:image -->'
+			. '</div>'
+			. '<!-- /wp:group -->';
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Group with nested image',
+				'post_content' => $content,
+			)
+		);
+		\set_post_format( $post_id, 'aside' );
+		$post = \get_post( $post_id );
+
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertArrayHasKey( 'embed', $record );
+		$this->assertSame( 'bafynested', $record['embed']['images'][0]['image']['cid'] );
+	}
 }

--- a/tests/phpunit/tests/transformer/class-test-post.php
+++ b/tests/phpunit/tests/transformer/class-test-post.php
@@ -2030,4 +2030,78 @@ class Test_Post extends WP_UnitTestCase {
 
 		$this->assertNull( Post::get_attachment_aspect_ratio( $attachment_id ) );
 	}
+
+	/*
+	 * -----------------------------------------------------------------
+	 * Short-form image embed — auto-extract from post content / featured image.
+	 * -----------------------------------------------------------------
+	 */
+
+	/**
+	 * A short-form post with no in-body images but with a featured image
+	 * attaches an `app.bsky.embed.images` record with that single image.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_short_form_with_featured_image_attaches_images_embed() {
+		$attachment_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'featured.jpg',
+				'post_mime_type' => 'image/jpeg',
+			),
+			0,
+			array(
+				'post_title' => 'Featured attachment',
+			)
+		);
+		\update_post_meta(
+			$attachment_id,
+			'_atmosphere_blob_ref',
+			array(
+				'cid'      => 'bafyfeatured',
+				'mimeType' => 'image/jpeg',
+				'size'     => 123,
+			)
+		);
+		\update_post_meta( $attachment_id, '_wp_attachment_image_alt', 'A featured image' );
+		\wp_update_attachment_metadata(
+			$attachment_id,
+			array(
+				'width'  => 1600,
+				'height' => 1200,
+			)
+		);
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Aside with featured image',
+				'post_content' => 'Just text in the body.',
+			)
+		);
+		\set_post_format( $post_id, 'aside' );
+		\set_post_thumbnail( $post_id, $attachment_id );
+		$post = \get_post( $post_id );
+
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertArrayHasKey( 'embed', $record );
+		$this->assertSame( 'app.bsky.embed.images', $record['embed']['$type'] );
+		$this->assertCount( 1, $record['embed']['images'] );
+		$this->assertSame( 'A featured image', $record['embed']['images'][0]['alt'] );
+		$this->assertSame(
+			array(
+				'cid'      => 'bafyfeatured',
+				'mimeType' => 'image/jpeg',
+				'size'     => 123,
+			),
+			$record['embed']['images'][0]['image']
+		);
+		$this->assertSame(
+			array(
+				'width'  => 1600,
+				'height' => 1200,
+			),
+			$record['embed']['images'][0]['aspectRatio']
+		);
+	}
 }


### PR DESCRIPTION
Fixes [CM-796](https://linear.app/a8c/issue/CM-796/short-form-posts-drop-images-when-distributed-to-bluesky)

## Proposed changes:

Short-form Bluesky posts (aside, status, quote — any format where the post body is shipped verbatim as text) were silently dropping their images. The link-card embed path only ran for the long-form composition, so a short-form post with images shipped with no embed at all.

This PR makes short-form posts build an `app.bsky.embed.images` record from:

1. `core/image` blocks parsed from `post_content` — recursive into `innerBlocks`, deduped, document order, capped at 4 per the AT Protocol limit.
2. The featured image (`get_post_thumbnail_id`) as a fallback when no in-body images are found.

Redacted (password-protected) posts continue to ship no embed. The `atmosphere_post_embed` filter contract is preserved — third-party listeners can still suppress, replace, or augment the default.

### Hardening from review:

* The walker that collects in-body image IDs is capped at 32 entries so an adversarial `post_content` packed with thousands of `core/image` blocks can't grow the working array linearly.
* Regression tests added for the `> 0` / `isset` ID guards and for the always-present `alt` field (Lexicon requirement).
* `atmosphere_post_embed` filter docblock corrected to reflect the new short-form default (was `null`; is now an `app.bsky.embed.images` record when the post has images).

### Out of scope:

* Classic-editor `<img>` tags (block-editor scope only — documented in code).
* The pre-existing 1 MB blob cap in `upload_image_blob()` (AT Protocol Lexicon now allows 2 MB — separate uplift opportunity).

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Connect ATmosphere to a Bluesky test account.
2. In the WordPress editor, create a new post with the **Aside** post format (or leave the title empty for any post type).
3. Add one or more `core/image` blocks to the post body — uploaded from the media library so they have attachment IDs. Publish.
4. Open the resulting post on Bluesky. Confirm the post body is shipped as text and the images are attached as a native image embed (up to 4, in document order).
5. Repeat with a post that has **no** in-body images but **does** have a featured image. Confirm the featured image is attached instead.
6. Repeat with a password-protected aside that has a featured image. Confirm Bluesky receives the redacted record with no embed and no leaked image.
7. Optional: drop a filter on `atmosphere_post_embed` that returns `null` and confirm the embed is suppressed; one that returns an array with a non-empty `$type` and confirm it replaces the default.

### Changelog entry

Already committed in `.github/changelog/fix-short-form-image-embed`.