### PR TITLE
Clamp publication name and description to standard.site grapheme limits

### DIFF
--- a/.github/changelog/clamp-publication-graphemes
+++ b/.github/changelog/clamp-publication-graphemes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Trim very long site titles and taglines when syncing your publication so the record is always accepted by the network.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -77,9 +77,14 @@ function sanitize_text( string $text ): string {
  * Uses `grapheme_substr` when the `intl` extension is loaded — the
  * spec-exact form, matching the way Lexicon counts characters. Falls
  * back to `mb_substr` (code points) otherwise: every grapheme is at
- * least one code point, so a code-point clamp at `$max` is always
- * within the grapheme limit, just sometimes more conservative than
- * needed for emoji-heavy or combining-character text.
+ * least one code point, so a code-point clamp at `$max_graphemes` is
+ * always within the grapheme limit, just sometimes more conservative
+ * than needed for emoji-heavy or combining-character text.
+ *
+ * A non-positive `$max_graphemes` returns an empty string. Both
+ * `grapheme_substr()` and `mb_substr()` would otherwise interpret a
+ * negative length as "drop the last N characters" — not a clamp, and
+ * the opposite of what every caller wants.
  *
  * No marker is appended — used for canonical fields like the
  * `site.standard.publication` `name` / `description`, where adding
@@ -92,6 +97,10 @@ function sanitize_text( string $text ): string {
  * @return string
  */
 function truncate_graphemes( string $text, int $max_graphemes ): string {
+	if ( $max_graphemes <= 0 ) {
+		return '';
+	}
+
 	if ( \function_exists( 'grapheme_strlen' ) ) {
 		$length = \grapheme_strlen( $text );
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -72,6 +72,55 @@ function sanitize_text( string $text ): string {
 }
 
 /**
+ * Hard-clamp a string to an AT Protocol `maxGraphemes` limit.
+ *
+ * Uses `grapheme_substr` when the `intl` extension is loaded — the
+ * spec-exact form, matching the way Lexicon counts characters. Falls
+ * back to `mb_substr` (code points) otherwise: every grapheme is at
+ * least one code point, so a code-point clamp at `$max` is always
+ * within the grapheme limit, just sometimes more conservative than
+ * needed for emoji-heavy or combining-character text.
+ *
+ * No marker is appended — used for canonical fields like the
+ * `site.standard.publication` `name` / `description`, where adding
+ * `…` would mislead consumers about the original length and burn
+ * grapheme budget. Callers that want an ellipsis on excerpts should
+ * use {@see truncate_text()} instead.
+ *
+ * @param string $text          Text to clamp.
+ * @param int    $max_graphemes Maximum graphemes.
+ * @return string
+ */
+function truncate_graphemes( string $text, int $max_graphemes ): string {
+	if ( \function_exists( 'grapheme_strlen' ) ) {
+		$length = \grapheme_strlen( $text );
+
+		/*
+		 * `grapheme_strlen()` returns null for invalid UTF-8. Falling
+		 * through to the `mb_*` branch instead of returning unchanged
+		 * keeps the clamp load-bearing — a malformed-and-oversized
+		 * blogname must still leave with a bounded length even if the
+		 * grapheme count is indeterminate.
+		 */
+		if ( null !== $length ) {
+			if ( $length <= $max_graphemes ) {
+				return $text;
+			}
+			$clamped = \grapheme_substr( $text, 0, $max_graphemes );
+			if ( \is_string( $clamped ) ) {
+				return $clamped;
+			}
+		}
+	}
+
+	if ( \mb_strlen( $text ) <= $max_graphemes ) {
+		return $text;
+	}
+
+	return \mb_substr( $text, 0, $max_graphemes );
+}
+
+/**
  * Truncate text to a character limit, breaking at word boundaries.
  *
  * @param string $text   Text to truncate.

--- a/includes/transformer/class-publication.php
+++ b/includes/transformer/class-publication.php
@@ -15,6 +15,7 @@ namespace Atmosphere\Transformer;
 use function Atmosphere\build_at_uri;
 use function Atmosphere\get_did;
 use function Atmosphere\sanitize_text;
+use function Atmosphere\truncate_graphemes;
 
 /**
  * Standard.site publication transformer.
@@ -50,15 +51,23 @@ class Publication extends Base {
 	 * @return array site.standard.publication record.
 	 */
 	public function transform(): array {
-		// WordPress stores the site name and tagline HTML-entity encoded
-		// (esc_html at save time). sanitize_text() strips tags, decodes
-		// those entities, and collapses whitespace, so the record carries
-		// clean plain text rather than codes like `&#039;`.
+		/*
+		 * WordPress stores the site name and tagline HTML-entity encoded
+		 * (esc_html at save time). sanitize_text() strips tags, decodes
+		 * those entities, and collapses whitespace, so the record carries
+		 * clean plain text rather than codes like `&#039;`.
+		 *
+		 * The site.standard.publication lexicon caps `name` at 500
+		 * graphemes and `description` at 3000 graphemes. WordPress puts
+		 * no such limit on `blogname` / `blogdescription`, so a long
+		 * tagline would otherwise produce a non-spec record and get
+		 * rejected by the PDS at sync time.
+		 */
 		$record = array(
 			'$type'       => 'site.standard.publication',
 			'url'         => \home_url( '/' ),
-			'name'        => sanitize_text( \get_bloginfo( 'name' ) ),
-			'description' => sanitize_text( \get_bloginfo( 'description' ) ),
+			'name'        => truncate_graphemes( sanitize_text( \get_bloginfo( 'name' ) ), 500 ),
+			'description' => truncate_graphemes( sanitize_text( \get_bloginfo( 'description' ) ), 3000 ),
 		);
 
 		// Site icon. The site.standard.publication lexicon expects a square

--- a/tests/phpunit/tests/class-test-functions.php
+++ b/tests/phpunit/tests/class-test-functions.php
@@ -144,6 +144,17 @@ class Test_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A negative limit clamps to an empty string. Without the guard,
+	 * `grapheme_substr( 'hello', 0, -1 )` returns `'hell'` — the
+	 * substring API interprets negative length as "drop N from the
+	 * end", which is the opposite of a clamp.
+	 */
+	public function test_truncate_graphemes_returns_empty_for_negative_limit() {
+		$this->assertSame( '', truncate_graphemes( 'hello', -1 ) );
+		$this->assertSame( '', truncate_graphemes( 'hello', -500 ) );
+	}
+
+	/**
 	 * Multi-codepoint grapheme clusters (a ZWJ emoji family) count as
 	 * one grapheme each under `intl`. A string of 5 family emoji
 	 * survives a 500-grapheme clamp intact even though it's many

--- a/tests/phpunit/tests/class-test-functions.php
+++ b/tests/phpunit/tests/class-test-functions.php
@@ -12,6 +12,7 @@ use function Atmosphere\parse_at_uri;
 use function Atmosphere\build_at_uri;
 use function Atmosphere\sanitize_text;
 use function Atmosphere\truncate_text;
+use function Atmosphere\truncate_graphemes;
 use function Atmosphere\to_iso8601;
 use function Atmosphere\is_post_publishable;
 use function Atmosphere\get_connection;
@@ -102,6 +103,88 @@ class Test_Functions extends WP_UnitTestCase {
 	 */
 	public function test_truncate_text_short() {
 		$this->assertSame( 'Hello', truncate_text( 'Hello', 300 ) );
+	}
+
+	/**
+	 * Returns text unchanged when it already fits the grapheme budget.
+	 */
+	public function test_truncate_graphemes_returns_short_text_unchanged() {
+		$this->assertSame( 'Hello', truncate_graphemes( 'Hello', 500 ) );
+	}
+
+	/**
+	 * Hard-clamps plain ASCII text at the grapheme limit and does NOT
+	 * append an ellipsis — canonical fields like publication `name`
+	 * must not have their grapheme budget burned by a marker.
+	 */
+	public function test_truncate_graphemes_hard_clamps_without_marker() {
+		$text   = \str_repeat( 'a', 600 );
+		$result = truncate_graphemes( $text, 500 );
+
+		$this->assertSame( 500, \mb_strlen( $result ) );
+		$this->assertStringEndsNotWith( '…', $result );
+		$this->assertStringEndsNotWith( '...', $result );
+	}
+
+	/**
+	 * Empty input is returned unchanged regardless of the limit.
+	 */
+	public function test_truncate_graphemes_returns_empty_string_unchanged() {
+		$this->assertSame( '', truncate_graphemes( '', 500 ) );
+		$this->assertSame( '', truncate_graphemes( '', 0 ) );
+	}
+
+	/**
+	 * Text exactly at the limit (`length === max_graphemes`) is returned
+	 * unchanged — the comparison is inclusive.
+	 */
+	public function test_truncate_graphemes_returns_text_at_exact_limit_unchanged() {
+		$text = \str_repeat( 'x', 500 );
+		$this->assertSame( $text, truncate_graphemes( $text, 500 ) );
+	}
+
+	/**
+	 * Multi-codepoint grapheme clusters (a ZWJ emoji family) count as
+	 * one grapheme each under `intl`. A string of 5 family emoji
+	 * survives a 500-grapheme clamp intact even though it's many
+	 * code points.
+	 *
+	 * Requires the `intl` extension.
+	 */
+	public function test_truncate_graphemes_counts_zwj_emoji_as_single_graphemes() {
+		if ( ! \function_exists( 'grapheme_strlen' ) ) {
+			$this->markTestSkipped( 'intl extension required for grapheme counting.' );
+		}
+
+		// "Family: man, woman, girl" — one grapheme, five code points.
+		$family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
+		$text   = \str_repeat( $family, 5 );
+
+		$result = truncate_graphemes( $text, 500 );
+
+		$this->assertSame( $text, $result );
+		$this->assertSame( 5, \grapheme_strlen( $result ) );
+	}
+
+	/**
+	 * Clamping in the middle of a grapheme cluster must keep the
+	 * cluster intact — never produce a broken final emoji. The clamp
+	 * lands at the boundary, dropping the partial cluster entirely.
+	 */
+	public function test_truncate_graphemes_preserves_cluster_boundaries() {
+		if ( ! \function_exists( 'grapheme_strlen' ) ) {
+			$this->markTestSkipped( 'intl extension required for grapheme counting.' );
+		}
+
+		$family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
+		// 10 families, ~50 code points, but exactly 10 graphemes.
+		$text = \str_repeat( $family, 10 );
+
+		// Clamp to 3 graphemes: result must be exactly 3 family glyphs.
+		$result = truncate_graphemes( $text, 3 );
+
+		$this->assertSame( 3, \grapheme_strlen( $result ) );
+		$this->assertSame( \str_repeat( $family, 3 ), $result );
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-functions.php
+++ b/tests/phpunit/tests/class-test-functions.php
@@ -7,7 +7,6 @@
 
 namespace Atmosphere\Tests;
 
-use WP_UnitTestCase;
 use function Atmosphere\parse_at_uri;
 use function Atmosphere\build_at_uri;
 use function Atmosphere\sanitize_text;
@@ -20,7 +19,7 @@ use function Atmosphere\get_connection;
 /**
  * Function tests.
  */
-class Test_Functions extends WP_UnitTestCase {
+class Test_Functions extends \WP_UnitTestCase {
 
 	/**
 	 * Test parsing a valid AT-URI.

--- a/tests/phpunit/tests/transformer/class-test-publication.php
+++ b/tests/phpunit/tests/transformer/class-test-publication.php
@@ -185,6 +185,55 @@ class Test_Publication extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A `blogname` longer than the standard.site lexicon limit (500
+	 * graphemes for `name`) is hard-clamped before it lands in the
+	 * record, so the PDS does not reject the putRecord with a Lexicon
+	 * validation error.
+	 */
+	public function test_name_is_clamped_to_lexicon_grapheme_limit() {
+		$long_name = \str_repeat( 'a', 600 );
+
+		\add_filter( 'pre_option_blogname', static fn() => $long_name );
+
+		try {
+			$record = ( new Publication( null ) )->transform();
+		} finally {
+			\remove_all_filters( 'pre_option_blogname' );
+		}
+
+		$count = \function_exists( 'grapheme_strlen' )
+			? \grapheme_strlen( $record['name'] )
+			: \mb_strlen( $record['name'] );
+
+		$this->assertLessThanOrEqual( 500, $count );
+		$this->assertSame( \str_repeat( 'a', 500 ), $record['name'] );
+	}
+
+	/**
+	 * The 3000-grapheme cap applies to `description` in the same way
+	 * `name` is clamped — long taglines do not reach the PDS in a
+	 * lexicon-violating shape.
+	 */
+	public function test_description_is_clamped_to_lexicon_grapheme_limit() {
+		$long_description = \str_repeat( 'b', 3500 );
+
+		\add_filter( 'pre_option_blogdescription', static fn() => $long_description );
+
+		try {
+			$record = ( new Publication( null ) )->transform();
+		} finally {
+			\remove_all_filters( 'pre_option_blogdescription' );
+		}
+
+		$count = \function_exists( 'grapheme_strlen' )
+			? \grapheme_strlen( $record['description'] )
+			: \mb_strlen( $record['description'] );
+
+		$this->assertLessThanOrEqual( 3000, $count );
+		$this->assertSame( \str_repeat( 'b', 3000 ), $record['description'] );
+	}
+
+	/**
 	 * `get_strong_ref()` returns a well-formed `com.atproto.repo.strongRef`
 	 * when all three inputs are present: the connected DID, the
 	 * stored TID, and the captured CID.

--- a/tests/phpunit/tests/transformer/class-test-publication.php
+++ b/tests/phpunit/tests/transformer/class-test-publication.php
@@ -9,13 +9,12 @@
 
 namespace Atmosphere\Tests\Transformer;
 
-use WP_UnitTestCase;
 use Atmosphere\Transformer\Publication;
 
 /**
  * Publication transformer tests.
  */
-class Test_Publication extends WP_UnitTestCase {
+class Test_Publication extends \WP_UnitTestCase {
 
 	/**
 	 * Test hex_to_rgb with a full hex color.


### PR DESCRIPTION
Fixes #99.

## Proposed changes:

* New `truncate_graphemes( string $text, int $max_graphemes )` helper in `includes/functions.php`. Uses `grapheme_substr` when the `intl` extension is loaded — the spec-exact form, since Lexicon counts grapheme clusters. Falls back to `mb_substr` otherwise, which always stays within the grapheme spec because every grapheme is at least one code point.
* Falls through to the `mb_*` branch when `grapheme_strlen()` returns null for invalid UTF-8, so a malformed-and-oversized blogname still leaves bounded.
* Applied in `Publication::transform()` to `name` (500 graphemes) and `description` (3000 graphemes) per the [`site.standard.publication` lexicon](https://github.com/standard-site/standard.site).

No ellipsis is appended — `name` and `description` are canonical identifier fields, not excerpts. The atproto convention (see bsky `displayName`) is hard-clamp without a marker; UI consumers add their own ellipsis when displaying. Callers that want word-boundary truncation with `...` continue to use `truncate_text()`.

**Scope note:** clamp is by graphemes only, not bytes (`maxLength`). A pathological all-ZWJ-emoji title that exceeds 5000 bytes after 500-grapheme clamp is theoretically possible but realistically never happens for site name/description, and is out of scope for this issue.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Helper tests (`tests/phpunit/tests/class-test-functions.php`):

* `test_truncate_graphemes_returns_short_text_unchanged` — passthrough below limit.
* `test_truncate_graphemes_hard_clamps_without_marker` — ASCII clamp, no ellipsis.
* `test_truncate_graphemes_returns_empty_string_unchanged` — empty input, including with `0` limit.
* `test_truncate_graphemes_returns_text_at_exact_limit_unchanged` — inclusive comparison at exactly the limit.
* `test_truncate_graphemes_counts_zwj_emoji_as_single_graphemes` — multi-codepoint ZWJ emoji counted as one grapheme each (requires `intl`).
* `test_truncate_graphemes_preserves_cluster_boundaries` — clamp lands at cluster boundary, never produces a broken final glyph (requires `intl`).

Transformer integration tests (`tests/phpunit/tests/transformer/class-test-publication.php`):

* `test_name_is_clamped_to_lexicon_grapheme_limit` — 600-char `blogname` → record carries exactly 500.
* `test_description_is_clamped_to_lexicon_grapheme_limit` — 3500-char `blogdescription` → record carries exactly 3000.

## Testing instructions:

* In WordPress: Settings → General. Set your site title to a string longer than 500 characters (paste any 600+ character placeholder). Optionally do the same for the tagline with 3500+ characters.
* Reconnect or trigger a publication sync (Settings → ATmosphere → "Sync publication record" if visible, or wait for the next `atmosphere_sync_publication` cron tick).
* Confirm in the network log that the `putRecord` to `site.standard.publication` succeeds (no Lexicon validation error from the PDS).
* `wp atmosphere debug publication` (or any other readback) should show `name` exactly 500 characters and `description` exactly 3000 characters when long source values are set.

Automated:

* `composer lint`
* `npm run env-test -- --filter='Test_Functions|Test_Publication'`

### Changelog entry

A changelog entry is already committed on this branch at `.github/changelog/clamp-publication-graphemes` (Patch / Fixed), so the automatic creation box below is intentionally left unchecked.

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Trim very long site titles and taglines when syncing your publication so the record is always accepted by the network.

</details>