### PR TITLE
Handle OpenSSL EC keygen failure gracefully in DPoP

### DIFF
--- a/.github/changelog/fix-dpop-keygen-fatal
+++ b/.github/changelog/fix-dpop-keygen-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show a clear error instead of crashing when connecting on a server whose OpenSSL build cannot create the secure key Bluesky requires.

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -167,6 +167,9 @@ class Client {
 
 		// DPoP key pair.
 		$dpop_jwk = DPoP::generate_key();
+		if ( \is_wp_error( $dpop_jwk ) ) {
+			return $dpop_jwk;
+		}
 
 		// State for CSRF.
 		$state = \wp_generate_password( 40, false );

--- a/includes/oauth/class-dpop.php
+++ b/includes/oauth/class-dpop.php
@@ -23,9 +23,11 @@ class DPoP {
 	/**
 	 * Generate an ES256 key pair suitable for DPoP.
 	 *
-	 * @return array JWK array with private key material.
+	 * @return array|\WP_Error JWK array with private key material, or a
+	 *                         WP_Error when the host's OpenSSL build cannot
+	 *                         produce the P-256 (EC) key DPoP requires.
 	 */
-	public static function generate_key(): array {
+	public static function generate_key(): array|\WP_Error {
 		$key = \openssl_pkey_new(
 			array(
 				'curve_name'       => 'prime256v1',
@@ -33,9 +35,27 @@ class DPoP {
 			)
 		);
 
-		\openssl_pkey_export( $key, $pem );
+		/*
+		 * Some OpenSSL builds (FIPS-restricted, stripped, or WebAssembly
+		 * runtimes like WordPress Playground) cannot generate EC keys and
+		 * return false here. Bail with a clear error instead of passing
+		 * false to openssl_pkey_get_details(), which fatals on PHP 8.
+		 */
+		if ( false === $key ) {
+			return new \WP_Error(
+				'atmosphere_dpop_keygen_failed',
+				\__( 'Could not create the secure key needed to connect to Bluesky. Your site\'s server is missing OpenSSL elliptic-curve (EC) support — please ask your host to enable it.', 'atmosphere' )
+			);
+		}
+
 		$details = \openssl_pkey_get_details( $key );
-		$ec      = $details['ec'];
+		if ( false === $details || ! isset( $details['ec'] ) ) {
+			return new \WP_Error(
+				'atmosphere_dpop_keygen_failed',
+				\__( 'Could not create the secure key needed to connect to Bluesky. Your site\'s server is missing OpenSSL elliptic-curve (EC) support — please ask your host to enable it.', 'atmosphere' )
+			);
+		}
+		$ec = $details['ec'];
 
 		return array(
 			'kty' => 'EC',

--- a/includes/oauth/class-dpop.php
+++ b/includes/oauth/class-dpop.php
@@ -42,18 +42,12 @@ class DPoP {
 		 * false to openssl_pkey_get_details(), which fatals on PHP 8.
 		 */
 		if ( false === $key ) {
-			return new \WP_Error(
-				'atmosphere_dpop_keygen_failed',
-				\__( 'Could not create the secure key needed to connect to Bluesky. Your site\'s server is missing OpenSSL elliptic-curve (EC) support — please ask your host to enable it.', 'atmosphere' )
-			);
+			return self::keygen_error();
 		}
 
 		$details = \openssl_pkey_get_details( $key );
 		if ( false === $details || ! isset( $details['ec'] ) ) {
-			return new \WP_Error(
-				'atmosphere_dpop_keygen_failed',
-				\__( 'Could not create the secure key needed to connect to Bluesky. Your site\'s server is missing OpenSSL elliptic-curve (EC) support — please ask your host to enable it.', 'atmosphere' )
-			);
+			return self::keygen_error();
 		}
 		$ec = $details['ec'];
 
@@ -63,6 +57,21 @@ class DPoP {
 			'x'   => self::base64url( $ec['x'] ),
 			'y'   => self::base64url( $ec['y'] ),
 			'd'   => self::base64url( $ec['d'] ),
+		);
+	}
+
+	/**
+	 * Build the error returned when EC key generation is unavailable.
+	 *
+	 * Shared by both failure branches in generate_key() so the code and
+	 * message stay in sync.
+	 *
+	 * @return \WP_Error
+	 */
+	private static function keygen_error(): \WP_Error {
+		return new \WP_Error(
+			'atmosphere_dpop_keygen_failed',
+			\__( 'Could not create the secure key needed to connect to Bluesky. Your site\'s server is missing OpenSSL elliptic-curve (EC) support — please ask your host to enable it.', 'atmosphere' )
 		);
 	}
 

--- a/tests/phpunit/tests/class-test-dpop.php
+++ b/tests/phpunit/tests/class-test-dpop.php
@@ -26,6 +26,7 @@ class Test_DPoP extends WP_UnitTestCase {
 	public function test_generate_key_produces_valid_jwk() {
 		$jwk = DPoP::generate_key();
 
+		$this->assertNotWPError( $jwk, 'Healthy OpenSSL builds must return a JWK, not an error.' );
 		$this->assertIsArray( $jwk );
 		$this->assertSame( 'EC', $jwk['kty'] );
 		$this->assertSame( 'P-256', $jwk['crv'] );


### PR DESCRIPTION
## Proposed changes:

Fixes a PHP fatal that crashed the "Connect to Bluesky" save when the server's OpenSSL can't generate the elliptic-curve key DPoP needs:

```
PHP Fatal error: Uncaught TypeError: openssl_pkey_get_details(): Argument #1 ($key)
must be of type OpenSSLAsymmetricKey, bool given in .../oauth/class-dpop.php:37
```

**Root cause:** `DPoP::generate_key()` used the result of `openssl_pkey_new()` (P-256 EC) without checking it. When OpenSSL can't produce an EC key it returns `false`, and the next call — `openssl_pkey_get_details(false)` — is a hard `TypeError` on PHP 8, killing the request mid-save on `options.php`.

This was the *only* crypto path in the class that didn't guard its OpenSSL call (`sign_es256()` checks `false === $key`; `create_proof()` wraps in try/catch), and the whole stack above it was already built to fail gracefully — `Client::authorize()` returns `string|WP_Error` and the admin handler turns that into a settings notice. Only `generate_key()` short-circuited that with a fatal.

**The fix:**
- `DPoP::generate_key()` now returns `array|WP_Error`, guards both `openssl_pkey_new() === false` and `openssl_pkey_get_details() === false`, and returns a clear, user-facing error.
- Removed a dead `openssl_pkey_export()` call writing to an unused `$pem` (it was line 36 in the trace and served no purpose — the PEM is rebuilt from the JWK in `sign_es256()`).
- `Client::authorize()` propagates the `WP_Error`; `Admin::sanitize_handle()` already renders it via `add_settings_error()`.

Instead of a white-screen fatal, the admin now sees: *"Could not create the secure key needed to connect to Bluesky. Your site's server is missing OpenSSL elliptic-curve (EC) support — please ask your host to enable it."*

Surfaced via the WordPress Playground demo (#116), whose php-wasm OpenSSL can't generate EC keys — but this protects any constrained build (FIPS-restricted, stripped, etc.), not just Playground.

### Other information:

- [x] Have you written new tests for your changes, if applicable? — Added `assertNotWPError` to the happy-path DPoP test to lock in the new contract. The failure branches can't be triggered on a healthy CI OpenSSL build (would require mocking global functions), so they're covered by inspection rather than an automated repro.

## Testing instructions:

* `npm run env-test -- --filter='Test_DPoP'` — all DPoP tests pass.
* Healthy host: connecting a handle still works exactly as before (returns a JWK, proceeds to OAuth).
* To see the graceful path without a constrained OpenSSL build: temporarily make `generate_key()` return a `WP_Error` and submit a handle under **Settings → ATmosphere** — confirm a settings-error notice appears instead of a fatal.

### Changelog entry

Added in `.github/changelog/fix-dpop-keygen-fatal` (Patch / Fixed).
