### PR TITLE
Write the site icon to the publication `icon` field, drop non-spec fields, decode HTML entities

### DIFF
--- a/.github/changelog/fix-publication-html-entities
+++ b/.github/changelog/fix-publication-html-entities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Site names and descriptions containing characters like apostrophes or ampersands now publish correctly instead of showing raw HTML codes.

--- a/.github/changelog/fix-publication-icon
+++ b/.github/changelog/fix-publication-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Your site icon now appears as the icon on your standard.site publication record.

--- a/.github/changelog/fix-publication-icon
+++ b/.github/changelog/fix-publication-icon
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Your site icon now appears as the icon on your standard.site publication record.
+Your site icon now appears on your standard.site publication.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -46,14 +46,20 @@ function build_at_uri( string $did, string $collection, string $rkey ): string {
 }
 
 /**
- * Strip HTML, decode entities, normalise whitespace.
+ * Decode entities, strip HTML, normalise whitespace.
  *
  * @param string $text Raw text.
  * @return string Clean text.
  */
 function sanitize_text( string $text ): string {
-	$text = \wp_strip_all_tags( $text );
+	// Decode BEFORE stripping. WordPress stores many strings HTML-entity
+	// encoded (esc_html at save time), so an entity-encoded tag such as
+	// `&lt;script&gt;` arrives with no literal angle brackets. Stripping
+	// first would leave it untouched and the later decode would turn it
+	// into live `<script>` markup in the record. Decoding first turns it
+	// into a real tag that wp_strip_all_tags then removes.
 	$text = \html_entity_decode( $text, ENT_QUOTES, 'UTF-8' );
+	$text = \wp_strip_all_tags( $text );
 	// `/u` matches Unicode whitespace too — without it NBSP (U+00A0),
 	// ideographic space (U+3000), and similar survive both this collapse
 	// and the trim() below, masquerading as real prose downstream.

--- a/includes/transformer/class-publication.php
+++ b/includes/transformer/class-publication.php
@@ -12,7 +12,6 @@ namespace Atmosphere\Transformer;
 
 \defined( 'ABSPATH' ) || exit;
 
-use function Atmosphere\get_did;
 use function Atmosphere\sanitize_text;
 
 /**
@@ -33,6 +32,10 @@ class Publication extends Base {
 	 * @return array site.standard.publication record.
 	 */
 	public function transform(): array {
+		// WordPress stores the site name and tagline HTML-entity encoded
+		// (esc_html at save time). sanitize_text() decodes those entities —
+		// and also strips tags and collapses whitespace — so the record
+		// carries clean plain text rather than codes like `&#039;`.
 		$record = array(
 			'$type'       => 'site.standard.publication',
 			'url'         => \home_url( '/' ),

--- a/includes/transformer/class-publication.php
+++ b/includes/transformer/class-publication.php
@@ -13,6 +13,7 @@ namespace Atmosphere\Transformer;
 \defined( 'ABSPATH' ) || exit;
 
 use function Atmosphere\get_did;
+use function Atmosphere\sanitize_text;
 
 /**
  * Standard.site publication transformer.
@@ -35,17 +36,18 @@ class Publication extends Base {
 		$record = array(
 			'$type'       => 'site.standard.publication',
 			'url'         => \home_url( '/' ),
-			'name'        => \get_bloginfo( 'name' ),
-			'displayName' => \get_bloginfo( 'name' ),
-			'description' => \get_bloginfo( 'description' ),
+			'name'        => sanitize_text( \get_bloginfo( 'name' ) ),
+			'description' => sanitize_text( \get_bloginfo( 'description' ) ),
 		);
 
-		// Site icon as avatar.
+		// Site icon. The site.standard.publication lexicon expects a square
+		// `icon` blob (at least 256x256). The Site Icon control crops to a
+		// square and recommends 512px, which clears that guideline.
 		$icon_id = \get_option( 'site_icon' );
 		if ( $icon_id ) {
 			$blob = Post::upload_thumbnail( (int) $icon_id );
 			if ( $blob ) {
-				$record['avatar'] = $blob;
+				$record['icon'] = $blob;
 			}
 		}
 

--- a/includes/transformer/class-publication.php
+++ b/includes/transformer/class-publication.php
@@ -33,9 +33,9 @@ class Publication extends Base {
 	 */
 	public function transform(): array {
 		// WordPress stores the site name and tagline HTML-entity encoded
-		// (esc_html at save time). sanitize_text() decodes those entities —
-		// and also strips tags and collapses whitespace — so the record
-		// carries clean plain text rather than codes like `&#039;`.
+		// (esc_html at save time). sanitize_text() strips tags, decodes
+		// those entities, and collapses whitespace, so the record carries
+		// clean plain text rather than codes like `&#039;`.
 		$record = array(
 			'$type'       => 'site.standard.publication',
 			'url'         => \home_url( '/' ),

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -19,6 +19,7 @@ use function Atmosphere\get_supported_post_types;
 use function Atmosphere\has_identity;
 use function Atmosphere\is_connected;
 use function Atmosphere\needs_reauth;
+use function Atmosphere\sanitize_text;
 
 /**
  * Admin class.
@@ -880,7 +881,7 @@ class Admin {
 	public static function serve_client_metadata(): \WP_REST_Response {
 		$metadata = array(
 			'client_id'                  => Client::client_id(),
-			'client_name'                => \get_bloginfo( 'name' ) . ' (ATmosphere)',
+			'client_name'                => sanitize_text( \get_bloginfo( 'name' ) ) . ' (ATmosphere)',
 			'client_uri'                 => \home_url( '/' ),
 			'redirect_uris'              => array( Client::redirect_uri() ),
 			'grant_types'                => array( 'authorization_code', 'refresh_token' ),

--- a/tests/phpunit/tests/class-test-functions.php
+++ b/tests/phpunit/tests/class-test-functions.php
@@ -59,6 +59,19 @@ class Test_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Entity-encoded markup must not survive as live tags. WordPress stores
+	 * values like the site title HTML-entity encoded, so `<b>` arrives as
+	 * `&lt;b&gt;`. sanitize_text() decodes before stripping, so the decoded
+	 * tag is removed rather than re-materialising as live markup in the
+	 * record.
+	 */
+	public function test_sanitize_text_removes_entity_encoded_markup() {
+		$this->assertSame( 'Bad', sanitize_text( '&lt;b&gt;Bad&lt;/b&gt;' ) );
+		$this->assertSame( '', sanitize_text( '&lt;script&gt;alert(1)&lt;/script&gt;' ) );
+		$this->assertStringNotContainsString( '<', sanitize_text( '&lt;img src=x onerror=alert(1)&gt;' ) );
+	}
+
+	/**
 	 * Unicode whitespace (NBSP, ideographic space) collapses and trims
 	 * just like ASCII whitespace. Without the `/u` regex flag a NBSP-only
 	 * string would survive both the collapse and the trim and leak

--- a/tests/phpunit/tests/transformer/class-test-publication.php
+++ b/tests/phpunit/tests/transformer/class-test-publication.php
@@ -98,8 +98,34 @@ class Test_Publication extends WP_UnitTestCase {
 
 		$record = ( new Publication( null ) )->transform();
 
+		$this->assertSame( 'site.standard.publication', $record['$type'] );
 		$this->assertSame( $blob, $record['icon'], 'Site icon should populate the spec `icon` field.' );
 		$this->assertArrayNotHasKey( 'avatar', $record, 'The non-spec `avatar` field must not be present.' );
+	}
+
+	/**
+	 * When a site icon is set but its blob cannot be uploaded, the `icon`
+	 * key is omitted rather than written as null. The attachment has no
+	 * backing file and no cached blob ref, so upload_image_blob() returns
+	 * null at its `! $file` guard without a network call.
+	 */
+	public function test_site_icon_omitted_when_blob_upload_fails() {
+		$attachment_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'missing.png',
+				'post_mime_type' => 'image/png',
+			),
+			0,
+			array(
+				'post_title' => 'Site icon',
+			)
+		);
+		\delete_post_meta( $attachment_id, '_wp_attached_file' );
+		\update_option( 'site_icon', $attachment_id );
+
+		$record = ( new Publication( null ) )->transform();
+
+		$this->assertArrayNotHasKey( 'icon', $record );
 	}
 
 	/**

--- a/tests/phpunit/tests/transformer/class-test-publication.php
+++ b/tests/phpunit/tests/transformer/class-test-publication.php
@@ -3,6 +3,8 @@
  * Tests for the Publication transformer.
  *
  * @package Atmosphere
+ * @group atmosphere
+ * @group transformer
  */
 
 namespace Atmosphere\Tests\Transformer;
@@ -65,5 +67,71 @@ class Test_Publication extends WP_UnitTestCase {
 		$pub = new Publication( null );
 
 		$this->assertSame( 'site.standard.publication', $pub->get_collection() );
+	}
+
+	/**
+	 * The site icon populates the spec-compliant `icon` field, not the
+	 * legacy non-spec `avatar` field.
+	 *
+	 * Seeds the `_atmosphere_blob_ref` cache so the transformer resolves
+	 * the blob from post meta instead of performing a network upload.
+	 */
+	public function test_site_icon_maps_to_icon_field() {
+		$attachment_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'site-icon.png',
+				'post_mime_type' => 'image/png',
+			),
+			0,
+			array(
+				'post_title' => 'Site icon',
+			)
+		);
+
+		$blob = array(
+			'cid'      => 'bafyicon',
+			'mimeType' => 'image/png',
+			'size'     => 4096,
+		);
+		\update_post_meta( $attachment_id, '_atmosphere_blob_ref', $blob );
+		\update_option( 'site_icon', $attachment_id );
+
+		$record = ( new Publication( null ) )->transform();
+
+		$this->assertSame( $blob, $record['icon'], 'Site icon should populate the spec `icon` field.' );
+		$this->assertArrayNotHasKey( 'avatar', $record, 'The non-spec `avatar` field must not be present.' );
+	}
+
+	/**
+	 * The publication record uses the spec field `name` and omits the
+	 * non-spec `displayName` field carried over from the bsky profile shape.
+	 */
+	public function test_record_omits_non_spec_display_name() {
+		$record = ( new Publication( null ) )->transform();
+
+		$this->assertArrayHasKey( 'name', $record );
+		$this->assertArrayNotHasKey( 'displayName', $record );
+	}
+
+	/**
+	 * The name and description are HTML-entity decoded before they reach
+	 * the record. WordPress stores `blogname` / `blogdescription`
+	 * entity-encoded (esc_html at save time), so the raw values carry
+	 * `&#039;`, `&amp;`, etc. Use `pre_option_*` filters to inject the
+	 * stored (encoded) form deterministically.
+	 */
+	public function test_name_and_description_decode_html_entities() {
+		\add_filter( 'pre_option_blogname', static fn() => 'Toni&#039;s blog' );
+		\add_filter( 'pre_option_blogdescription', static fn() => 'Tom &amp; Jerry' );
+
+		try {
+			$record = ( new Publication( null ) )->transform();
+		} finally {
+			\remove_all_filters( 'pre_option_blogname' );
+			\remove_all_filters( 'pre_option_blogdescription' );
+		}
+
+		$this->assertSame( "Toni's blog", $record['name'] );
+		$this->assertSame( 'Tom & Jerry', $record['description'] );
 	}
 }

