### PR TITLE
Add Code of Conduct, Contributing, and Security policy

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people.
+* Being respectful of differing opinions, viewpoints, and experiences.
+* Giving and gracefully accepting constructive feedback.
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience.
+* Focusing on what is best not just for us as individuals, but for the
+  overall community.
+* Contributing constructive, concise, and actionable feedback that helps improve the project.
+* Keeping contributions relevant to the plugin's purpose and scope.
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind.
+* Trolling, insulting or derogatory comments, and personal or political attacks.
+* Public or private harassment.
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission.
+* Submitting off-topic issues, excessive feature requests, or contributions
+  that don't align with the project's goals.
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting.
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<https://developer.wordpress.com/contact/?g21-subject=Code%20of%20Conduct>.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to ATmosphere
+
+👍🎉 First off, thanks for taking the time to contribute! 🎉👍
+
+Developers of all levels can help — whether you can barely recognize a filter (or don’t know what that means) or you’ve already authored your own plugins, there are ways for you to pitch in.
+
+## Create Bug Reports
+
+If you find a bug, please use our [bug report form](https://github.com/Automattic/wordpress-atmosphere/issues/new?template=bug_report.yml). This helps us gather the information we need efficiently.
+
+**Keep your bug reports focused and actionable:**
+- Include specific steps to reproduce the issue.
+- Provide the URL of the page that has the bug.
+- Describe what you expected to see and what happened instead.
+- Stay within the plugin's scope—issues unrelated to ATmosphere functionality may be closed.
+
+If you have write access, add the appropriate labels.
+
+## Write and submit a patch
+
+If you'd like to fix a bug or make an enhancement, you can submit a Pull Request. Before you get started, you'll want to **[set up your development environment.](docs/development-environment.md)**
+
+Once your development environment is ready, you can get started and [create your first Pull Request!](docs/pull-request.md)
+
+### Get started
+
+If you'd like to contribute but don't know where to get started, you can take a look at existing issues:
+
+- ["Good First Issues"](https://github.com/Automattic/wordpress-atmosphere/labels/%5BType%5D%20Good%20First%20Issue) are a good entry point to get familiar with the ATmosphere plugin's code base.
+- All issues labeled with [the "Good For Community" label](https://github.com/Automattic/wordpress-atmosphere/issues?q=is%3Aopen+sort%3Aupdated-desc+label%3A%22Good+For+Community%22) are fair game. That's a great way to contribute new features and fix small issues within the ATmosphere plugin.
+
+### We're Here To Help
+
+We encourage you to ask for help at any point. We want your first experience with the ATmosphere plugin to be a good one, so don't be shy.
+
+**For questions and discussions:**
+- Use [GitHub Discussions](https://github.com/Automattic/wordpress-atmosphere/discussions) for feature ideas, general questions, and open-ended topics.
+- Create issues only for specific bugs or concrete enhancement proposals.
+- Keep questions concise and directly related to the plugin.
+
+This helps us organize feedback effectively and ensures your questions get the right attention.
+
+## Translate the plugin
+
+If you speak a foreign language, you can help translate the ATmosphere plugin into your own language. [Here is how to get started with translating.](docs/translations.md)
+
+## License
+
+The ATmosphere plugin is licensed under the [GPL-2.0-or-later](https://github.com/Automattic/wordpress-atmosphere/blob/trunk/LICENSE) license.
+
+All materials contributed should be compatible with the GPLv2 license. This means that if you own the material, you agree to license it under the GPLv2 (or later) license. If you are contributing code that is not your own, such as adding a component from another Open Source project, or adding an `npm` package, you need to make sure you follow these steps:
+
+1. Check that the code has a license. If you can't find one, you can try to contact the original author and get permission to use, or ask them to release under a compatible Open Source license.
+2. Check the license is compatible with [GPLv2](http://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses), noting that the Apache 2.0 license is *not* compatible with GPLv2.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+Full details of the Automattic Security Policy can be found on [automattic.com](https://automattic.com/security/).
+
+## Supported Versions
+
+Generally, only the latest version of the ATmosphere plugin has continued support. If a critical vulnerability is found in the current version of the ATmosphere plugin, we may opt to backport any patches to previous versions.
+
+## Reporting a Vulnerability
+
+[ATmosphere](https://wordpress.org/plugins/atmosphere/) is an open-source plugin for WordPress. Our HackerOne program covers the plugin software, as well as a variety of related projects and infrastructure.
+
+**For responsible disclosure of security issues and to be eligible for our bug bounty program, please submit your report via the [HackerOne](https://hackerone.com/automattic) portal.**
+
+Our most critical targets are:
+
+* ATmosphere plugin (all within this repo)
+* wordpress.com -- hosted offering on WordPress.com.
+
+For more targets, see the `In Scope` section on [HackerOne](https://hackerone.com/automattic).
+
+_Please note that the **WordPress software is a separate entity** from Automattic. Please report vulnerabilities for WordPress through [the WordPress Foundation's HackerOne page](https://hackerone.com/wordpress)._
+
+## Guidelines
+
+We're committed to working with security researchers to resolve the vulnerabilities they discover. You can help us by following these guidelines:
+
+*   Follow [HackerOne's disclosure guidelines](https://www.hackerone.com/disclosure-guidelines).
+*   Pen-testing Production:
+    *   Please **setup a local environment** instead whenever possible. Most of our code is open source (see above).
+    *   If that's not possible, **limit any data access/modification** to the bare minimum necessary to reproduce a PoC.
+    *   **_Don't_ automate form submissions!** That's very annoying for us, because it adds extra work for the volunteers who manage those systems, and reduces the signal/noise ratio in our communication channels.
+    *   To be eligible for a bounty, all of these guidelines must be followed.
+*   Be Patient - Give us a reasonable time to correct the issue before you disclose the vulnerability.
+
+We also expect you to comply with all applicable laws. You're responsible to pay any taxes associated with your bounties.


### PR DESCRIPTION
## Proposed changes:

Adds the GitHub community-health files ATmosphere was missing, so the repo's **Community Standards** checklist is satisfied. All three are adapted from the sibling [ActivityPub plugin](https://github.com/Automattic/wordpress-activitypub):

- **`CODE_OF_CONDUCT.md`** — the stock Contributor Covenant (verbatim from ActivityPub; no plugin-specific text). Enforcement reports go to Automattic's existing WordPress.com contact form.
- **`CONTRIBUTING.md`** — adapted to ATmosphere: repo URLs, the bug-report form, dev-environment / pull-request / translation doc links, and **GPL-2.0-or-later** licensing (ActivityPub is MIT; ATmosphere is GPL, per `readme.txt` and `atmosphere.php`).
- **`SECURITY.md`** — Automattic's HackerOne program and security policy, with targets pointed at the ATmosphere plugin and `wordpress.org/plugins/atmosphere/`.

### Already in place (no change needed)

- **License** — `LICENSE` already exists (full GPL-2.0 text).
- **Issue templates** — `bug_report.yml` / `feature_request.yml` already match ActivityPub's (already adapted to "ATmosphere").
- **Pull request template** — `.github/PULL_REQUEST_TEMPLATE.md` already present.

### Out of scope (not a file)

- **"Repository admins accept content reports"** is a GitHub repo *setting* (Settings → Moderation/Reports), not a committed file — a repo admin needs to toggle it.

### Note

GitHub currently detects the license as "Other" rather than "GPL-2.0" because `LICENSE` has a custom copyright preamble before the canonical GPL text. Left untouched here (it's valid legal text); can be normalized in a follow-up if we want the green "License: GPL-2.0" badge.

### Other information:

- [ ] Have you written new tests for your changes, if applicable? — N/A (documentation only).

## Testing instructions:

* Browse the three new files on the branch and confirm links resolve to this repo (`Automattic/wordpress-atmosphere`) and to existing `docs/` files.
* After merge, check **Insights → Community Standards** — Code of conduct, Contributing, and Security policy should now show as complete.

### Changelog entry

No changelog entry — documentation / `.github` community files, not user-facing plugin code. Please apply the **Skip Changelog** label.
