### PR TITLE
Align publication theme with the site.standard.theme.basic spec

### DIFF
--- a/.github/changelog/fix-publication-basic-theme
+++ b/.github/changelog/fix-publication-basic-theme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Send your site's theme colours to standard.site in the format the network expects so they show up on your publication page.

--- a/includes/transformer/class-publication.php
+++ b/includes/transformer/class-publication.php
@@ -249,7 +249,16 @@ class Publication extends Base {
 			return $rgb;
 		}
 
-		if ( \preg_match( '/var\(\s*--wp--preset--color--([a-z0-9_-]+)/i', $value, $matches ) ) {
+		/*
+		 * Anchored on both ends so a `var(...)` reference embedded in a
+		 * larger expression (e.g. `linear-gradient(var(--wp--preset--
+		 * color--primary), #fff)`) does NOT resolve to a single RGB
+		 * triple — the surrounding gradient changes the rendered colour
+		 * meaningfully, and there's no honest single-colour answer for
+		 * the publication record. An optional `, fallback` between the
+		 * slug and the closing `)` is consumed but ignored.
+		 */
+		if ( \preg_match( '/^var\(\s*--wp--preset--color--([a-z0-9_-]+)\s*(?:,[^)]*)?\)$/i', $value, $matches ) ) {
 			$slug = \strtolower( $matches[1] );
 			if ( isset( $palette_lookup[ $slug ] ) ) {
 				return self::hex_to_rgb( $palette_lookup[ $slug ] );
@@ -260,25 +269,55 @@ class Publication extends Base {
 	}
 
 	/**
-	 * Read the theme palette into a `slug => hex` lookup.
+	 * Flatten the active theme palette into a `slug => hex` lookup.
 	 *
+	 * Accepts either of the two shapes `wp_get_global_settings()` is
+	 * known to return: a flat list of `{ slug, name, color }` entries
+	 * (the default, when no `context` is supplied), or an origin-grouped
+	 * map `{ default: [...], theme: [...], custom: [...] }` (some
+	 * context-passing variants of the API). Theme-defined slugs land
+	 * last in iteration order and overwrite default-palette slugs of
+	 * the same name — same precedence consumers see when the browser
+	 * resolves the CSS variable.
+	 *
+	 * The `$raw_palette` parameter exists to make the flattening
+	 * testable without standing up a real `wp_theme_json` merge. The
+	 * default `null` resolves to whatever `wp_get_global_settings()`
+	 * returns at call time.
+	 *
+	 * @param mixed $raw_palette Raw palette data, or null to read from
+	 *                           `wp_get_global_settings()`.
 	 * @return array<string,string>
 	 */
-	private static function get_palette_lookup(): array {
-		if ( ! \function_exists( 'wp_get_global_settings' ) ) {
-			return array();
+	public static function get_palette_lookup( $raw_palette = null ): array {
+		if ( null === $raw_palette ) {
+			if ( ! \function_exists( 'wp_get_global_settings' ) ) {
+				return array();
+			}
+			$raw_palette = \wp_get_global_settings( array( 'color', 'palette' ) );
 		}
 
-		$palette = \wp_get_global_settings( array( 'color', 'palette' ) );
-
-		if ( ! \is_array( $palette ) ) {
+		if ( ! \is_array( $raw_palette ) ) {
 			return array();
 		}
 
 		$lookup = array();
-		foreach ( $palette as $entry ) {
-			if ( \is_array( $entry ) && isset( $entry['slug'], $entry['color'] ) ) {
+		foreach ( $raw_palette as $entry ) {
+			if ( ! \is_array( $entry ) ) {
+				continue;
+			}
+
+			// Flat shape: `{ slug, color }`.
+			if ( isset( $entry['slug'], $entry['color'] ) ) {
 				$lookup[ \strtolower( (string) $entry['slug'] ) ] = (string) $entry['color'];
+				continue;
+			}
+
+			// Origin-grouped shape: each nested entry is itself a `{ slug, color }` array.
+			foreach ( $entry as $sub_entry ) {
+				if ( \is_array( $sub_entry ) && isset( $sub_entry['slug'], $sub_entry['color'] ) ) {
+					$lookup[ \strtolower( (string) $sub_entry['slug'] ) ] = (string) $sub_entry['color'];
+				}
 			}
 		}
 

--- a/includes/transformer/class-publication.php
+++ b/includes/transformer/class-publication.php
@@ -72,10 +72,13 @@ class Publication extends Base {
 			}
 		}
 
-		// Theme colors.
-		$theme = $this->extract_theme();
-		if ( $theme ) {
-			$record['theme'] = $theme;
+		// Theme colours. site.standard.publication uses the `basicTheme`
+		// field, a ref to site.standard.theme.basic with four required
+		// colors. Skipped entirely if any colour can't be sourced — the
+		// spec requires all four and a partial record is rejected.
+		$basic_theme = $this->extract_basic_theme();
+		if ( $basic_theme ) {
+			$record['basicTheme'] = $basic_theme;
 		}
 
 		/**
@@ -158,49 +161,185 @@ class Publication extends Base {
 	}
 
 	/**
-	 * Extract theme colours from the active theme.
+	 * Extract a site.standard.theme.basic record from the active theme.
+	 *
+	 * Returns null when any of the four required colours can't be
+	 * sourced — the lexicon rejects partial records, so the whole
+	 * `basicTheme` field is omitted in that case. Classic themes
+	 * (which only reliably expose `background_color` via theme mods)
+	 * fall into this path.
 	 *
 	 * @return array|null
 	 */
-	private function extract_theme(): ?array {
-		// Block theme: global styles.
-		if ( \function_exists( 'wp_get_global_styles' ) ) {
-			$styles = \wp_get_global_styles();
-
-			$bg   = $styles['color']['background'] ?? '';
-			$text = $styles['color']['text'] ?? '';
-
-			$theme = array();
-
-			if ( $bg ) {
-				$rgb = self::hex_to_rgb( $bg );
-				if ( $rgb ) {
-					$theme['backgroundColor'] = $rgb;
-				}
-			}
-
-			if ( $text ) {
-				$rgb = self::hex_to_rgb( $text );
-				if ( $rgb ) {
-					$theme['textColor'] = $rgb;
-				}
-			}
-
-			if ( ! empty( $theme ) ) {
-				return $theme;
-			}
+	private function extract_basic_theme(): ?array {
+		if ( ! \function_exists( 'wp_get_global_styles' ) ) {
+			return null;
 		}
 
-		// Classic theme: background_color mod.
-		$bg_hex = \get_theme_mod( 'background_color' );
-		if ( $bg_hex ) {
-			$rgb = self::hex_to_rgb( '#' . \ltrim( $bg_hex, '#' ) );
-			if ( $rgb ) {
-				return array( 'backgroundColor' => $rgb );
+		$styles  = \wp_get_global_styles();
+		$palette = self::get_palette_lookup();
+
+		return self::build_basic_theme( \is_array( $styles ) ? $styles : array(), $palette );
+	}
+
+	/**
+	 * Build the spec-shaped basicTheme record from already-resolved
+	 * global styles and a palette lookup.
+	 *
+	 * Pure transformation — accepts the WP-resolved inputs as arguments
+	 * so the unit tests can drive it without standing up a real
+	 * theme.json merge.
+	 *
+	 * @param array                $styles  Output of `wp_get_global_styles()`.
+	 * @param array<string,string> $palette Slug => hex map from the theme palette.
+	 * @return array|null Spec-shaped record, or null when any required colour
+	 *                    is missing.
+	 */
+	public static function build_basic_theme( array $styles, array $palette ): ?array {
+		$background = self::resolve_color( (string) ( $styles['color']['background'] ?? '' ), $palette );
+		$foreground = self::resolve_color( (string) ( $styles['color']['text'] ?? '' ), $palette );
+
+		/*
+		 * Link colour is the conventional accent source in WP themes —
+		 * it's the one element nearly every theme styles explicitly.
+		 * Falls back to a palette slug literally named `accent` for
+		 * themes that don't restyle links.
+		 */
+		$accent = self::resolve_color(
+			(string) ( $styles['elements']['link']['color']['text'] ?? '' ),
+			$palette
+		);
+
+		if ( null === $accent && isset( $palette['accent'] ) ) {
+			$accent = self::resolve_color( $palette['accent'], $palette );
+		}
+
+		if ( null === $background || null === $foreground || null === $accent ) {
+			return null;
+		}
+
+		return array(
+			'background'       => self::color_object( $background ),
+			'foreground'       => self::color_object( $foreground ),
+			'accent'           => self::color_object( $accent ),
+			'accentForeground' => self::color_object( self::contrast_color( $accent ) ),
+		);
+	}
+
+	/**
+	 * Resolve a colour value to an `{r, g, b}` array.
+	 *
+	 * Accepts a direct hex string or a `var(--wp--preset--color--{slug})`
+	 * reference that resolves against the supplied palette lookup.
+	 * Returns null for anything else (named colours, `currentColor`,
+	 * gradients, etc.).
+	 *
+	 * @param string               $value           Raw colour value.
+	 * @param array<string,string> $palette_lookup  Slug => hex map.
+	 * @return array{r: int, g: int, b: int}|null
+	 */
+	private static function resolve_color( string $value, array $palette_lookup ): ?array {
+		$value = \trim( $value );
+		if ( '' === $value ) {
+			return null;
+		}
+
+		$rgb = self::hex_to_rgb( $value );
+		if ( $rgb ) {
+			return $rgb;
+		}
+
+		if ( \preg_match( '/var\(\s*--wp--preset--color--([a-z0-9_-]+)/i', $value, $matches ) ) {
+			$slug = \strtolower( $matches[1] );
+			if ( isset( $palette_lookup[ $slug ] ) ) {
+				return self::hex_to_rgb( $palette_lookup[ $slug ] );
 			}
 		}
 
 		return null;
+	}
+
+	/**
+	 * Read the theme palette into a `slug => hex` lookup.
+	 *
+	 * @return array<string,string>
+	 */
+	private static function get_palette_lookup(): array {
+		if ( ! \function_exists( 'wp_get_global_settings' ) ) {
+			return array();
+		}
+
+		$palette = \wp_get_global_settings( array( 'color', 'palette' ) );
+
+		if ( ! \is_array( $palette ) ) {
+			return array();
+		}
+
+		$lookup = array();
+		foreach ( $palette as $entry ) {
+			if ( \is_array( $entry ) && isset( $entry['slug'], $entry['color'] ) ) {
+				$lookup[ \strtolower( (string) $entry['slug'] ) ] = (string) $entry['color'];
+			}
+		}
+
+		return $lookup;
+	}
+
+	/**
+	 * Wrap an `{r, g, b}` array in the site.standard.theme.color#rgb
+	 * union shape.
+	 *
+	 * @param array{r: int, g: int, b: int} $rgb Source RGB triple, channels 0-255.
+	 * @return array
+	 */
+	private static function color_object( array $rgb ): array {
+		return array(
+			'$type' => 'site.standard.theme.color#rgb',
+			'r'     => $rgb['r'],
+			'g'     => $rgb['g'],
+			'b'     => $rgb['b'],
+		);
+	}
+
+	/**
+	 * Pick a high-contrast foreground colour (pure white or pure black)
+	 * for a given accent colour, using WCAG relative luminance.
+	 *
+	 * The 0.5 threshold matches the rule of thumb used by most design
+	 * systems: a colour with relative luminance above 0.5 reads as
+	 * light, below as dark. White-on-dark / black-on-light always
+	 * clears the WCAG AA 4.5:1 contrast bar.
+	 *
+	 * @param array{r: int, g: int, b: int} $rgb Accent colour, channels 0-255.
+	 * @return array{r: int, g: int, b: int}
+	 */
+	private static function contrast_color( array $rgb ): array {
+		$luminance = 0.2126 * self::srgb_to_linear( $rgb['r'] / 255 )
+			+ 0.7152 * self::srgb_to_linear( $rgb['g'] / 255 )
+			+ 0.0722 * self::srgb_to_linear( $rgb['b'] / 255 );
+
+		return $luminance > 0.5
+			? array(
+				'r' => 0,
+				'g' => 0,
+				'b' => 0,
+			)
+			: array(
+				'r' => 255,
+				'g' => 255,
+				'b' => 255,
+			);
+	}
+
+	/**
+	 * Inverse of the sRGB transfer function — convert a gamma-encoded
+	 * 0..1 channel to a linear 0..1 channel for luminance calculation.
+	 *
+	 * @param float $c Channel value in 0..1.
+	 * @return float
+	 */
+	private static function srgb_to_linear( float $c ): float {
+		return $c <= 0.03928 ? $c / 12.92 : \pow( ( $c + 0.055 ) / 1.055, 2.4 );
 	}
 
 	/**

--- a/tests/phpunit/tests/transformer/class-test-publication.php
+++ b/tests/phpunit/tests/transformer/class-test-publication.php
@@ -204,10 +204,17 @@ class Test_Publication extends WP_UnitTestCase {
 		$record = Publication::build_basic_theme( $styles, array() );
 
 		$this->assertIsArray( $record );
-		$this->assertSame(
+
+		/*
+		 * Lexicon JSON objects are unordered — only the set of keys is
+		 * part of the contract. Canonicalizing the comparison guards
+		 * against false positives if a future refactor emits the same
+		 * required fields in a different `transform()` insertion order.
+		 */
+		$this->assertEqualsCanonicalizing(
 			array( 'background', 'foreground', 'accent', 'accentForeground' ),
 			\array_keys( $record ),
-			'basicTheme must carry all four required colours in the spec field order.'
+			'basicTheme must carry all four required colours.'
 		);
 
 		foreach ( $record as $key => $color ) {
@@ -309,6 +316,93 @@ class Test_Publication extends WP_UnitTestCase {
 		$this->assertSame( 250, $record['background']['r'] );
 		$this->assertSame( 34, $record['foreground']['r'] );
 		$this->assertSame( 170, $record['accent']['r'] );
+	}
+
+	/**
+	 * A `var(...)` reference embedded in a larger expression — typically
+	 * a gradient — does NOT resolve to a single RGB triple. The
+	 * resulting publication record would advertise a flat colour where
+	 * the rendered page draws a gradient, so the safer behaviour is to
+	 * treat the value as unresolvable and omit `basicTheme` entirely
+	 * (per the all-or-nothing required-fields contract).
+	 */
+	public function test_build_basic_theme_rejects_var_inside_gradient() {
+		$styles  = array(
+			'color'    => array(
+				'background' => 'linear-gradient(var(--wp--preset--color--primary), #ffffff)',
+				'text'       => '#000000',
+			),
+			'elements' => array(
+				'link' => array( 'color' => array( 'text' => '#0066cc' ) ),
+			),
+		);
+		$palette = array( 'primary' => '#ff0000' );
+
+		$this->assertNull(
+			Publication::build_basic_theme( $styles, $palette ),
+			'A var() inside a gradient must not be silently resolved to a single colour.'
+		);
+	}
+
+	/**
+	 * `get_palette_lookup()` accepts the origin-grouped shape returned
+	 * by some context-passing variants of `wp_get_global_settings()`,
+	 * not just the flat default form. Slugs from later origin groups
+	 * (typically `theme` after `default`) overwrite same-named slugs
+	 * from earlier groups — matching CSS-variable precedence.
+	 */
+	public function test_get_palette_lookup_flattens_origin_grouped_shape() {
+		$nested = array(
+			'default' => array(
+				array(
+					'slug'  => 'primary',
+					'color' => '#000000',
+				),
+				array(
+					'slug'  => 'base',
+					'color' => '#ffffff',
+				),
+			),
+			'theme'   => array(
+				array(
+					'slug'  => 'primary',
+					'color' => '#ff0000',
+				),
+				array(
+					'slug'  => 'accent',
+					'color' => '#00ff00',
+				),
+			),
+		);
+
+		$lookup = Publication::get_palette_lookup( $nested );
+
+		$this->assertSame( '#ff0000', $lookup['primary'], 'Theme-origin slug should override default-origin slug.' );
+		$this->assertSame( '#ffffff', $lookup['base'] );
+		$this->assertSame( '#00ff00', $lookup['accent'] );
+	}
+
+	/**
+	 * `get_palette_lookup()` still flattens a plain `{ slug, color }`
+	 * list — the default shape `wp_get_global_settings()` returns when
+	 * no context is supplied.
+	 */
+	public function test_get_palette_lookup_flattens_flat_shape() {
+		$flat = array(
+			array(
+				'slug'  => 'primary',
+				'color' => '#112233',
+			),
+			array(
+				'slug'  => 'accent',
+				'color' => '#445566',
+			),
+		);
+
+		$lookup = Publication::get_palette_lookup( $flat );
+
+		$this->assertSame( '#112233', $lookup['primary'] );
+		$this->assertSame( '#445566', $lookup['accent'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/transformer/class-test-publication.php
+++ b/tests/phpunit/tests/transformer/class-test-publication.php
@@ -185,6 +185,213 @@ class Test_Publication extends WP_UnitTestCase {
 	}
 
 	/**
+	 * `build_basic_theme()` produces the spec-shaped record with all
+	 * four required colours when background/foreground/accent are
+	 * resolvable from the supplied styles. Each colour carries the
+	 * `site.standard.theme.color#rgb` union discriminator.
+	 */
+	public function test_build_basic_theme_returns_spec_shape_with_all_four_colors() {
+		$styles = array(
+			'color'    => array(
+				'background' => '#ffffff',
+				'text'       => '#111111',
+			),
+			'elements' => array(
+				'link' => array( 'color' => array( 'text' => '#0066cc' ) ),
+			),
+		);
+
+		$record = Publication::build_basic_theme( $styles, array() );
+
+		$this->assertIsArray( $record );
+		$this->assertSame(
+			array( 'background', 'foreground', 'accent', 'accentForeground' ),
+			\array_keys( $record ),
+			'basicTheme must carry all four required colours in the spec field order.'
+		);
+
+		foreach ( $record as $key => $color ) {
+			$this->assertSame(
+				'site.standard.theme.color#rgb',
+				$color['$type'],
+				"Color object `{$key}` must carry the rgb union discriminator."
+			);
+			$this->assertIsInt( $color['r'] );
+			$this->assertIsInt( $color['g'] );
+			$this->assertIsInt( $color['b'] );
+		}
+
+		$this->assertSame(
+			array(
+				'$type' => 'site.standard.theme.color#rgb',
+				'r'     => 255,
+				'g'     => 255,
+				'b'     => 255,
+			),
+			$record['background']
+		);
+		$this->assertSame(
+			array(
+				'$type' => 'site.standard.theme.color#rgb',
+				'r'     => 17,
+				'g'     => 17,
+				'b'     => 17,
+			),
+			$record['foreground']
+		);
+		$this->assertSame(
+			array(
+				'$type' => 'site.standard.theme.color#rgb',
+				'r'     => 0,
+				'g'     => 102,
+				'b'     => 204,
+			),
+			$record['accent']
+		);
+	}
+
+	/**
+	 * Each required colour gates the entire record: if any one of
+	 * background / foreground / accent cannot be resolved, `null` is
+	 * returned and the caller omits `basicTheme` entirely. A partial
+	 * record would be rejected by the PDS — the spec demands all four.
+	 */
+	public function test_build_basic_theme_returns_null_when_any_required_color_missing() {
+		$base = array(
+			'color'    => array(
+				'background' => '#ffffff',
+				'text'       => '#000000',
+			),
+			'elements' => array( 'link' => array( 'color' => array( 'text' => '#0066cc' ) ) ),
+		);
+
+		// No background.
+		$without_bg                        = $base;
+		$without_bg['color']['background'] = '';
+		$this->assertNull( Publication::build_basic_theme( $without_bg, array() ) );
+
+		// No foreground.
+		$without_fg                  = $base;
+		$without_fg['color']['text'] = '';
+		$this->assertNull( Publication::build_basic_theme( $without_fg, array() ) );
+
+		// No accent and no `accent` slug in palette.
+		$without_accent                                      = $base;
+		$without_accent['elements']['link']['color']['text'] = '';
+		$this->assertNull( Publication::build_basic_theme( $without_accent, array() ) );
+	}
+
+	/**
+	 * A `var(--wp--preset--color--{slug})` reference in any colour
+	 * field resolves against the supplied palette lookup. This is the
+	 * common modern shape — WP themes emit CSS variables that the
+	 * browser later resolves against `:root` custom properties.
+	 */
+	public function test_build_basic_theme_resolves_css_var_references_against_palette() {
+		$styles  = array(
+			'color'    => array(
+				'background' => 'var(--wp--preset--color--base)',
+				'text'       => 'var(--wp--preset--color--contrast)',
+			),
+			'elements' => array(
+				'link' => array( 'color' => array( 'text' => 'var(--wp--preset--color--primary)' ) ),
+			),
+		);
+		$palette = array(
+			'base'     => '#fafafa',
+			'contrast' => '#222222',
+			'primary'  => '#aa2233',
+		);
+
+		$record = Publication::build_basic_theme( $styles, $palette );
+
+		$this->assertIsArray( $record );
+		$this->assertSame( 250, $record['background']['r'] );
+		$this->assertSame( 34, $record['foreground']['r'] );
+		$this->assertSame( 170, $record['accent']['r'] );
+	}
+
+	/**
+	 * Themes that don't style links explicitly fall back to a palette
+	 * slug literally named `accent` for the accent colour source.
+	 */
+	public function test_build_basic_theme_falls_back_to_palette_accent_slug() {
+		$styles  = array(
+			'color' => array(
+				'background' => '#ffffff',
+				'text'       => '#000000',
+			),
+		);
+		$palette = array( 'accent' => '#ff5500' );
+
+		$record = Publication::build_basic_theme( $styles, $palette );
+
+		$this->assertIsArray( $record );
+		$this->assertSame( 255, $record['accent']['r'] );
+		$this->assertSame( 85, $record['accent']['g'] );
+		$this->assertSame( 0, $record['accent']['b'] );
+	}
+
+	/**
+	 * `accentForeground` is derived from the accent's WCAG relative
+	 * luminance — pure black for a light accent (yellow), pure white
+	 * for a dark accent (deep blue). The 0.5 threshold places yellow
+	 * (~0.93) firmly on the light side and deep blue (~0.05) firmly
+	 * on the dark side.
+	 */
+	public function test_build_basic_theme_derives_accent_foreground_from_luminance() {
+		$light_accent = array(
+			'color'    => array(
+				'background' => '#ffffff',
+				'text'       => '#000000',
+			),
+			'elements' => array( 'link' => array( 'color' => array( 'text' => '#ffeb3b' ) ) ),
+		);
+		$dark_accent  = array(
+			'color'    => array(
+				'background' => '#ffffff',
+				'text'       => '#000000',
+			),
+			'elements' => array( 'link' => array( 'color' => array( 'text' => '#0d47a1' ) ) ),
+		);
+
+		$light = Publication::build_basic_theme( $light_accent, array() );
+		$dark  = Publication::build_basic_theme( $dark_accent, array() );
+
+		$this->assertSame(
+			array(
+				'$type' => 'site.standard.theme.color#rgb',
+				'r'     => 0,
+				'g'     => 0,
+				'b'     => 0,
+			),
+			$light['accentForeground'],
+			'Light accent should yield black foreground.'
+		);
+		$this->assertSame(
+			array(
+				'$type' => 'site.standard.theme.color#rgb',
+				'r'     => 255,
+				'g'     => 255,
+				'b'     => 255,
+			),
+			$dark['accentForeground'],
+			'Dark accent should yield white foreground.'
+		);
+	}
+
+	/**
+	 * The record uses the spec field `basicTheme` (not the legacy
+	 * `theme` field, which was modelled on the bsky profile shape and
+	 * gets ignored by standard.site consumers).
+	 */
+	public function test_record_omits_non_spec_theme_field() {
+		$record = ( new Publication( null ) )->transform();
+
+		$this->assertArrayNotHasKey( 'theme', $record, 'Non-spec `theme` field must not be present.' );
+	}
+
+	/**
 	 * `get_strong_ref()` returns a well-formed `com.atproto.repo.strongRef`
 	 * when all three inputs are present: the connected DID, the
 	 * stored TID, and the captured CID.

--- a/tests/phpunit/tests/transformer/class-test-publication.php
+++ b/tests/phpunit/tests/transformer/class-test-publication.php
@@ -9,13 +9,12 @@
 
 namespace Atmosphere\Tests\Transformer;
 
-use WP_UnitTestCase;
 use Atmosphere\Transformer\Publication;
 
 /**
  * Publication transformer tests.
  */
-class Test_Publication extends WP_UnitTestCase {
+class Test_Publication extends \WP_UnitTestCase {
 
 	/**
 	 * Test hex_to_rgb with a full hex color.


### PR DESCRIPTION
Fixes #97.

## Proposed changes:

* Restructure the publication record's theme field to match [`site.standard.theme.basic`](https://standard.site/docs/lexicons/theme/):
  * Top-level key `theme` → `basicTheme`
  * `backgroundColor` → `background`, `textColor` → `foreground`
  * Add `accent` and `accentForeground` (the spec requires all four)
  * Each colour object carries `\$type: site.standard.theme.color#rgb`
* Colour sources:
  * `background` / `foreground` ← `wp_get_global_styles()['color']['background' | 'text']`
  * `accent` ← `elements.link.color.text`, falling back to a palette slug literally named `accent`
  * `accentForeground` ← derived from the accent's WCAG relative luminance: pure black for light accents (luminance > 0.5), pure white for dark accents. White-on-dark / black-on-light always clears the WCAG AA 4.5:1 contrast bar.
* `var(--wp--preset--color--{slug})` references in any colour field resolve against the merged theme palette (`wp_get_global_settings(['color','palette'])`).
* Partial records are rejected by the PDS, so if any of the three source colours can't be resolved, `basicTheme` is omitted from the record entirely. Classic themes typically fall into this path (they expose `background_color` via theme mods but no foreground/accent).
* `Publication::build_basic_theme()` is a `public static` accepting pre-resolved styles + palette, so the unit tests drive the logic directly without standing up a full theme.json merge.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

New tests in `tests/phpunit/tests/transformer/class-test-publication.php`:

* `test_build_basic_theme_returns_spec_shape_with_all_four_colors` — happy path, asserts spec field names, `\$type` discriminator on each colour, and RGB integers.
* `test_build_basic_theme_returns_null_when_any_required_color_missing` — each of background / foreground / accent missing in turn produces a null return.
* `test_build_basic_theme_resolves_css_var_references_against_palette` — `var(--wp--preset--color--{slug})` resolves through the palette lookup.
* `test_build_basic_theme_falls_back_to_palette_accent_slug` — palette-slug \`accent\` is used when no link colour is set.
* `test_build_basic_theme_derives_accent_foreground_from_luminance` — yellow accent yields black foreground, deep-blue accent yields white.
* `test_record_omits_non_spec_theme_field` — the legacy non-spec \`theme\` key is gone.

## Testing instructions:

* In a block theme (e.g. Twenty Twenty-Five): Site Editor → Styles → set a background, text, and link colour. Optionally also set a colour palette slug named \`accent\`.
* Reconnect or trigger a publication sync (Settings → ATmosphere → \"Sync publication record\", or wait for the next \`atmosphere_sync_publication\` cron tick).
* Inspect the published \`site.standard.publication\` record (e.g. via the PDS \`getRecord\` XRPC or your AT Protocol explorer). Confirm:
  * Top-level field is \`basicTheme\` (not \`theme\`).
  * Four colour objects: \`background\`, \`foreground\`, \`accent\`, \`accentForeground\`.
  * Each colour has \`\$type: site.standard.theme.color#rgb\` with integer \`r\`, \`g\`, \`b\` channels.
* Switch to a classic theme that only sets \`background_color\` via Customize. Re-sync. Confirm the record does NOT contain \`basicTheme\` at all (partial would be rejected by the PDS).
* On standard.site, your publication page should now pick up the theme colours (consumers previously ignored the non-spec \`theme\` field entirely).

Automated:

* \`composer lint\`
* \`npm run env-test -- --filter='Test_Publication'\`

### Changelog entry

A changelog entry is already committed on this branch at \`.github/changelog/fix-publication-basic-theme\` (Patch / Fixed), so the automatic creation box below is intentionally left unchecked.

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Send your site's theme colours to standard.site in the format the network expects so they show up on your publication page.

</details>