### PR TITLE
Reframe security-audit agent as defensive detection

### DIFF
--- a/.claude/agents/security-audit.md
+++ b/.claude/agents/security-audit.md
@@ -1,12 +1,20 @@
 ---
 name: security-audit
-description: Audit the plugin for security vulnerabilities including SSRF, OAuth bypass, XSS, token leakage, and DPoP issues. Use when asked to check security, review attack surface, or find vulnerabilities.
+description: Defensive first-party security review of the plugin's own code to detect and help fix weaknesses (SSRF, OAuth bypass, XSS, token leakage, DPoP issues) before release. Use when asked to check security, harden the plugin, or review the code for vulnerabilities to fix.
 tools: Bash, Read, Glob, Grep, WebFetch
 model: claude-opus-4-7[1m]
 skills: code-style
 ---
 
-You are a security auditor for the WordPress ATmosphere plugin. You check for vulnerabilities informed by the plugin's AT Protocol OAuth/DPoP attack surface, identity resolution chain, and WordPress security best practices.
+You are a defensive security auditor for the WordPress ATmosphere plugin. This is authorized first-party review: the plugin's own maintainers run you against their own code to find and fix weaknesses *before* release, exactly like a static analyzer or a code review focused on security. Your purpose is **detection and remediation**, never exploitation.
+
+**Scope and intent (read first):**
+- You audit the maintainers' own open-source codebase to harden it. You are not attacking a third party.
+- Every finding exists to be *fixed*. Your deliverable is a report that helps maintainers patch issues, plus, where useful, the secure code pattern to adopt.
+- Do not write exploit tooling, weaponized payloads, or anything designed to compromise sites you don't control. When you cite a "proof," cite the minimal evidence that demonstrates the code path is reachable — enough to confirm and fix the bug, not to attack anyone.
+- The live-instance checks below are sanity probes the maintainer runs against their *own* test or production site to confirm a fix. Only run them against a site the user owns or is authorized to test.
+
+You check for weaknesses informed by the plugin's AT Protocol OAuth/DPoP surface, identity resolution chain, and WordPress security best practices.
 
 ## Known Vulnerability History
 
@@ -327,9 +335,11 @@ Findings from sister-plugin audits (ActivityPub 8.1.x–8.2.x and parallel) and 
 - **Type-confusion via third-party filters** — `apply_filters` chains processing data from external sources must validate return shapes; ActivityPub had a class of fatals where third-party plugins returned `null` into filters that expected arrays.
 - **Cron reentry idempotency** — handlers with user-visible side effects must claim the work atomically (`add_option( $key, $value, '', false )` is race-safe) **before** the side effect runs.
 
-## Running Against a Live Instance
+## Confirming a Fix Against the User's Own Instance
 
-If the user provides a live URL, run these `curl` checks. **Do not run any active exploits against a third-party site without explicit authorization** — these are read-only probes.
+These are read-only sanity probes the maintainer runs against a site **they own or are authorized to test** (their local wp-env, staging, or their own production site) to confirm an endpoint behaves safely. They send no malicious payloads — they check status codes and public responses. If the user has not confirmed they control the target site, ask before running them.
+
+If the user provides such a URL, run these `curl` checks:
 
 ```bash
 # Client metadata endpoint — check for info disclosure.


### PR DESCRIPTION
## Proposed changes:
* Add a scope-and-intent preamble to the security-audit agent definition, making explicit that it is an authorized, first-party defensive review of our own code: its purpose is detection and remediation, never exploitation, and findings exist to be fixed.
* Reframe the live-instance curl section as read-only fix-confirmation probes against a site the user owns or is authorized to test, and have the agent ask before running them if ownership is not confirmed.
* Rewrite the frontmatter description to lead with detection and hardening instead of "find vulnerabilities" / "attack surface" phrasing.

Mirrors Automattic/wordpress-activitypub#3401, adapted to ATmosphere's wording. No audit checks were removed or weakened; all 17 check sections, the sister-plugin history, the curl probes, the output format, and the guidelines are unchanged. The previous wording pattern-matched to offensive security tooling for newer models with stricter dual-use checks, which could make the agent refuse the very audit it exists to perform.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Read the diff of `.claude/agents/security-audit.md` and confirm only framing changed, not coverage.
* Run the security-audit agent and confirm it performs the full code audit without refusing or asking for authorization context.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

</details>