### PR TITLE
Fill in a default comment body for synced likes and reposts

### DIFF
--- a/.github/changelog/atproto-like-repost-comment-body
+++ b/.github/changelog/atproto-like-repost-comment-body
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Likes and reposts synced from Bluesky now include a readable comment body ("… liked this!" / "… reposted this!") so they display sensibly in themes that render activity-feed comments.

--- a/includes/class-reaction-sync.php
+++ b/includes/class-reaction-sync.php
@@ -543,6 +543,10 @@ class Reaction_Sync {
 		$timestamp = \strtotime( $record['createdAt'] ?? '' );
 		$gm_date   = \gmdate( 'Y-m-d H:i:s', false === $timestamp ? 0 : $timestamp );
 
+		if ( '' === $content ) {
+			$content = self::default_reaction_excerpt( $comment_type );
+		}
+
 		$comment_data = array(
 			'comment_post_ID'      => $post_id,
 			'comment_parent'       => $comment_parent,
@@ -633,6 +637,30 @@ class Reaction_Sync {
 		\do_action( 'atmosphere_reaction_synced', $comment_id, $notification, $post_id, $comment_type );
 
 		return $comment_id;
+	}
+
+	/**
+	 * Default comment body for content-less reactions (likes and reposts).
+	 *
+	 * Mirrors the wording the wordpress-activitypub plugin uses for its
+	 * own like/repost rows, so themes that render activity feeds get a
+	 * consistent reading experience across protocols. The leading
+	 * ellipsis is intentional: most themes render the author name
+	 * immediately before the comment body, so the result reads as
+	 * "Jane Doe … liked this!".
+	 *
+	 * @param string $comment_type One of 'like', 'repost'.
+	 * @return string Translated excerpt, or empty string for unknown types.
+	 */
+	private static function default_reaction_excerpt( string $comment_type ): string {
+		switch ( $comment_type ) {
+			case 'like':
+				return \__( '… liked this!', 'atmosphere' );
+			case 'repost':
+				return \__( '… reposted this!', 'atmosphere' );
+			default:
+				return '';
+		}
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-reaction-sync.php
+++ b/tests/phpunit/tests/class-test-reaction-sync.php
@@ -602,7 +602,7 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 
 		$comment = \get_comment( $comment_id );
 
-		$this->assertSame( '', $comment->comment_content );
+		$this->assertSame( '… liked this!', $comment->comment_content );
 		$this->assertSame( 'like', $comment->comment_type );
 		$this->assertSame( (string) $post_id, $comment->comment_post_ID );
 		$this->assertSame( '0', $comment->comment_parent );
@@ -702,7 +702,7 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 
 		$comment = \get_comment( $comment_id );
 
-		$this->assertSame( '', $comment->comment_content );
+		$this->assertSame( '… reposted this!', $comment->comment_content );
 		$this->assertSame( 'repost', $comment->comment_type );
 		$this->assertSame( (string) $post_id, $comment->comment_post_ID );
 


### PR DESCRIPTION
Fixes CM-810

## Proposed changes:

* Likes and reposts ingested by `Reaction_Sync` previously saved an empty `comment_content`, so themes that render activity-feed style comments had no text to display next to the author name.
* In `Reaction_Sync::insert_reaction()`, when the incoming content is empty, fill it with a translated excerpt that mirrors the wording the wordpress-activitypub plugin uses for its own like/repost comment types:
  * like → "… liked this!"
  * repost → "… reposted this!"
* The leading ellipsis is intentional — most themes render the author name immediately before the body, so the result reads as "Jane Doe … liked this!".
* Reply imports are untouched: they still carry the real reply text, and the default only kicks in when content is empty.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

The two existing PHPUnit tests that asserted `comment_content === ''` for like and repost rows were updated to assert the new excerpts. No new test cases were necessary — the existing tests already exercise the only code path that changed.

## Testing instructions:

* Sync some Bluesky activity to a connected ATmosphere site (or run the relevant PHPUnit tests).
* Like and repost one of the site's published posts from another Bluesky account.
* Wait for `Reaction_Sync::sync()` to run (or trigger it manually).
* In wp-admin → Comments, confirm the new like / repost rows show "… liked this!" / "… reposted this!" as their body instead of being blank.
* Confirm regular reply imports still carry their original text.

To run the tests locally:

```
npm run env-test -- --filter=Reaction_Sync
```

### Changelog entry

A changelog entry is included in this PR at `.github/changelog/atproto-like-repost-comment-body`.