### PR TITLE
Exclude meta docs from release archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,6 +23,9 @@
 /CLAUDE.md        export-ignore
 /AGENTS.md        export-ignore
 /README.md        export-ignore
+/CODE_OF_CONDUCT.md export-ignore
+/CONTRIBUTING.md  export-ignore
+/SECURITY.md      export-ignore
 
 # GitHub linguist attributes
 /docs/**           linguist-documentation


### PR DESCRIPTION
## Proposed changes:
* Add `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, and `SECURITY.md` to the `export-ignore` list in `.gitattributes` so they no longer ship in release archives.

These three files were added in #119 without updating the exclusion list, while their siblings (`README.md`, `CHANGELOG.md`, `AGENTS.md`) were already excluded. They are repository meta docs with no value inside the plugin zip. `LICENSE` and `readme.txt` intentionally remain in the archive.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Run `git archive --worktree-attributes HEAD | tar -t` on this branch.
* Confirm the output outside `includes/`, `assets/`, `templates/`, and `integrations/` is exactly: `LICENSE`, `atmosphere.php`, `readme.txt`, `uninstall.php`.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

</details>