--- a/tests/phpunit/tests/transformer/class-test-publication.php
+++ b/tests/phpunit/tests/transformer/class-test-publication.php
@@ -134,4 +134,27 @@ class Test_Publication extends WP_UnitTestCase {
 		$this->assertSame( "Toni's blog", $record['name'] );
 		$this->assertSame( 'Tom & Jerry', $record['description'] );
 	}
+
+	/**
+	 * End-to-end proof against WordPress's real storage path: a site name
+	 * and tagline saved with special characters round-trip to clean text
+	 * in the record.
+	 *
+	 * `update_option()` runs the value through `sanitize_option()`, which
+	 * `esc_html()`s `blogname` / `blogdescription` exactly once. `esc_html()`
+	 * is idempotent (`_wp_specialchars()` defaults to `$double_encode =
+	 * false`), so the stored value is always single-encoded — a single
+	 * `html_entity_decode()` pass in `sanitize_text()` fully decodes it.
+	 * This is the realistic counterpart to the `pre_option_*` test above,
+	 * which injects an arbitrary encoded string directly.
+	 */
+	public function test_name_and_description_round_trip_real_option_values() {
+		\update_option( 'blogname', "Toni's blog & Co" );
+		\update_option( 'blogdescription', "Books, coffee & friends'" );
+
+		$record = ( new Publication( null ) )->transform();
+
+		$this->assertSame( "Toni's blog & Co", $record['name'] );
+		$this->assertSame( "Books, coffee & friends'", $record['description'] );
+	}
 }

