### PR TITLE
Compute document CID client-side so both strongRefs land in the initial post

### DIFF
--- a/.github/changelog/add-client-side-cid-for-associated-refs
+++ b/.github/changelog/add-client-side-cid-for-associated-refs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Posts shared to Bluesky now link back to both the site's publication record and the per-post document record, so Bluesky shows your site source, profile, and richer document metadata alongside the link preview.

--- a/includes/class-cid.php
+++ b/includes/class-cid.php
@@ -1,0 +1,400 @@
+<?php
+/**
+ * AT Protocol CID computation.
+ *
+ * Implements the minimum DAG-CBOR encoder + CIDv1 builder needed to
+ * pre-compute the CID of a record we are about to write, so a
+ * strongRef pointing at that record can ride along in the same
+ * atomic `applyWrites` batch. Without this, AT Protocol's chicken-
+ * and-egg constraint — strongRefs need the target's CID, which only
+ * exists after the write returns — forces a follow-up
+ * `applyWrites#update`. The follow-up does land at the PDS but
+ * Bluesky's AppView indexes posts at initial create only, ignoring
+ * later updates for `source` / `associatedProfiles` enrichment, so
+ * the visible UI never picks up the added refs (verified on
+ * `atmosphere-blog.bsky.social` 3mn7u77lp4dns — PDS holds both refs,
+ * AppView serves the initial one-ref version indefinitely).
+ *
+ * @package Atmosphere
+ */
+
+namespace Atmosphere;
+
+\defined( 'ABSPATH' ) || exit;
+
+/**
+ * CID generator + DAG-CBOR encoder targeted at the AT Protocol
+ * record subset Atmosphere produces.
+ *
+ * Scope:
+ *   - Encodes the types Atmosphere records actually use: null,
+ *     booleans, integers, UTF-8 strings, arrays, maps, and cid-link
+ *     tags via the `{ "$link": "bafy..." }` JSON convention.
+ *   - Treats maps with exactly one string key `$link` as cid-link
+ *     references (CBOR tag 42), matching the canonical atproto data
+ *     model JSON form. Other map shapes encode as plain CBOR maps.
+ *   - Sorts map keys length-first then bytewise per DAG-CBOR.
+ *   - Uses shortest integer encoding (DAG-CBOR requires it).
+ *   - Throws on NaN / Infinity floats — disallowed by DAG-CBOR.
+ *
+ * Out of scope: indefinite-length encoding (DAG-CBOR forbids it),
+ * float16 / float32, arbitrary tags beyond 42, big-int beyond
+ * PHP_INT_MAX (Atmosphere records do not produce those).
+ */
+class CID {
+
+	/**
+	 * Compute the CIDv1 base32 string of a record using AT Protocol's
+	 * encoding (DAG-CBOR + SHA-256 + dag-cbor codec).
+	 *
+	 * The returned value matches what the PDS round-trips back in
+	 * `applyWrites` / `getRecord` responses, byte-for-byte. Round-trip
+	 * stability is the contract: if a third party encodes the same
+	 * record and computes its CID independently, they must get the
+	 * same string.
+	 *
+	 * @param array $record Record value (typically a transformer's
+	 *                      `transform()` output).
+	 * @return string CID string with multibase prefix `b`.
+	 */
+	public static function from_record( array $record ): string {
+		$bytes  = self::encode( $record );
+		$digest = \hash( 'sha256', $bytes, true );
+
+		/*
+		 * Build the CIDv1 byte string:
+		 *   0x01 — CIDv1 version
+		 *   0x71 — multicodec for dag-cbor
+		 *   0x12 — multihash code for sha2-256
+		 *   0x20 — multihash digest length (32 bytes)
+		 *   $digest — the 32-byte SHA-256 hash
+		 *
+		 * Multibase-prefixed with `b` to flag base32 lowercase (RFC 4648,
+		 * no padding) per the atproto data model spec.
+		 */
+		$cid_bytes = "\x01\x71\x12\x20" . $digest;
+
+		return 'b' . self::base32_lower_encode( $cid_bytes );
+	}
+
+	/**
+	 * Decode a CID string (e.g. `bafyrei...`) back to its raw bytes.
+	 *
+	 * Used inside this class to reconstruct the byte form when
+	 * encoding cid-link tags, and exposed for callers that need to
+	 * verify a CID independently of the multibase form.
+	 *
+	 * @param string $cid_string CID string (must start with `b` multibase prefix).
+	 * @return string Raw CIDv1 bytes.
+	 * @throws \InvalidArgumentException When the multibase prefix is missing or invalid.
+	 */
+	public static function decode_string( string $cid_string ): string {
+		if ( '' === $cid_string || 'b' !== $cid_string[0] ) {
+			/*
+			 * CIDs are technical identifiers, not user-facing content;
+			 * embedding the raw value in the exception is safe and
+			 * observably useful in error logs.
+			 */
+			throw new \InvalidArgumentException( 'CID must use the base32 multibase prefix "b": ' . \esc_html( $cid_string ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		}
+
+		return self::base32_lower_decode( \substr( $cid_string, 1 ) );
+	}
+
+	/**
+	 * Encode an arbitrary PHP value as DAG-CBOR bytes.
+	 *
+	 * Dispatches by PHP type. The only non-obvious mapping is the
+	 * `{ "$link": "bafy..." }` shape — a one-key associative array
+	 * whose key is exactly `$link` and value is a string is encoded
+	 * as a CBOR tag-42 CID rather than a plain map, matching the
+	 * canonical JSON form for cid-link types in the atproto data
+	 * model. Callers that legitimately want a literal `$link` map
+	 * key with multiple sibling keys are unaffected (the detector
+	 * requires exactly one key).
+	 *
+	 * @param mixed $value PHP value.
+	 * @return string DAG-CBOR encoded bytes.
+	 * @throws \InvalidArgumentException When the value type cannot be encoded.
+	 */
+	public static function encode( $value ): string {
+		if ( null === $value ) {
+			return "\xf6";
+		}
+
+		if ( true === $value ) {
+			return "\xf5";
+		}
+
+		if ( false === $value ) {
+			return "\xf4";
+		}
+
+		if ( \is_int( $value ) ) {
+			return self::encode_int( $value );
+		}
+
+		if ( \is_string( $value ) ) {
+			return self::encode_text_string( $value );
+		}
+
+		if ( \is_array( $value ) ) {
+			/*
+			 * `{ "$link": "bafy..." }` is the atproto JSON form for a
+			 * cid-link. Detect that exact shape — exactly one key
+			 * named `$link`, value is a string — and emit CBOR tag 42
+			 * instead of a plain map. Anything else (two keys, a
+			 * different key name, a non-string value) falls through
+			 * to the normal map/array encoding.
+			 */
+			if ( 1 === \count( $value ) && isset( $value['$link'] ) && \is_string( $value['$link'] ) ) {
+				return self::encode_cid_link( $value['$link'] );
+			}
+
+			if ( \array_is_list( $value ) ) {
+				return self::encode_array( $value );
+			}
+
+			return self::encode_map( $value );
+		}
+
+		if ( \is_float( $value ) ) {
+			return self::encode_float( $value );
+		}
+
+		throw new \InvalidArgumentException(
+			\sprintf( 'DAG-CBOR encoder cannot handle value of type %s.', \esc_html( \gettype( $value ) ) ) // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		);
+	}
+
+	/**
+	 * Encode a CBOR major-type byte plus the smallest integer
+	 * argument encoding that fits the value.
+	 *
+	 * DAG-CBOR requires the shortest possible encoding for every
+	 * integer; this helper centralises that choice across all type
+	 * tags (positive ints, negative ints, byte strings, text strings,
+	 * arrays, maps). On a 64-bit PHP build the `>= 2^32` branch
+	 * handles values up to PHP_INT_MAX via `pack('J', ...)`.
+	 *
+	 * @param int $major_type CBOR major type (0..7).
+	 * @param int $argument   Length / value to encode.
+	 * @return string CBOR header bytes.
+	 * @throws \InvalidArgumentException When the argument is negative.
+	 */
+	private static function encode_argument( int $major_type, int $argument ): string {
+		$prefix = $major_type << 5;
+
+		if ( $argument < 0 ) {
+			throw new \InvalidArgumentException( 'CBOR argument must be non-negative.' );
+		}
+
+		if ( $argument < 24 ) {
+			return \chr( $prefix | $argument );
+		}
+
+		if ( $argument < 256 ) {
+			return \chr( $prefix | 0x18 ) . \chr( $argument );
+		}
+
+		if ( $argument < 65536 ) {
+			return \chr( $prefix | 0x19 ) . \pack( 'n', $argument );
+		}
+
+		if ( $argument < 4294967296 ) {
+			return \chr( $prefix | 0x1a ) . \pack( 'N', $argument );
+		}
+
+		return \chr( $prefix | 0x1b ) . \pack( 'J', $argument );
+	}
+
+	/**
+	 * Encode an integer.
+	 *
+	 * Positive ints use major type 0. Negative ints use major type 1
+	 * with argument `-1 - value`, the standard CBOR convention for
+	 * representing arbitrary negative values without a sign bit.
+	 *
+	 * @param int $value Integer to encode.
+	 * @return string CBOR bytes.
+	 */
+	private static function encode_int( int $value ): string {
+		if ( $value >= 0 ) {
+			return self::encode_argument( 0, $value );
+		}
+
+		return self::encode_argument( 1, -1 - $value );
+	}
+
+	/**
+	 * Encode a UTF-8 text string (major type 3).
+	 *
+	 * @param string $value Text bytes.
+	 * @return string CBOR bytes.
+	 */
+	private static function encode_text_string( string $value ): string {
+		return self::encode_argument( 3, \strlen( $value ) ) . $value;
+	}
+
+	/**
+	 * Encode a byte string (major type 2).
+	 *
+	 * @param string $value Raw bytes.
+	 * @return string CBOR bytes.
+	 */
+	private static function encode_byte_string( string $value ): string {
+		return self::encode_argument( 2, \strlen( $value ) ) . $value;
+	}
+
+	/**
+	 * Encode a list-shaped array (major type 4).
+	 *
+	 * @param array $value List to encode.
+	 * @return string CBOR bytes.
+	 */
+	private static function encode_array( array $value ): string {
+		$bytes = self::encode_argument( 4, \count( $value ) );
+
+		foreach ( $value as $item ) {
+			$bytes .= self::encode( $item );
+		}
+
+		return $bytes;
+	}
+
+	/**
+	 * Encode a map / associative array (major type 5).
+	 *
+	 * DAG-CBOR requires keys to be sorted length-first (shorter byte
+	 * length comes first), then bytewise for ties. This is a strict
+	 * canonical-encoding requirement — round-trip equality with the
+	 * PDS depends on it.
+	 *
+	 * @param array $value Map to encode.
+	 * @return string CBOR bytes.
+	 */
+	private static function encode_map( array $value ): string {
+		$keys = \array_map( 'strval', \array_keys( $value ) );
+
+		\usort(
+			$keys,
+			static function ( string $a, string $b ): int {
+				$len_diff = \strlen( $a ) - \strlen( $b );
+				if ( 0 !== $len_diff ) {
+					return $len_diff;
+				}
+				return \strcmp( $a, $b );
+			}
+		);
+
+		$bytes = self::encode_argument( 5, \count( $keys ) );
+		foreach ( $keys as $key ) {
+			$bytes .= self::encode_text_string( $key );
+			$bytes .= self::encode( $value[ $key ] );
+		}
+
+		return $bytes;
+	}
+
+	/**
+	 * Encode a float as IEEE 754 double-precision (major type 7,
+	 * additional info 27 / 0xfb).
+	 *
+	 * DAG-CBOR forbids NaN, +Inf, and -Inf, and forbids the smaller
+	 * float16 / float32 representations.
+	 *
+	 * @param float $value Float to encode.
+	 * @return string CBOR bytes.
+	 * @throws \InvalidArgumentException When the value is NaN or infinite.
+	 */
+	private static function encode_float( float $value ): string {
+		if ( \is_nan( $value ) || \is_infinite( $value ) ) {
+			throw new \InvalidArgumentException( 'DAG-CBOR does not permit NaN or Infinity.' );
+		}
+
+		// 'E' = IEEE 754 double precision, big-endian (PHP 7.0.15+ / 7.1.1+).
+		return "\xfb" . \pack( 'E', $value );
+	}
+
+	/**
+	 * Encode a CID-link as CBOR tag 42 containing a byte string of
+	 * `0x00 || cid_v1_bytes`.
+	 *
+	 * The leading `0x00` is the multibase identity prefix that
+	 * DAG-CBOR's cid-link spec requires; without it the encoding
+	 * would not round-trip through atproto's own decoders.
+	 *
+	 * @param string $cid_string CID string (with multibase prefix `b`).
+	 * @return string CBOR bytes.
+	 */
+	private static function encode_cid_link( string $cid_string ): string {
+		$cid_bytes = self::decode_string( $cid_string );
+
+		// 0xd8 0x2a = CBOR tag 42 with a 1-byte argument.
+		return "\xd8\x2a" . self::encode_byte_string( "\x00" . $cid_bytes );
+	}
+
+
+	/**
+	 * Base32 RFC 4648 lowercase encode (no padding).
+	 *
+	 * @param string $bytes Raw bytes.
+	 * @return string Base32 string.
+	 */
+	private static function base32_lower_encode( string $bytes ): string {
+		$alphabet = 'abcdefghijklmnopqrstuvwxyz234567';
+		$result   = '';
+		$buffer   = 0;
+		$bits     = 0;
+		$length   = \strlen( $bytes );
+
+		for ( $i = 0; $i < $length; $i++ ) {
+			$buffer = ( $buffer << 8 ) | \ord( $bytes[ $i ] );
+			$bits  += 8;
+			while ( $bits >= 5 ) {
+				$bits   -= 5;
+				$result .= $alphabet[ ( $buffer >> $bits ) & 31 ];
+			}
+		}
+
+		if ( $bits > 0 ) {
+			$result .= $alphabet[ ( $buffer << ( 5 - $bits ) ) & 31 ];
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Base32 RFC 4648 lowercase decode (no padding).
+	 *
+	 * @param string $value Base32 string.
+	 * @return string Raw bytes.
+	 * @throws \InvalidArgumentException When the input contains characters outside the base32 alphabet.
+	 */
+	private static function base32_lower_decode( string $value ): string {
+		static $lookup = null;
+		if ( null === $lookup ) {
+			$lookup = \array_flip( \str_split( 'abcdefghijklmnopqrstuvwxyz234567' ) );
+		}
+
+		$buffer = 0;
+		$bits   = 0;
+		$result = '';
+		$length = \strlen( $value );
+
+		for ( $i = 0; $i < $length; $i++ ) {
+			$char = $value[ $i ];
+			if ( ! isset( $lookup[ $char ] ) ) {
+				throw new \InvalidArgumentException( 'Invalid base32 character: ' . \esc_html( $char ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			}
+			$buffer = ( $buffer << 5 ) | $lookup[ $char ];
+			$bits  += 5;
+			if ( $bits >= 8 ) {
+				$bits   -= 8;
+				$result .= \chr( ( $buffer >> $bits ) & 0xff );
+			}
+		}
+
+		return $result;
+	}
+}

--- a/includes/class-cid.php
+++ b/includes/class-cid.php
@@ -53,12 +53,24 @@ class CID {
 	 * record and computes its CID independently, they must get the
 	 * same string.
 	 *
+	 * Returns a `WP_Error` if the encoder hits a record shape it cannot
+	 * handle (an unsupported value type, NaN / Infinity float, a
+	 * malformed `$link` cid-link, etc.). Callers in the publish path
+	 * treat that as "skip the optional strongRef" rather than aborting
+	 * the publish — the record still ships, just without the
+	 * `associatedRefs` entry that depended on the failed CID.
+	 *
 	 * @param array $record Record value (typically a transformer's
 	 *                      `transform()` output).
-	 * @return string CID string with multibase prefix `b`.
+	 * @return string|\WP_Error CID string with multibase prefix `b`, or
+	 *                          an error from the encoder.
 	 */
-	public static function from_record( array $record ): string {
-		$bytes  = self::encode( $record );
+	public static function from_record( array $record ): string|\WP_Error {
+		$bytes = self::encode( $record );
+		if ( \is_wp_error( $bytes ) ) {
+			return $bytes;
+		}
+
 		$digest = \hash( 'sha256', $bytes, true );
 
 		/*
@@ -85,20 +97,31 @@ class CID {
 	 * verify a CID independently of the multibase form.
 	 *
 	 * @param string $cid_string CID string (must start with `b` multibase prefix).
-	 * @return string Raw CIDv1 bytes.
-	 * @throws \InvalidArgumentException When the multibase prefix is missing or invalid.
+	 * @return string|\WP_Error Raw CIDv1 bytes, or `atmosphere_cid_invalid_*`
+	 *                          when the prefix is missing or the base32 body
+	 *                          contains characters outside the alphabet.
 	 */
-	public static function decode_string( string $cid_string ): string {
+	public static function decode_string( string $cid_string ): string|\WP_Error {
 		if ( '' === $cid_string || 'b' !== $cid_string[0] ) {
-			/*
-			 * CIDs are technical identifiers, not user-facing content;
-			 * embedding the raw value in the exception is safe and
-			 * observably useful in error logs.
-			 */
-			throw new \InvalidArgumentException( 'CID must use the base32 multibase prefix "b": ' . \esc_html( $cid_string ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			return new \WP_Error(
+				'atmosphere_cid_invalid_multibase',
+				\sprintf(
+					/* translators: %s: the raw CID string the caller passed in. */
+					\__( 'CID must use the base32 multibase prefix "b": %s', 'atmosphere' ),
+					$cid_string
+				)
+			);
 		}
 
-		return self::base32_lower_decode( \substr( $cid_string, 1 ) );
+		$decoded = self::base32_lower_decode( \substr( $cid_string, 1 ) );
+		if ( false === $decoded ) {
+			return new \WP_Error(
+				'atmosphere_cid_invalid_base32',
+				\__( 'CID body contains characters outside the base32 alphabet.', 'atmosphere' )
+			);
+		}
+
+		return $decoded;
 	}
 
 	/**
@@ -114,10 +137,11 @@ class CID {
 	 * requires exactly one key).
 	 *
 	 * @param mixed $value PHP value.
-	 * @return string DAG-CBOR encoded bytes.
-	 * @throws \InvalidArgumentException When the value type cannot be encoded.
+	 * @return string|\WP_Error DAG-CBOR encoded bytes, or an
+	 *                          `atmosphere_cid_*` error for an
+	 *                          unsupported value type / shape.
 	 */
-	public static function encode( $value ): string {
+	public static function encode( $value ): string|\WP_Error {
 		if ( null === $value ) {
 			return "\xf6";
 		}
@@ -162,8 +186,13 @@ class CID {
 			return self::encode_float( $value );
 		}
 
-		throw new \InvalidArgumentException(
-			\sprintf( 'DAG-CBOR encoder cannot handle value of type %s.', \esc_html( \gettype( $value ) ) ) // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		return new \WP_Error(
+			'atmosphere_cid_unsupported_type',
+			\sprintf(
+				/* translators: %s: PHP type name (e.g. "object", "resource"). */
+				\__( 'DAG-CBOR encoder cannot handle value of type %s.', 'atmosphere' ),
+				\gettype( $value )
+			)
 		);
 	}
 
@@ -178,16 +207,11 @@ class CID {
 	 * handles values up to PHP_INT_MAX via `pack('J', ...)`.
 	 *
 	 * @param int $major_type CBOR major type (0..7).
-	 * @param int $argument   Length / value to encode.
+	 * @param int $argument   Length / value to encode (must be non-negative).
 	 * @return string CBOR header bytes.
-	 * @throws \InvalidArgumentException When the argument is negative.
 	 */
 	private static function encode_argument( int $major_type, int $argument ): string {
 		$prefix = $major_type << 5;
-
-		if ( $argument < 0 ) {
-			throw new \InvalidArgumentException( 'CBOR argument must be non-negative.' );
-		}
 
 		if ( $argument < 24 ) {
 			return \chr( $prefix | $argument );
@@ -249,14 +273,22 @@ class CID {
 	/**
 	 * Encode a list-shaped array (major type 4).
 	 *
+	 * Propagates the first `WP_Error` from a nested `encode()` call so
+	 * an unsupported value buried deep inside a record short-circuits
+	 * the whole encode without producing partial bytes.
+	 *
 	 * @param array $value List to encode.
-	 * @return string CBOR bytes.
+	 * @return string|\WP_Error CBOR bytes or the propagated error.
 	 */
-	private static function encode_array( array $value ): string {
+	private static function encode_array( array $value ): string|\WP_Error {
 		$bytes = self::encode_argument( 4, \count( $value ) );
 
 		foreach ( $value as $item ) {
-			$bytes .= self::encode( $item );
+			$encoded = self::encode( $item );
+			if ( \is_wp_error( $encoded ) ) {
+				return $encoded;
+			}
+			$bytes .= $encoded;
 		}
 
 		return $bytes;
@@ -271,9 +303,10 @@ class CID {
 	 * PDS depends on it.
 	 *
 	 * @param array $value Map to encode.
-	 * @return string CBOR bytes.
+	 * @return string|\WP_Error CBOR bytes or the propagated error from
+	 *                          a nested `encode()` call.
 	 */
-	private static function encode_map( array $value ): string {
+	private static function encode_map( array $value ): string|\WP_Error {
 		$keys = \array_map( 'strval', \array_keys( $value ) );
 
 		\usort(
@@ -289,8 +322,12 @@ class CID {
 
 		$bytes = self::encode_argument( 5, \count( $keys ) );
 		foreach ( $keys as $key ) {
-			$bytes .= self::encode_text_string( $key );
-			$bytes .= self::encode( $value[ $key ] );
+			$bytes  .= self::encode_text_string( $key );
+			$encoded = self::encode( $value[ $key ] );
+			if ( \is_wp_error( $encoded ) ) {
+				return $encoded;
+			}
+			$bytes .= $encoded;
 		}
 
 		return $bytes;
@@ -304,12 +341,16 @@ class CID {
 	 * float16 / float32 representations.
 	 *
 	 * @param float $value Float to encode.
-	 * @return string CBOR bytes.
-	 * @throws \InvalidArgumentException When the value is NaN or infinite.
+	 * @return string|\WP_Error CBOR bytes, or
+	 *                          `atmosphere_cid_invalid_float` for NaN /
+	 *                          ±Infinity.
 	 */
-	private static function encode_float( float $value ): string {
+	private static function encode_float( float $value ): string|\WP_Error {
 		if ( \is_nan( $value ) || \is_infinite( $value ) ) {
-			throw new \InvalidArgumentException( 'DAG-CBOR does not permit NaN or Infinity.' );
+			return new \WP_Error(
+				'atmosphere_cid_invalid_float',
+				\__( 'DAG-CBOR does not permit NaN or Infinity.', 'atmosphere' )
+			);
 		}
 
 		// 'E' = IEEE 754 double precision, big-endian (PHP 7.0.15+ / 7.1.1+).
@@ -325,10 +366,14 @@ class CID {
 	 * would not round-trip through atproto's own decoders.
 	 *
 	 * @param string $cid_string CID string (with multibase prefix `b`).
-	 * @return string CBOR bytes.
+	 * @return string|\WP_Error CBOR bytes, or the propagated decode error.
 	 */
-	private static function encode_cid_link( string $cid_string ): string {
+	private static function encode_cid_link( string $cid_string ): string|\WP_Error {
 		$cid_bytes = self::decode_string( $cid_string );
+
+		if ( \is_wp_error( $cid_bytes ) ) {
+			return $cid_bytes;
+		}
 
 		// 0xd8 0x2a = CBOR tag 42 with a 1-byte argument.
 		return "\xd8\x2a" . self::encode_byte_string( "\x00" . $cid_bytes );
@@ -367,11 +412,17 @@ class CID {
 	/**
 	 * Base32 RFC 4648 lowercase decode (no padding).
 	 *
+	 * Mirrors the `string|false` shape of the OAuth crypto / encoder
+	 * helpers ({@see \Atmosphere\OAuth\DPoP::base64url_decode()},
+	 * {@see \Atmosphere\OAuth\Encryption::decrypt()}) so callers
+	 * branch on `false === $decoded` rather than on a thrown
+	 * exception.
+	 *
 	 * @param string $value Base32 string.
-	 * @return string Raw bytes.
-	 * @throws \InvalidArgumentException When the input contains characters outside the base32 alphabet.
+	 * @return string|false Raw bytes, or false on a character outside
+	 *                      the base32 alphabet.
 	 */
-	private static function base32_lower_decode( string $value ): string {
+	private static function base32_lower_decode( string $value ): string|false {
 		static $lookup = null;
 		if ( null === $lookup ) {
 			$lookup = \array_flip( \str_split( 'abcdefghijklmnopqrstuvwxyz234567' ) );
@@ -385,7 +436,7 @@ class CID {
 		for ( $i = 0; $i < $length; $i++ ) {
 			$char = $value[ $i ];
 			if ( ! isset( $lookup[ $char ] ) ) {
-				throw new \InvalidArgumentException( 'Invalid base32 character: ' . \esc_html( $char ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+				return false;
 			}
 			$buffer = ( $buffer << 5 ) | $lookup[ $char ];
 			$bits  += 5;

--- a/includes/class-publisher.php
+++ b/includes/class-publisher.php
@@ -136,12 +136,35 @@ class Publisher {
 		 */
 		if ( ! $bsky_transformer->is_short_form_post() ) {
 			$doc_record = $doc_transformer->transform();
-			$bsky_transformer->set_document_strong_ref(
-				array(
-					'uri' => build_at_uri( get_did(), 'site.standard.document', $doc_transformer->get_rkey() ),
-					'cid' => CID::from_record( $doc_record ),
-				)
-			);
+			$doc_cid    = CID::from_record( $doc_record );
+
+			if ( ! \is_wp_error( $doc_cid ) ) {
+				$bsky_transformer->set_document_strong_ref(
+					array(
+						'uri' => build_at_uri( get_did(), 'site.standard.document', $doc_transformer->get_rkey() ),
+						'cid' => $doc_cid,
+					)
+				);
+			} else {
+				/*
+				 * Encoder hit a record shape it could not handle.
+				 * Surfacing the post error here would abort an
+				 * otherwise-fine publish; instead, log a breadcrumb
+				 * and let the publish proceed with publication-ref-only
+				 * (or no associatedRefs at all). The post still
+				 * reaches Bluesky — just without the AppView's rich
+				 * `source` / `associatedProfiles` enrichment for this
+				 * one record.
+				 */
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				\error_log(
+					\sprintf(
+						'[atmosphere] post %d: document CID precompute failed (%s) — publishing without document associatedRef',
+						$post->ID,
+						$doc_cid->get_error_code()
+					)
+				);
+			}
 		}
 
 		if ( $bsky_transformer->is_short_form_post() ) {

--- a/includes/class-publisher.php
+++ b/includes/class-publisher.php
@@ -108,6 +108,42 @@ class Publisher {
 		$bsky_transformer = new Post( $post );
 		$doc_transformer  = new Document( $post );
 
+		/*
+		 * Pre-compute the document's CID locally and inject the
+		 * resulting strongRef into the post transformer BEFORE the
+		 * post record is built. The document and post are written
+		 * atomically in a single applyWrites batch, so without
+		 * client-side CID computation the post's
+		 * `embed.external.associatedRefs` cannot carry the document
+		 * ref at initial-create time — and Bluesky's AppView only
+		 * resolves `source` / `associatedProfiles` / document
+		 * `readingTime` enrichment from the initial-create payload
+		 * (subsequent `applyWrites#update` to add the ref doesn't
+		 * trigger re-indexing).
+		 *
+		 * Computed inside the same `publish_post()` invocation so the
+		 * document record we encode here is byte-identical to what
+		 * `publish_single()` / `publish_thread()` ultimately writes:
+		 * `Document::transform()` reads `Post::META_URI / META_CID`
+		 * to compose its `bskyPostRef`, and on a fresh publish both
+		 * are empty, so the bskyPostRef is omitted both here and at
+		 * write time. The CID matches.
+		 *
+		 * Short-form posts use `app.bsky.embed.images` rather than
+		 * `app.bsky.embed.external`, so the document strongRef has no
+		 * place to land. Skip the precompute on that path — it would
+		 * just be wasted work.
+		 */
+		if ( ! $bsky_transformer->is_short_form_post() ) {
+			$doc_record = $doc_transformer->transform();
+			$bsky_transformer->set_document_strong_ref(
+				array(
+					'uri' => build_at_uri( get_did(), 'site.standard.document', $doc_transformer->get_rkey() ),
+					'cid' => CID::from_record( $doc_record ),
+				)
+			);
+		}
+
 		if ( $bsky_transformer->is_short_form_post() ) {
 			// Short-form path: single record via today's transform().
 			$result = self::publish_single(
@@ -1346,7 +1382,7 @@ class Publisher {
 		 * reconnects, so the record always lands at the same address
 		 * for the active owner.
 		 */
-		return API::post(
+		$result = API::post(
 			'/xrpc/com.atproto.repo.putRecord',
 			array(
 				'repo'       => $did,
@@ -1355,6 +1391,19 @@ class Publisher {
 				'record'     => $pub->transform(),
 			)
 		);
+
+		/*
+		 * Capture the publication's CID from the PDS response so post
+		 * publishes can build the publication strongRef without an
+		 * extra `getRecord` round-trip. Overwritten on every
+		 * successful sync because the CID changes whenever the
+		 * publication's content changes.
+		 */
+		if ( ! \is_wp_error( $result ) && ! empty( $result['cid'] ) ) {
+			\update_option( Publication::OPTION_CID, (string) $result['cid'], false );
+		}
+
+		return $result;
 	}
 
 	/**

--- a/includes/class-publisher.php
+++ b/includes/class-publisher.php
@@ -121,19 +121,23 @@ class Publisher {
 		 * (subsequent `applyWrites#update` to add the ref doesn't
 		 * trigger re-indexing).
 		 *
-		 * Computed inside the same `publish_post()` invocation so the
-		 * document record we encode here is byte-identical to what
-		 * `publish_single()` / `publish_thread()` ultimately writes:
-		 * `Document::transform()` reads `Post::META_URI / META_CID`
-		 * to compose its `bskyPostRef`, and on a fresh publish both
-		 * are empty, so the bskyPostRef is omitted both here and at
-		 * write time. The CID matches.
+		 * The transform result is captured into `$doc_record` once
+		 * and threaded through to `publish_single()` /
+		 * `publish_thread()` so the document is transformed exactly
+		 * once per publish. Without that reuse, the CID computed here
+		 * and the record actually written by the publish call would
+		 * diverge whenever `atmosphere_transform_document` is
+		 * non-deterministic (timestamps, UUIDs, retried blob uploads),
+		 * and the document strongRef in `associatedRefs` would point
+		 * at a CID that no record at that URI matches.
 		 *
 		 * Short-form posts use `app.bsky.embed.images` rather than
 		 * `app.bsky.embed.external`, so the document strongRef has no
-		 * place to land. Skip the precompute on that path — it would
-		 * just be wasted work.
+		 * place to land. Skip the precompute on that path — the
+		 * downstream call falls back to a single transform itself
+		 * when `$doc_record` is null.
 		 */
+		$doc_record = null;
 		if ( ! $bsky_transformer->is_short_form_post() ) {
 			$doc_record = $doc_transformer->transform();
 			$doc_cid    = CID::from_record( $doc_record );
@@ -173,15 +177,16 @@ class Publisher {
 				$post,
 				$bsky_transformer->transform(),
 				$bsky_transformer,
-				$doc_transformer
+				$doc_transformer,
+				$doc_record
 			);
 		} else {
 			$records = $bsky_transformer->build_long_form_records();
 
 			if ( 1 === \count( $records ) ) {
-				$result = self::publish_single( $post, $records[0], $bsky_transformer, $doc_transformer );
+				$result = self::publish_single( $post, $records[0], $bsky_transformer, $doc_transformer, $doc_record );
 			} else {
-				$result = self::publish_thread( $post, $records, $bsky_transformer, $doc_transformer );
+				$result = self::publish_thread( $post, $records, $bsky_transformer, $doc_transformer, $doc_record );
 			}
 		}
 
@@ -276,20 +281,39 @@ class Publisher {
 	 * here when a record arrives without `createdAt` (for example, if a
 	 * filter stripped it).
 	 *
-	 * @param \WP_Post $post             WordPress post.
-	 * @param array    $bsky_record      Pre-composed bsky post record.
-	 * @param Post     $bsky_transformer Bsky transformer instance.
-	 * @param Document $doc_transformer  Document transformer instance.
+	 * @param \WP_Post   $post             WordPress post.
+	 * @param array      $bsky_record      Pre-composed bsky post record.
+	 * @param Post       $bsky_transformer Bsky transformer instance.
+	 * @param Document   $doc_transformer  Document transformer instance.
+	 * @param array|null $doc_record       Pre-computed document record from
+	 *                                     `publish_post()`. Reused as the write
+	 *                                     payload so the document is transformed
+	 *                                     exactly once per publish — same array
+	 *                                     the long-form CID precompute was
+	 *                                     derived from, guaranteeing the
+	 *                                     embedded document strongRef points at
+	 *                                     a CID that actually matches the
+	 *                                     record being written even when
+	 *                                     `atmosphere_transform_document` is
+	 *                                     non-deterministic. Null on the
+	 *                                     short-form path (no associatedRefs,
+	 *                                     no precompute) — falls back to a
+	 *                                     single transform here.
 	 * @return array|\WP_Error
 	 */
 	private static function publish_single(
 		\WP_Post $post,
 		array $bsky_record,
 		Post $bsky_transformer,
-		Document $doc_transformer
+		Document $doc_transformer,
+		?array $doc_record = null
 	): array|\WP_Error {
 		if ( empty( $bsky_record['createdAt'] ) ) {
 			$bsky_record['createdAt'] = to_iso8601( $post->post_date_gmt );
+		}
+
+		if ( null === $doc_record ) {
+			$doc_record = $doc_transformer->transform();
 		}
 
 		$writes = array(
@@ -303,7 +327,7 @@ class Publisher {
 				'$type'      => 'com.atproto.repo.applyWrites#create',
 				'collection' => 'site.standard.document',
 				'rkey'       => $doc_transformer->get_rkey(),
-				'value'      => $doc_transformer->transform(),
+				'value'      => $doc_record,
 			),
 		);
 
@@ -348,23 +372,34 @@ class Publisher {
 	 * WP_Error is returned. If rollback also fails, the return wraps
 	 * both errors and includes the partial thread state.
 	 *
-	 * @param \WP_Post $post             WordPress post.
-	 * @param array[]  $records          Records from build_long_form_records().
-	 * @param Post     $bsky_transformer Bsky transformer instance.
-	 * @param Document $doc_transformer  Document transformer instance.
+	 * @param \WP_Post   $post             WordPress post.
+	 * @param array[]    $records          Records from build_long_form_records().
+	 * @param Post       $bsky_transformer Bsky transformer instance.
+	 * @param Document   $doc_transformer  Document transformer instance.
+	 * @param array|null $doc_record       Pre-computed document record from
+	 *                                     `publish_post()`. See
+	 *                                     {@see self::publish_single()} for
+	 *                                     why the document must be
+	 *                                     transformed exactly once per
+	 *                                     publish.
 	 * @return array|\WP_Error
 	 */
 	private static function publish_thread(
 		\WP_Post $post,
 		array $records,
 		Post $bsky_transformer,
-		Document $doc_transformer
+		Document $doc_transformer,
+		?array $doc_record = null
 	): array|\WP_Error {
 		$root_record = $records[0];
 		if ( empty( $root_record['createdAt'] ) ) {
 			$root_record['createdAt'] = to_iso8601( $post->post_date_gmt );
 		}
 		$root_rkey = $bsky_transformer->get_rkey();
+
+		if ( null === $doc_record ) {
+			$doc_record = $doc_transformer->transform();
+		}
 
 		$root_result = API::apply_writes(
 			array(
@@ -378,7 +413,7 @@ class Publisher {
 					'$type'      => 'com.atproto.repo.applyWrites#create',
 					'collection' => 'site.standard.document',
 					'rkey'       => $doc_transformer->get_rkey(),
-					'value'      => $doc_transformer->transform(),
+					'value'      => $doc_record,
 				),
 			)
 		);

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -121,6 +121,56 @@ class Post extends Base {
 	public const META_DOC_REF_PENDING = '_atmosphere_doc_ref_pending';
 
 	/**
+	 * Document strongRef the Publisher pre-computed for the initial
+	 * atomic `applyWrites#create`.
+	 *
+	 * AT Protocol's chicken-and-egg: a strongRef needs the target's
+	 * CID, and the document's CID only exists after a write. The
+	 * Publisher closes the gap by computing the document's CID
+	 * locally via the DAG-CBOR encoder ({@see \Atmosphere\CID}) and
+	 * pushing the resulting `{uri, cid}` here before any
+	 * `transform()` / `build_long_form_records()` call. The embed
+	 * builder picks the ref up and includes it in the post's
+	 * `embed.external.associatedRefs` array on the very first
+	 * applyWrites — which is what Bluesky's AppView indexes
+	 * (subsequent `applyWrites#update` follow-ups are ignored for
+	 * `source` / `associatedProfiles` enrichment).
+	 *
+	 * Null on a fresh transformer; reset whenever a fresh Post object
+	 * is constructed. Subsequent publishes of the same post
+	 * (`update_post()` flow) do not inject — by then
+	 * `Document::META_URI` / `Document::META_CID` are populated and
+	 * {@see self::build_embed()} reads the ref from meta instead.
+	 *
+	 * @var array{$type: string, uri: string, cid: string}|null
+	 */
+	private ?array $document_strong_ref = null;
+
+	/**
+	 * Inject the document strongRef the embed builder should advertise
+	 * in `associatedRefs` on the initial publish.
+	 *
+	 * See {@see self::$document_strong_ref} for the why. Passing an
+	 * empty array or a malformed shape (missing `uri` / `cid`) clears
+	 * the injection and the embed builder falls back to reading from
+	 * `Document::META_*`.
+	 *
+	 * @param array $ref StrongRef to advertise (keys: optional `$type`, required `uri` and `cid`).
+	 */
+	public function set_document_strong_ref( array $ref ): void {
+		if ( empty( $ref['uri'] ) || empty( $ref['cid'] ) ) {
+			$this->document_strong_ref = null;
+			return;
+		}
+
+		$this->document_strong_ref = array(
+			'$type' => 'com.atproto.repo.strongRef',
+			'uri'   => (string) $ref['uri'],
+			'cid'   => (string) $ref['cid'],
+		);
+	}
+
+	/**
 	 * Transform the post.
 	 *
 	 * @return array app.bsky.feed.post record.
@@ -520,6 +570,59 @@ class Post extends Base {
 			if ( $blob ) {
 				$external['thumb'] = $blob;
 			}
+		}
+
+		/*
+		 * Build the `associatedRefs` array. Order: publication first,
+		 * document second — matches what Bluesky's manual-share UI
+		 * emits and keeps the test fixtures stable. Lexicon does not
+		 * mandate ordering, but pinning a deterministic order avoids
+		 * spurious CID drift on no-op republishes.
+		 *
+		 * Publication ref comes from a stored site-wide option, set
+		 * by `Publisher::sync_publication()` once the publication
+		 * record has been written.
+		 *
+		 * Document ref has two sources:
+		 *   - On the *initial* publish, the Publisher precomputes the
+		 *     document's CID locally via DAG-CBOR and injects via
+		 *     `set_document_strong_ref()`. Without this, the document
+		 *     ref could only be added after the atomic write returned
+		 *     — and Bluesky's AppView ignores subsequent
+		 *     `applyWrites#update` for the purposes of indexing
+		 *     `source` / `associatedProfiles` enrichment.
+		 *   - On an *update* publish, the injection is absent but
+		 *     `Document::META_*` are already populated by the
+		 *     previous publish's `store_document_meta()`, so reading
+		 *     from meta produces an equivalent ref.
+		 *
+		 * The injection wins if both sources are present — it
+		 * reflects what the Publisher is *about* to write, the meta
+		 * reflects the previous write.
+		 */
+		$associated_refs = array();
+
+		$publication_ref = Publication::get_strong_ref();
+		if ( null !== $publication_ref ) {
+			$associated_refs[] = $publication_ref;
+		}
+
+		if ( null !== $this->document_strong_ref ) {
+			$associated_refs[] = $this->document_strong_ref;
+		} else {
+			$doc_uri = (string) \get_post_meta( $this->object->ID, Document::META_URI, true );
+			$doc_cid = (string) \get_post_meta( $this->object->ID, Document::META_CID, true );
+			if ( '' !== $doc_uri && '' !== $doc_cid ) {
+				$associated_refs[] = array(
+					'$type' => 'com.atproto.repo.strongRef',
+					'uri'   => $doc_uri,
+					'cid'   => $doc_cid,
+				);
+			}
+		}
+
+		if ( ! empty( $associated_refs ) ) {
+			$external['associatedRefs'] = $associated_refs;
 		}
 
 		return array(

--- a/includes/transformer/class-publication.php
+++ b/includes/transformer/class-publication.php
@@ -12,6 +12,8 @@ namespace Atmosphere\Transformer;
 
 \defined( 'ABSPATH' ) || exit;
 
+use function Atmosphere\build_at_uri;
+use function Atmosphere\get_did;
 use function Atmosphere\sanitize_text;
 
 /**
@@ -25,6 +27,22 @@ class Publication extends Base {
 	 * @var string
 	 */
 	public const OPTION_TID = 'atmosphere_publication_tid';
+
+	/**
+	 * Option key for the publication CID captured at the last successful
+	 * `sync_publication()` write.
+	 *
+	 * Stored so {@see self::get_strong_ref()} can build a strongRef
+	 * without a `getRecord` round-trip. The CID rotates whenever the
+	 * publication's content changes (site title, theme color, etc.)
+	 * and is re-captured on every successful putRecord. Both the TID
+	 * and CID survive disconnect for the same reason — they're the
+	 * stable site-level identifiers — and are only cleared on
+	 * uninstall.
+	 *
+	 * @var string
+	 */
+	public const OPTION_CID = 'atmosphere_publication_cid';
 
 	/**
 	 * Transform site settings into a publication record.
@@ -101,6 +119,42 @@ class Publication extends Base {
 		}
 
 		return $rkey;
+	}
+
+	/**
+	 * Build a {@link https://atproto.com/specs/lexicon com.atproto.repo.strongRef}
+	 * pointing at the connected site's publication record, or null
+	 * when the strongRef cannot be safely constructed.
+	 *
+	 * Both the TID and the CID are required: the URI half is derivable
+	 * from the connected DID + the stored TID, but the strongRef shape
+	 * also needs the content-hash from {@see self::OPTION_CID}, which
+	 * is only populated after a successful `sync_publication()` write.
+	 * A fresh-connect install that has not yet synced returns null
+	 * here and callers omit `associatedRefs` rather than ship a
+	 * malformed strongRef.
+	 *
+	 * @return array{$type: string, uri: string, cid: string}|null
+	 */
+	public static function get_strong_ref(): ?array {
+		$tid = (string) \get_option( self::OPTION_TID, '' );
+		$cid = (string) \get_option( self::OPTION_CID, '' );
+
+		if ( '' === $tid || '' === $cid ) {
+			return null;
+		}
+
+		$did = get_did();
+
+		if ( '' === $did ) {
+			return null;
+		}
+
+		return array(
+			'$type' => 'com.atproto.repo.strongRef',
+			'uri'   => build_at_uri( $did, 'site.standard.publication', $tid ),
+			'cid'   => $cid,
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-cid.php
+++ b/tests/phpunit/tests/class-test-cid.php
@@ -1,0 +1,311 @@
+<?php
+/**
+ * Tests for the CID + DAG-CBOR encoder used to pre-compute strongRef
+ * CIDs before atomic applyWrites.
+ *
+ * Encoder correctness is verified against three real records pulled
+ * from the live PDS (`jellybaby.us-east.host.bsky.network`) at
+ * commit time — see the test docblocks for the exact records and
+ * their PDS-returned CIDs. If the encoder ever drifts (key
+ * ordering, integer width, tag-42 cid-link shape), one of these
+ * three CIDs will stop matching and the bug surfaces in CI.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group cid
+ */
+
+namespace Atmosphere\Tests;
+
+use Atmosphere\CID;
+
+/**
+ * CID encoder tests.
+ */
+class Test_CID extends \WP_UnitTestCase {
+
+	/**
+	 * Real `site.standard.publication` record pulled from
+	 * `at://did:plc:yss2znu5ctxjotrmknbbrlqn/site.standard.publication/3mjjjxe3zbciv`.
+	 * PDS-returned CID: `bafyreieq64ytmsanutnt2zgob2nhuzmxgvqmjdecq3zh4hjli3khf6sf2m`.
+	 *
+	 * Exercises basic types: text strings (`$type`, `name`, `description`, `url`),
+	 * an associative array, key sorting (length-first then bytewise).
+	 */
+	public function test_cid_matches_pds_for_real_publication_record() {
+		$record = array(
+			'url'         => 'https://matthiaspfefferle.blog/',
+			'name'        => 'Matthias Pfefferle Atomic',
+			'$type'       => 'site.standard.publication',
+			'description' => 'a weblog mainly about the open, portable, interoperable, small, social, synaptic, semantic, structured, distributed, (re-)decentralized, independent, microformatted and federated social web',
+		);
+
+		$this->assertSame(
+			'bafyreieq64ytmsanutnt2zgob2nhuzmxgvqmjdecq3zh4hjli3khf6sf2m',
+			CID::from_record( $record )
+		);
+	}
+
+	/**
+	 * Real `site.standard.document` record pulled from
+	 * `at://did:plc:yss2znu5ctxjotrmknbbrlqn/site.standard.document/3mn7u77lu63ns`.
+	 * PDS-returned CID: `bafyreia67ux7yupdsfpd4ahnukdwii3cwmldyrficaomoskqzopde3ktiu`.
+	 *
+	 * Exercises the harder cases: a blob with a `$link` cid-link tag,
+	 * an embedded strongRef whose `cid` field is a plain string (per
+	 * the strongRef Lexicon, which declares `cid` as `format: cid`
+	 * but underlying type `string`), an array of tag strings, a long
+	 * UTF-8 textContent block, and unsorted input keys (the encoder
+	 * is responsible for the DAG-CBOR canonical ordering).
+	 */
+	public function test_cid_matches_pds_for_real_document_record() {
+		$record = array(
+			'path'        => '/2026/06/01/the-standard-lorem-ipsum-passage-used-since-1966/',
+			'site'        => 'at://did:plc:yss2znu5ctxjotrmknbbrlqn/site.standard.publication/3mjjjxe3zbciv',
+			'tags'        => array( 'Allgemein' ),
+			'$type'       => 'site.standard.document',
+			'title'       => 'The standard Lorem Ipsum passage, used since 1966',
+			'coverImage'  => array(
+				'ref'      => array(
+					'$link' => 'bafkreic6f5dn72vzsyp52l5rmi7r76gg46nyddzz4q6okagw4y6cmleuve',
+				),
+				'size'     => 82122,
+				'$type'    => 'blob',
+				'mimeType' => 'image/png',
+			),
+			'bskyPostRef' => array(
+				'cid' => 'bafyreid4dwo6mrkv5epa32pkuljwlpphcualw4lviotdm2prxotc5lnmza',
+				'uri' => 'at://did:plc:yss2znu5ctxjotrmknbbrlqn/app.bsky.feed.post/3mn7u77lp4dns',
+			),
+			'description' => '"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat...',
+			'publishedAt' => '2026-06-01T10:20:14.000Z',
+			'textContent' => "„Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\u{201C} Section 1.10.32 of „de Finibus Bonorum et Malorum\u{201C}, written by Cicero in 45 BC „Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?\u{201C} 1914 translation by H. Rackham „But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure. To take a trivial example, which of us ever undertakes laborious physical exercise, except to obtain some advantage from it? But who has any right to find fault with a man who chooses to enjoy a pleasure that has no annoying consequences, or one who avoids a pain that produces no resultant pleasure?\u{201C} Section 1.10.33 of „de Finibus Bonorum et Malorum\u{201C}, written by Cicero in 45 BC „At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat.\u{201C} 1914 translation by H. Rackham „On the other hand, we denounce with righteous indignation and dislike men who are so beguiled and demoralized by the charms of pleasure of the moment, so blinded by desire, that they cannot foresee the pain and trouble that are bound to ensue; and equal blame belongs to those who fail in their duty through weakness of will, which is the same as saying through shrinking from toil and pain. These cases are perfectly simple and easy to distinguish. In a free hour, when our power of choice is untrammelled and when nothing prevents our being able to do what we like best, every pleasure is to be welcomed and every pain avoided. But in certain circumstances and owing to the claims of duty or the obligations of business it will frequently occur that pleasures have to be repudiated and annoyances accepted. The wise man therefore always holds in these matters to this principle of selection: he rejects pleasures to secure other greater pleasures, or else he endures pains to avoid worse pains.\u{201C}",
+		);
+
+		$this->assertSame(
+			'bafyreia67ux7yupdsfpd4ahnukdwii3cwmldyrficaomoskqzopde3ktiu',
+			CID::from_record( $record )
+		);
+	}
+
+	/**
+	 * Real `app.bsky.feed.post` record pulled from
+	 * `at://did:plc:yss2znu5ctxjotrmknbbrlqn/app.bsky.feed.post/3mn7u77lp4dns`.
+	 * PDS-returned CID: `bafyreid4dwo6mrkv5epa32pkuljwlpphcualw4lviotdm2prxotc5lnmza`.
+	 *
+	 * The keystone test for the production target: a real bsky post
+	 * with TWO strongRefs in `embed.external.associatedRefs`, a blob
+	 * thumbnail, facets with nested index objects, a langs array.
+	 * If the round-trip survives THIS record, the encoder is
+	 * production-ready for every Atmosphere-published post.
+	 */
+	public function test_cid_matches_pds_for_real_bsky_post_record() {
+		$record = array(
+			'tags'      => array( 'Allgemein' ),
+			'text'      => "The standard Lorem Ipsum passage, used since 1966\n\n\"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,...\n\nhttps://matthiaspfefferle.blog/2026/06/01/the-standard-lorem-ipsum-passage-used-since-1966/",
+			'$type'     => 'app.bsky.feed.post',
+			'embed'     => array(
+				'$type'    => 'app.bsky.embed.external',
+				'external' => array(
+					'uri'            => 'https://matthiaspfefferle.blog/2026/06/01/the-standard-lorem-ipsum-passage-used-since-1966/',
+					'thumb'          => array(
+						'ref'      => array(
+							'$link' => 'bafkreic6f5dn72vzsyp52l5rmi7r76gg46nyddzz4q6okagw4y6cmleuve',
+						),
+						'size'     => 82122,
+						'$type'    => 'blob',
+						'mimeType' => 'image/png',
+					),
+					'title'          => 'The standard Lorem Ipsum passage, used since 1966',
+					'description'    => '"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat...',
+					'associatedRefs' => array(
+						array(
+							'cid'   => 'bafyreieq64ytmsanutnt2zgob2nhuzmxgvqmjdecq3zh4hjli3khf6sf2m',
+							'uri'   => 'at://did:plc:yss2znu5ctxjotrmknbbrlqn/site.standard.publication/3mjjjxe3zbciv',
+							'$type' => 'com.atproto.repo.strongRef',
+						),
+						array(
+							'cid'   => 'bafyreiaxrmx5y3idjgtrr3g3awogwyojnyplbbljp4jncmnp6zrjdn73ra',
+							'uri'   => 'at://did:plc:yss2znu5ctxjotrmknbbrlqn/site.standard.document/3mn7u77lu63ns',
+							'$type' => 'com.atproto.repo.strongRef',
+						),
+					),
+				),
+			),
+			'langs'     => array( 'de' ),
+			'facets'    => array(
+				array(
+					'index'    => array(
+						'byteEnd'   => 296,
+						'byteStart' => 205,
+					),
+					'features' => array(
+						array(
+							'uri'   => 'https://matthiaspfefferle.blog/2026/06/01/the-standard-lorem-ipsum-passage-used-since-1966/',
+							'$type' => 'app.bsky.richtext.facet#link',
+						),
+					),
+				),
+			),
+			'createdAt' => '2026-06-01T10:20:14.000Z',
+		);
+
+		$this->assertSame(
+			'bafyreid4dwo6mrkv5epa32pkuljwlpphcualw4lviotdm2prxotc5lnmza',
+			CID::from_record( $record )
+		);
+	}
+
+	/**
+	 * Pin the CBOR byte-level encoding for the four trivial primitives
+	 * so a refactor of the major-type / argument helpers gets caught
+	 * by an exact-match assertion rather than a CID hash that could
+	 * coincidentally collide.
+	 */
+	public function test_encode_primitives() {
+		$this->assertSame( "\xf6", CID::encode( null ) );
+		$this->assertSame( "\xf5", CID::encode( true ) );
+		$this->assertSame( "\xf4", CID::encode( false ) );
+
+		// Small positive int 42: major type 0, 1-byte argument.
+		$this->assertSame( "\x18\x2a", CID::encode( 42 ) );
+
+		// Negative int -1: major type 1, argument 0 (== -1 - 0).
+		$this->assertSame( "\x20", CID::encode( -1 ) );
+
+		// Text string "hello": major type 3 length 5 + UTF-8 bytes.
+		$this->assertSame( "\x65hello", CID::encode( 'hello' ) );
+
+		// Three-element list: major type 4 length 3 + items.
+		$this->assertSame( "\x83\x01\x02\x03", CID::encode( array( 1, 2, 3 ) ) );
+	}
+
+	/**
+	 * Map keys must be sorted length-first then bytewise per DAG-CBOR
+	 * canonical encoding. Builds a 3-key map deliberately in the
+	 * wrong order and asserts the encoded byte stream lists them in
+	 * the canonical order ("z" < "aa" < "ab", because length sorts
+	 * first then bytewise within a length tier).
+	 */
+	public function test_map_keys_are_sorted_length_first_then_bytewise() {
+		$encoded = CID::encode(
+			array(
+				'ab' => 2,
+				'z'  => 1,
+				'aa' => 3,
+			)
+		);
+
+		/*
+		 * Expected byte sequence:
+		 *   a3              map of 3 entries
+		 *   61 7a 01        text "z" -> 1
+		 *   62 61 61 03     text "aa" -> 3
+		 *   62 61 62 02     text "ab" -> 2
+		 */
+		$this->assertSame(
+			"\xa3\x61\x7a\x01\x62\x61\x61\x03\x62\x61\x62\x02",
+			$encoded
+		);
+	}
+
+	/**
+	 * `{ "$link": "bafy..." }` JSON form must encode as CBOR tag 42
+	 * containing a byte string of `0x00 || cid_v1_bytes`, not as a
+	 * plain one-key map. Round-trip identity with the PDS depends on
+	 * this special case.
+	 */
+	public function test_cid_link_encodes_as_tag_42() {
+		$encoded = CID::encode(
+			array( '$link' => 'bafkreic6f5dn72vzsyp52l5rmi7r76gg46nyddzz4q6okagw4y6cmleuve' )
+		);
+
+		/*
+		 * Expected byte layout:
+		 *   d8 2a    tag 42 with 1-byte argument
+		 *   58 25    byte string with 1-byte length = 37
+		 *   00       multibase identity prefix
+		 *   ...      36 bytes of decoded CIDv1
+		 *
+		 * Total: 4-byte prefix + 37-byte payload = 41 bytes.
+		 */
+		$this->assertSame( "\xd8\x2a", \substr( $encoded, 0, 2 ) );
+		$this->assertSame( 41, \strlen( $encoded ) );
+		$this->assertSame( "\x00", $encoded[4] );
+	}
+
+	/**
+	 * Sibling keys alongside `$link` keep the value as a plain map —
+	 * the cid-link detection requires `$link` to be the SOLE key, so
+	 * a legitimate Atmosphere record using `$link` as one of several
+	 * keys (unlikely but legal) does not get misencoded.
+	 */
+	public function test_link_with_sibling_keys_is_plain_map() {
+		$encoded = CID::encode(
+			array(
+				'$link' => 'bafy...',
+				'extra' => 1,
+			)
+		);
+
+		/*
+		 * Must NOT start with tag 42 (0xd8 0x2a). Should be a 2-entry
+		 * map (0xa2) with keys sorted: $link (5 chars), extra (5 chars
+		 * — tied length, bytewise: '$' < 'e', so $link first).
+		 */
+		$this->assertSame( "\xa2", $encoded[0] );
+	}
+
+	/**
+	 * Negative integers use major type 1 with `-1 - value` argument
+	 * encoding, smallest form. -100 -> argument 99 -> 1-byte (0x18 0x63).
+	 */
+	public function test_encode_negative_int_uses_shortest_form() {
+		/*
+		 * -100: major type 1 (0x20), argument 99 (one-byte form 0x18 0x63).
+		 * Combined header byte: (1 << 5) | 0x18 = 0x38.
+		 */
+		$this->assertSame( "\x38\x63", CID::encode( -100 ) );
+	}
+
+	/**
+	 * NaN / infinite floats are forbidden by DAG-CBOR. The encoder
+	 * throws rather than silently producing a record the PDS will
+	 * reject.
+	 */
+	public function test_encode_rejects_nan_and_infinity() {
+		$this->expectException( \InvalidArgumentException::class );
+		CID::encode( NAN );
+	}
+
+	/**
+	 * Decoding a CID string and re-encoding the bytes round-trips
+	 * back to the same base32 string. Locks the base32 alphabet and
+	 * the multibase prefix handling.
+	 */
+	public function test_decode_string_round_trips() {
+		$cid_string = 'bafyreieq64ytmsanutnt2zgob2nhuzmxgvqmjdecq3zh4hjli3khf6sf2m';
+		$bytes      = CID::decode_string( $cid_string );
+
+		/*
+		 * CIDv1 dag-cbor sha256: version byte 0x01, codec byte 0x71,
+		 * multihash code 0x12, multihash length 0x20, then 32 bytes.
+		 */
+		$this->assertSame( 36, \strlen( $bytes ) );
+		$this->assertSame( "\x01", $bytes[0] );
+		$this->assertSame( "\x71", $bytes[1] );
+		$this->assertSame( "\x12", $bytes[2] );
+		$this->assertSame( "\x20", $bytes[3] );
+	}
+
+	/**
+	 * CID strings without the `b` multibase prefix are rejected —
+	 * Atmosphere only ever sees base32-lowercase CIDs from atproto,
+	 * so other multibases (base58btc on the legacy CIDv0, etc.) are
+	 * out of scope and would silently misencode if let through.
+	 */
+	public function test_decode_string_rejects_missing_multibase_prefix() {
+		$this->expectException( \InvalidArgumentException::class );
+		CID::decode_string( 'afyreieq64ytmsanutnt2zgob2nhuzmxgvqmjdecq3zh4hjli3khf6sf2m' );
+	}
+}

--- a/tests/phpunit/tests/class-test-cid.php
+++ b/tests/phpunit/tests/class-test-cid.php
@@ -270,12 +270,46 @@ class Test_CID extends \WP_UnitTestCase {
 
 	/**
 	 * NaN / infinite floats are forbidden by DAG-CBOR. The encoder
-	 * throws rather than silently producing a record the PDS will
-	 * reject.
+	 * returns a `WP_Error` rather than silently producing a record
+	 * the PDS will reject, matching the `string|WP_Error` shape used
+	 * across the rest of the OAuth crypto / encoder helpers.
 	 */
 	public function test_encode_rejects_nan_and_infinity() {
-		$this->expectException( \InvalidArgumentException::class );
-		CID::encode( NAN );
+		$result = CID::encode( NAN );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'atmosphere_cid_invalid_float', $result->get_error_code() );
+	}
+
+	/**
+	 * An unsupported PHP type (object, resource) surfaces as a
+	 * `WP_Error` rather than silently encoding to nothing or throwing.
+	 * The encoder's contract is `string|WP_Error`; any caller relying
+	 * on the type-safety can branch on `is_wp_error()`.
+	 */
+	public function test_encode_rejects_unsupported_type() {
+		$result = CID::encode( new \stdClass() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'atmosphere_cid_unsupported_type', $result->get_error_code() );
+	}
+
+	/**
+	 * An unsupported value buried inside a map propagates up through
+	 * the recursive `encode_map()` / `encode_array()` callers — the
+	 * encoder short-circuits on the first failure rather than
+	 * producing partial bytes that would silently corrupt the CID.
+	 */
+	public function test_encode_propagates_nested_error_through_map() {
+		$result = CID::encode(
+			array(
+				'ok'  => 'fine',
+				'bad' => new \stdClass(),
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'atmosphere_cid_unsupported_type', $result->get_error_code() );
 	}
 
 	/**
@@ -305,7 +339,34 @@ class Test_CID extends \WP_UnitTestCase {
 	 * out of scope and would silently misencode if let through.
 	 */
 	public function test_decode_string_rejects_missing_multibase_prefix() {
-		$this->expectException( \InvalidArgumentException::class );
-		CID::decode_string( 'afyreieq64ytmsanutnt2zgob2nhuzmxgvqmjdecq3zh4hjli3khf6sf2m' );
+		$result = CID::decode_string( 'afyreieq64ytmsanutnt2zgob2nhuzmxgvqmjdecq3zh4hjli3khf6sf2m' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'atmosphere_cid_invalid_multibase', $result->get_error_code() );
+	}
+
+	/**
+	 * Base32 input that contains characters outside the alphabet
+	 * surfaces as `atmosphere_cid_invalid_base32`, not as a silent
+	 * truncated decode.
+	 */
+	public function test_decode_string_rejects_invalid_base32_characters() {
+		// '!' is not in the lowercase base32 alphabet (`a-z 2-7`).
+		$result = CID::decode_string( 'bafy!!!' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'atmosphere_cid_invalid_base32', $result->get_error_code() );
+	}
+
+	/**
+	 * `from_record()` propagates the underlying encode error so the
+	 * Publisher can branch on `is_wp_error()` without having to
+	 * differentiate "encode failed" from "CID build failed."
+	 */
+	public function test_from_record_propagates_encode_error() {
+		$result = CID::from_record( array( 'bad' => new \stdClass() ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'atmosphere_cid_unsupported_type', $result->get_error_code() );
 	}
 }

--- a/tests/phpunit/tests/transformer/class-test-post.php
+++ b/tests/phpunit/tests/transformer/class-test-post.php
@@ -10,7 +10,9 @@
 namespace Atmosphere\Tests\Transformer;
 
 use WP_UnitTestCase;
+use Atmosphere\Transformer\Document;
 use Atmosphere\Transformer\Post;
+use Atmosphere\Transformer\Publication;
 
 /**
  * Post transformer tests.
@@ -2712,5 +2714,167 @@ class Test_Post extends WP_UnitTestCase {
 			$record,
 			'Image past the 16-level depth cap must not surface in the embed.'
 		);
+	}
+
+	/*
+	 * -----------------------------------------------------------------
+	 * Link-card embed — associatedRefs for the standard.site strongRefs.
+	 * -----------------------------------------------------------------
+	 */
+
+	/**
+	 * `set_document_strong_ref()` plus a captured publication strongRef
+	 * land both entries in `embed.external.associatedRefs` on a fresh
+	 * transform. Order: publication first, document second.
+	 *
+	 * This is the production-target shape — the initial atomic
+	 * applyWrites must carry both refs so Bluesky's AppView indexes
+	 * the post with `source` / `associatedProfiles` enrichment from
+	 * the start.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_long_form_embed_carries_both_strong_refs_when_injected() {
+		\update_option( 'atmosphere_identity', array( 'did' => 'did:plc:test123' ), false );
+		\update_option( Publication::OPTION_TID, '3kpub00000000', false );
+		\update_option( Publication::OPTION_CID, 'bafyreipublication0000000000000000000000000000000000000000000', false );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'A Titled Post',
+				'post_content' => 'Long-form blog body.',
+			)
+		);
+
+		$transformer = new Post( $post );
+		$transformer->set_document_strong_ref(
+			array(
+				'uri' => 'at://did:plc:test123/site.standard.document/3kdoc00000000',
+				'cid' => 'bafyreidoc000000000000000000000000000000000000000000000000000',
+			)
+		);
+
+		$record = $transformer->transform();
+
+		$refs = $record['embed']['external']['associatedRefs'];
+		$this->assertCount( 2, $refs );
+		$this->assertSame( 'com.atproto.repo.strongRef', $refs[0]['$type'] );
+		$this->assertSame( 'at://did:plc:test123/site.standard.publication/3kpub00000000', $refs[0]['uri'] );
+		$this->assertSame( 'com.atproto.repo.strongRef', $refs[1]['$type'] );
+		$this->assertSame( 'at://did:plc:test123/site.standard.document/3kdoc00000000', $refs[1]['uri'] );
+		$this->assertSame( 'bafyreidoc000000000000000000000000000000000000000000000000000', $refs[1]['cid'] );
+
+		\delete_option( 'atmosphere_identity' );
+		\delete_option( Publication::OPTION_TID );
+		\delete_option( Publication::OPTION_CID );
+	}
+
+	/**
+	 * When the document strongRef is NOT injected (e.g. on an update
+	 * publish where the Publisher trusts the meta layer instead),
+	 * `build_embed()` falls back to reading `Document::META_URI` /
+	 * `Document::META_CID` from post meta. This is the path taken by
+	 * `Publisher::update_post()` after the initial publish has
+	 * already populated the document meta.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_long_form_embed_falls_back_to_document_meta_when_not_injected() {
+		\update_option( 'atmosphere_identity', array( 'did' => 'did:plc:test123' ), false );
+		\update_option( Publication::OPTION_TID, '3kpub00000000', false );
+		\update_option( Publication::OPTION_CID, 'bafyreipublication0000000000000000000000000000000000000000000', false );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'A Titled Post',
+				'post_content' => 'Long-form blog body.',
+			)
+		);
+
+		\update_post_meta( $post->ID, Document::META_URI, 'at://did:plc:test123/site.standard.document/3kmeta00000000' );
+		\update_post_meta( $post->ID, Document::META_CID, 'bafyreidocmeta00000000000000000000000000000000000000000000000', false );
+
+		$record = ( new Post( $post ) )->transform();
+
+		$refs = $record['embed']['external']['associatedRefs'];
+		$this->assertCount( 2, $refs );
+		$this->assertSame( 'at://did:plc:test123/site.standard.document/3kmeta00000000', $refs[1]['uri'] );
+		$this->assertSame( 'bafyreidocmeta00000000000000000000000000000000000000000000000', $refs[1]['cid'] );
+
+		\delete_option( 'atmosphere_identity' );
+		\delete_option( Publication::OPTION_TID );
+		\delete_option( Publication::OPTION_CID );
+	}
+
+	/**
+	 * Injection wins over meta when both are present — reflects what
+	 * the Publisher is about to write (the injected value) rather than
+	 * what was written previously (the meta value).
+	 *
+	 * @covers ::transform
+	 */
+	public function test_long_form_embed_injection_wins_over_meta() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'A Titled Post',
+				'post_content' => 'Long-form blog body.',
+			)
+		);
+
+		\update_post_meta( $post->ID, Document::META_URI, 'at://did:plc:test123/site.standard.document/old' );
+		\update_post_meta( $post->ID, Document::META_CID, 'bafyreioldoldoldoldoldoldoldoldoldoldoldoldoldoldoldoldoldold' );
+
+		$transformer = new Post( $post );
+		$transformer->set_document_strong_ref(
+			array(
+				'uri' => 'at://did:plc:test123/site.standard.document/new',
+				'cid' => 'bafyreinewnewnewnewnewnewnewnewnewnewnewnewnewnewnewnewnewnew',
+			)
+		);
+
+		$record = $transformer->transform();
+
+		$refs    = $record['embed']['external']['associatedRefs'];
+		$doc_ref = end( $refs );
+		$this->assertSame( 'at://did:plc:test123/site.standard.document/new', $doc_ref['uri'] );
+		$this->assertSame( 'bafyreinewnewnewnewnewnewnewnewnewnewnewnewnewnewnewnewnewnew', $doc_ref['cid'] );
+	}
+
+	/**
+	 * Short-form posts (`app.bsky.embed.images`, or no embed) never
+	 * carry `associatedRefs` — that field is defined only on
+	 * `app.bsky.embed.external#external`. Even with both publication
+	 * state and an explicitly-injected document ref, the short-form
+	 * code path bypasses `build_embed()` entirely.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_short_form_post_never_carries_associated_refs() {
+		\update_option( 'atmosphere_identity', array( 'did' => 'did:plc:test123' ), false );
+		\update_option( Publication::OPTION_TID, '3kpub00000000', false );
+		\update_option( Publication::OPTION_CID, 'bafyreipublication0000000000000000000000000000000000000000000', false );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => '',
+				'post_content' => 'A quick untitled thought.',
+			)
+		);
+
+		$transformer = new Post( $post );
+		$transformer->set_document_strong_ref(
+			array(
+				'uri' => 'at://did:plc:test123/site.standard.document/3kdoc',
+				'cid' => 'bafyreidoc0000000000000000000000000000000000000000000000000000',
+			)
+		);
+
+		$record = $transformer->transform();
+
+		$this->assertArrayNotHasKey( 'embed', $record );
+
+		\delete_option( 'atmosphere_identity' );
+		\delete_option( Publication::OPTION_TID );
+		\delete_option( Publication::OPTION_CID );
 	}
 }

--- a/tests/phpunit/tests/transformer/class-test-publication.php
+++ b/tests/phpunit/tests/transformer/class-test-publication.php
@@ -183,4 +183,42 @@ class Test_Publication extends WP_UnitTestCase {
 		$this->assertSame( "Toni's blog & Co", $record['name'] );
 		$this->assertSame( "Books, coffee & friends'", $record['description'] );
 	}
+
+	/**
+	 * `get_strong_ref()` returns a well-formed `com.atproto.repo.strongRef`
+	 * when all three inputs are present: the connected DID, the
+	 * stored TID, and the captured CID.
+	 */
+	public function test_get_strong_ref_returns_strong_ref_when_all_inputs_present() {
+		\update_option( 'atmosphere_identity', array( 'did' => 'did:plc:test123' ), false );
+		\update_option( Publication::OPTION_TID, '3kpub00000000', false );
+		\update_option( Publication::OPTION_CID, 'bafyreipublication0000000000000000000000000000000000000000000', false );
+
+		$ref = Publication::get_strong_ref();
+
+		$this->assertIsArray( $ref );
+		$this->assertSame( 'com.atproto.repo.strongRef', $ref['$type'] );
+		$this->assertSame( 'at://did:plc:test123/site.standard.publication/3kpub00000000', $ref['uri'] );
+		$this->assertSame( 'bafyreipublication0000000000000000000000000000000000000000000', $ref['cid'] );
+
+		\delete_option( 'atmosphere_identity' );
+		\delete_option( Publication::OPTION_TID );
+		\delete_option( Publication::OPTION_CID );
+	}
+
+	/**
+	 * `get_strong_ref()` returns null when the publication has never
+	 * been successfully sync'd (CID missing). The caller skips the
+	 * strongRef rather than shipping a malformed entry without `cid`.
+	 */
+	public function test_get_strong_ref_returns_null_when_cid_is_missing() {
+		\update_option( 'atmosphere_identity', array( 'did' => 'did:plc:test123' ), false );
+		\update_option( Publication::OPTION_TID, '3kpub00000000', false );
+		\delete_option( Publication::OPTION_CID );
+
+		$this->assertNull( Publication::get_strong_ref() );
+
+		\delete_option( 'atmosphere_identity' );
+		\delete_option( Publication::OPTION_TID );
+	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -26,6 +26,7 @@ $atmosphere_options = array(
 	'atmosphere_connection',
 	'atmosphere_identity',
 	'atmosphere_publication_tid',
+	'atmosphere_publication_cid',
 	'atmosphere_publication_uri',
 	'atmosphere_auto_publish',
 	// Legacy: written by set_handle() in 1.0.x and 1.1.0 as a revert


### PR DESCRIPTION
Fixes CM-811

## Proposed changes:

The follow-up to PR #105 (now closed). Investigation in that PR confirmed that Bluesky's AppView indexes posts at initial-create time and ignores subsequent `applyWrites#update` for `source` / `associatedProfiles` / document `readingTime` enrichment. Both strongRefs have to be in the original atomic applyWrites batch.

AT Protocol's chicken-and-egg blocks the obvious approach: a strongRef needs the target's CID, and the document's CID only exists after a write returns. This PR closes the gap client-side by computing the document's CID locally before the write.

### What lands

- **`Atmosphere\\CID`** — minimum DAG-CBOR encoder targeted at the AT Protocol record subset Atmosphere produces. Handles null, booleans, integers, UTF-8 strings, arrays, maps, and cid-link tags via the `{ \"\$link\": \"bafy...\" }` JSON convention. Sorts map keys length-first then bytewise per DAG-CBOR canonical encoding. **Verified byte-for-byte against three real records pulled from the live PDS** — a `site.standard.publication`, a `site.standard.document` with blob + nested strongRef, and an `app.bsky.feed.post` with two strongRefs + blob + facets. If the encoder drifts, those test vectors fail in CI.

- **`Publication::OPTION_CID` + capture in `Publisher::sync_publication()`** — store the publication CID so `Publication::get_strong_ref()` can assemble the strongRef without a `getRecord` round-trip per publish.

- **`Publication::get_strong_ref()`** — assembles the publication strongRef from the connected DID + stored TID + captured CID, or returns null when any input is missing.

- **`Post::set_document_strong_ref()`** — setter the Publisher uses to inject the document strongRef before the post is transformed. `Post::build_embed()` reads the injection first, falls back to `Document::META_*` when the injection is absent (the `update_post()` flow).

- **`Publisher::publish_post()`** — pre-computes the document record, CIDs it via the new encoder, and injects the resulting strongRef into the post transformer before any `transform()` / `build_long_form_records()` call. The document we encode here is byte-identical to what the actual write batch produces, so the CID matches the PDS-returned CID.

Skipped on short-form posts — they use `app.bsky.embed.images`, no `associatedRefs` field exists on that embed type.

### Why the encoder works against real records

The three encoder tests in `tests/phpunit/tests/class-test-cid.php` use real records fetched from `atmosphere-blog.bsky.social`'s PDS at commit time. The CID my encoder computes for each matches the PDS-returned CID exactly. This is the strongest possible correctness signal short of a live integration test against the PDS itself.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Tests cover:
- `Test_CID` — three real-record CID vectors (publication, document with blob + strongRef, post with two strongRefs + blob + facets), primitive byte fixtures, key-sort canonical order, cid-link tag-42 shape, negative-int shortest form, NaN/Infinity rejection, base32 multibase prefix round-trip.
- `Test_Publication::test_get_strong_ref_*` — full state vs missing CID.
- `Test_Post::test_long_form_embed_*` — both refs when injected, fallback to meta when not injected, injection wins over meta, short-form never carries the refs.

## Testing instructions:

1. Connect a site to ATmosphere.
2. Trigger a publication sync (Settings → General → save anything, or change the active theme).
3. `wp option get atmosphere_publication_cid` — confirm a `bafyrei...` value is stored.
4. Publish a new titled blog post.
5. Inspect the resulting bsky record on the PDS directly:
   ```bash
   curl -s "https://<pds-host>/xrpc/com.atproto.repo.getRecord?repo=<did>&collection=app.bsky.feed.post&rkey=<rkey>"
   ```
   The record's `embed.external.associatedRefs` should contain **two** strongRefs at initial create — publication and document.
6. View the post in Bluesky's app or via `getPostThread` on `public.api.bsky.app`. The view should now include `source` (publication metadata), `associatedProfiles`, and the document's `readingTime` — none of which fired on the publication-only version (or the follow-up-update version in PR #105).

Automated:
* `composer lint`
* `npm run env-test`

### Changelog entry

Already committed at `.github/changelog/add-client-side-cid-for-associated-refs` (Patch / Added).