### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install subversion
       - name: WordPress Plugin Deploy
-        uses: 10up/action-wordpress-plugin-deploy@stable
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
         env:
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/extract-wp-hooks.yml
+++ b/.github/workflows/extract-wp-hooks.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write # Required to push to wiki repository
     steps:
       - uses: actions/checkout@v6
-      - uses: akirk/extract-wp-hooks@1.4.0
+      - uses: akirk/extract-wp-hooks@c0b59d9607347a0390627756c095c52d5f98016a # 1.4.0
         with:
           namespace: 'Atmosphere'
           wiki-directory: '../wordpress-atmosphere.wiki'

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: lts/*
 
       - name: Wait for prior instances of the workflow to finish
-        uses: softprops/turnstyle@v3
+        uses: softprops/turnstyle@fa86562458e34a9067f0dc1316a76b3975b1c413 # v3.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -26,14 +26,14 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '8.2'
           coverage: none
           tools: composer
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@5c2bcf28d7b060ef3c601d7b476d5430a7b46c27 # v4
 
       - name: Detect coding standard violations
         run: ./vendor/bin/phpcs

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: ${{ matrix.php-versions }}
           coverage: none
@@ -53,7 +53,7 @@ jobs:
           extensions: mysql
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@5c2bcf28d7b060ef3c601d7b476d5430a7b46c27 # v4
 
       - name: Setup Test Environment
         run: bash ./bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 ${{ matrix.wp-version }}


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

This is a draft PR for review before merging. It was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 5
- Repo-level unpinned usage count from the trunk recheck: 7
- Dependabot GitHub Actions coverage: already_present (.github/dependabot.yml)


Known label limitations:
- `ramsey/composer-install` keeps `# v4` because the existing `v4` ref resolves to this commit; specific `4.x` tags point to different commits.

Verification commands:

```bash
# 10up/action-wordpress-plugin-deploy # 2.3.0 -> 54bd289b8525fd23a5c365ec369185f2966529c2
gh api repos/10up/action-wordpress-plugin-deploy/commits/2.3.0 --jq '.sha'
# expected: 54bd289b8525fd23a5c365ec369185f2966529c2

# akirk/extract-wp-hooks # 1.4.0 -> c0b59d9607347a0390627756c095c52d5f98016a
gh api repos/akirk/extract-wp-hooks/commits/1.4.0 --jq '.sha'
# expected: c0b59d9607347a0390627756c095c52d5f98016a

# ramsey/composer-install # v4 -> 5c2bcf28d7b060ef3c601d7b476d5430a7b46c27
gh api repos/ramsey/composer-install/commits/v4 --jq '.sha'
# expected: 5c2bcf28d7b060ef3c601d7b476d5430a7b46c27

# shivammathur/setup-php # 2.37.1 -> 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
gh api repos/shivammathur/setup-php/commits/2.37.1 --jq '.sha'
# expected: 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc

# softprops/turnstyle # v3.3.1 -> fa86562458e34a9067f0dc1316a76b3975b1c413
gh api repos/softprops/turnstyle/commits/v3.3.1 --jq '.sha'
# expected: fa86562458e34a9067f0dc1316a76b3975b1c413
```
