### PR TITLE
Send no-cache headers on the well-known verification routes

### DIFF
--- a/.github/changelog/fix-wellknown-nocache-headers
+++ b/.github/changelog/fix-wellknown-nocache-headers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop caches from holding on to a stale domain handle or publication link, so reconnecting or switching accounts takes effect right away.

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -471,6 +471,14 @@ class Atmosphere {
 		}
 
 		/*
+		 * Bidirectional verification re-fetches this endpoint on every
+		 * profile load, so a fronting page/CDN cache must never retain a
+		 * pre-connect 404 or a post-disconnect 200 with a stale DID. Send
+		 * no-cache headers on every response branch below.
+		 */
+		\nocache_headers();
+
+		/*
 		 * Identity gate (not connection gate): an expired OAuth session
 		 * must not break domain handle verification. Bluesky's resolver
 		 * re-fetches this endpoint to confirm the bidirectional link
@@ -499,6 +507,14 @@ class Atmosphere {
 		if ( \get_query_var( 'atmosphere_wellknown' ) !== 'publication' ) {
 			return;
 		}
+
+		/*
+		 * Bidirectional verification re-fetches this endpoint on every
+		 * profile load, so a fronting page/CDN cache must never retain a
+		 * pre-connect 404 or a post-disconnect 200 with a stale AT-URI.
+		 * Send no-cache headers on every response branch below.
+		 */
+		\nocache_headers();
 
 		/*
 		 * Identity gate (not connection gate): the publication AT-URI is


### PR DESCRIPTION
Fixes #83

## Proposed changes:

The `/.well-known/atproto-did` and `/.well-known/site.standard.publication` handlers set a status code and body and then `exit`, but never called `nocache_headers()`. A fronting page or CDN cache could therefore hold on to:

- a **pre-connect 404** after OAuth succeeds — handle resolution stays broken until the cache TTL expires, and
- a **post-disconnect 200** with a stale DID / AT-URI — Bluesky / standard.site keep resolving the old identity against the domain.

This is most visible in the disconnect → reconnect-to-a-different-account flow, where a cached `200` at `/.well-known/atproto-did` returning the old DID defeats bidirectional verification on the new identity.

The fix adds a single `\nocache_headers()` call right after each handler's query-var guard, so every response branch (both 404s and the 200) is marked uncacheable. The non-matching early-return path is untouched — that request is handed back to WordPress's normal loop and must not be affected.

Context: FOSSE's bundled copy used to mirror these handlers and called `nocache_headers()` itself; that duplicate was removed (Automattic/fosse#170), leaving Atmosphere as the sole responder without the cache defense.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

> No automated test added. Both handlers terminate with a bare `exit;`, which PHPUnit cannot intercept (unlike `wp_die()`, which throws `WPDieException`). Asserting the emitted headers would require refactoring the handlers to separate response-building from `exit`, which is out of scope for this fix. The full suite (500 tests) and PHPCS both pass.

## Testing instructions:

1. Connect an account and confirm `curl -i https://YOUR_SITE/.well-known/atproto-did` returns `200` with the DID **and** a `Cache-Control: no-cache, must-revalidate, max-age=0` header (plus `Expires` in the past). Same for `/.well-known/site.standard.publication`.
2. Disconnect the account (or test before connecting) and confirm the `404` branch also carries the no-cache headers.
3. Confirm the headers are absent for unrelated front-end URLs (the early `return` path is not affected).

### Changelog entry

A changelog entry is committed in `.github/changelog/fix-wellknown-nocache-headers` (Patch / Fixed).