--- a/tests/phpunit/tests/wp-admin/class-test-client-metadata-filter.php
+++ b/tests/phpunit/tests/wp-admin/class-test-client-metadata-filter.php
@@ -247,12 +247,13 @@ class Test_Client_Metadata_Filter extends WP_UnitTestCase {
 	 * decoding the consent screen would render raw codes like `&#039;`.
 	 */
 	public function test_client_name_decodes_html_entities() {
-		\add_filter( 'pre_option_blogname', static fn() => 'Toni&#039;s blog' );
+		// Covers both a numeric entity (&#039;) and a named entity (&amp;).
+		\add_filter( 'pre_option_blogname', static fn() => 'Tom &amp; Toni&#039;s blog' );
 
 		$response = Admin::serve_client_metadata();
 		$data     = $response->get_data();
 
-		$this->assertSame( "Toni's blog (ATmosphere)", $data['client_name'] );
+		$this->assertSame( "Tom & Toni's blog (ATmosphere)", $data['client_name'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/wp-admin/class-test-client-metadata-filter.php
+++ b/tests/phpunit/tests/wp-admin/class-test-client-metadata-filter.php
@@ -27,6 +27,7 @@ class Test_Client_Metadata_Filter extends WP_UnitTestCase {
 	 */
 	public function tear_down(): void {
 		\remove_all_filters( 'atmosphere_client_metadata' );
+		\remove_all_filters( 'pre_option_blogname' );
 		parent::tear_down();
 	}
 
@@ -238,6 +239,20 @@ class Test_Client_Metadata_Filter extends WP_UnitTestCase {
 			'nested-array' => array( array( 'nested' ) ),
 			'bool'         => array( true ),
 		);
+	}
+
+	/**
+	 * The OAuth client name is HTML-entity decoded. WordPress stores
+	 * `blogname` entity-encoded (esc_html at save time), so without
+	 * decoding the consent screen would render raw codes like `&#039;`.
+	 */
+	public function test_client_name_decodes_html_entities() {
+		\add_filter( 'pre_option_blogname', static fn() => 'Toni&#039;s blog' );
+
+		$response = Admin::serve_client_metadata();
+		$data     = $response->get_data();
+
+		$this->assertSame( "Toni's blog (ATmosphere)", $data['client_name'] );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

Our `site.standard.publication` record was modeled on `app.bsky.actor.profile` — it carried `displayName` and wrote the site icon to an `avatar` field. Neither is part of the publication lexicon. The lexicon's image field is `icon` (a square blob), and the name field is just `name`. So the site icon we were already uploading never rendered: it sat in a field consumers ignore.

You can see it in the wild. Here's toni.org's live publication record *before* this change:

```json
{
  "url": "https://toni.org/",
  "name": "Toni.org",
  "$type": "site.standard.publication",
  "avatar": { "$type": "blob", "ref": { "$link": "bafkrei…" }, "mimeType": "image/png", "size": 307193 },
  "description": "Toni Schneider&#039;s blog",
  "displayName": "Toni.org"
}
```

Two problems are visible there: the 307 KB icon blob is parked in `avatar` (ignored), and `description` renders `&#039;` instead of an apostrophe.

This PR:

- **Writes the site icon to `icon`** instead of `avatar`, so it actually renders. WordPress site icons are already square (the Site Icon control crops to a square and recommends 512px), so they clear the lexicon's 256px guideline with no resizing.
- **Drops `displayName`.** It was never spec-compliant and the plugin never reads it back, so there's nothing to migrate. `name` already carries the value.
- **Decodes HTML entities in `name` and `description`.** WordPress stores `blogname`/`blogdescription` entity-encoded (esc_html at save time), so the raw values leak `&#039;`, `&amp;`, and friends into the record. Routing them through the existing `sanitize_text()` helper — which every other transformer already uses — fixes it. The same decode is applied to the OAuth `client_name` shown on the consent screen, which had the same bug.
- **Hardens `sanitize_text()` to decode entities before stripping tags.** Previously it stripped first, so an entity-encoded tag (`&lt;script&gt;`) survived the strip and the later decode turned it into live markup. Since this PR now routes identity strings through the helper, that markup could have reached a record or the OAuth consent screen. Decoding first means a decoded tag is removed. This is a shared helper, so the fix also hardens the post/document/comment transformers; plain text is unaffected.

Worth naming the things this *doesn't* do, both surfaced by review and tracked separately:
- The publication `theme` field is also non-spec (should be `basicTheme` → `site.standard.theme.basic`) — a restructure, not a rename. Tracked in issue 97.
- `name`/`description` aren't clamped to the lexicon's grapheme limits (500 / 3000). Pre-existing. Tracked in issue 99.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

New tests cover: icon-field mapping, the omitted-icon path when a blob upload fails, `displayName` omission, entity decoding for `name`/`description` (both injected and via the real `update_option` path), entity decoding for the OAuth `client_name`, and that entity-encoded markup is stripped by `sanitize_text()`. Network-free — they seed the `_atmosphere_blob_ref` blob cache and use `pre_option_*` / `update_option`.

## Testing instructions:

1. `composer lint` — clean.
2. `npm run env-test` — full suite passes (422 tests).
3. To verify against a real record: connect a site that has a Site Icon set and a tagline containing an apostrophe, sync the publication from the settings page, then read the record back from the PDS:
   ```
   curl -s "$PDS/xrpc/com.atproto.repo.listRecords?repo=$DID&collection=site.standard.publication" | jq '.records[0].value'
   ```
   It should now carry an `icon` blob (and no `avatar`), no `displayName`, and a `description` with the apostrophe decoded.

### Changelog entry

Entries are committed on the branch (`.github/changelog/fix-publication-icon`, `.github/changelog/fix-publication-html-entities`), so the auto-create box is intentionally left unchecked.

- [ ] Automatically create a changelog entry from the details below.