### PR TITLE
Never log exception messages from DPoP proof generation

### DIFF
--- a/.github/changelog/fix-dpop-exception-message-logging
+++ b/.github/changelog/fix-dpop-exception-message-logging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Hardened error logging so details from cryptographic failures are never written to the log.

--- a/includes/oauth/class-dpop.php
+++ b/includes/oauth/class-dpop.php
@@ -135,23 +135,24 @@ class DPoP {
 
 			return self::sign_es256( $header, $payload, $jwk );
 		} catch ( \Throwable $e ) {
-			/*
-			 * Never log $e->getMessage() here: the exception is thrown
-			 * with the private-key JWK in scope, and OpenSSL error
-			 * strings are not guaranteed to be free of key material.
-			 * Class name and throw site are enough to debug with.
-			 */
-			\wp_trigger_error(
-				__METHOD__,
-				\sprintf(
-					'DPoP proof generation failed: %s at %s:%d',
-					$e::class,
-					\basename( $e->getFile() ),
-					$e->getLine()
-				)
-			);
+			\wp_trigger_error( __METHOD__, 'DPoP proof generation failed: ' . self::describe_throwable( $e ) );
 			return false;
 		}
+	}
+
+	/**
+	 * Summarize a throwable for logging without its message.
+	 *
+	 * Signing failures are thrown with the private-key JWK in scope,
+	 * and OpenSSL error strings are not guaranteed to be free of key
+	 * material — so only the class name and throw site are safe to
+	 * log. Never add getMessage() here.
+	 *
+	 * @param \Throwable $e Caught throwable.
+	 * @return string Class name plus file:line of the throw site.
+	 */
+	private static function describe_throwable( \Throwable $e ): string {
+		return \sprintf( '%s at %s:%d', $e::class, \basename( $e->getFile() ), $e->getLine() );
 	}
 
 	/**

--- a/includes/oauth/class-dpop.php
+++ b/includes/oauth/class-dpop.php
@@ -135,7 +135,21 @@ class DPoP {
 
 			return self::sign_es256( $header, $payload, $jwk );
 		} catch ( \Throwable $e ) {
-			\wp_trigger_error( __METHOD__, 'DPoP proof generation failed: ' . $e->getMessage() );
+			/*
+			 * Never log $e->getMessage() here: the exception is thrown
+			 * with the private-key JWK in scope, and OpenSSL error
+			 * strings are not guaranteed to be free of key material.
+			 * Class name and throw site are enough to debug with.
+			 */
+			\wp_trigger_error(
+				__METHOD__,
+				\sprintf(
+					'DPoP proof generation failed: %s at %s:%d',
+					$e::class,
+					\basename( $e->getFile() ),
+					$e->getLine()
+				)
+			);
 			return false;
 		}
 	}

--- a/includes/oauth/class-dpop.php
+++ b/includes/oauth/class-dpop.php
@@ -135,7 +135,10 @@ class DPoP {
 
 			return self::sign_es256( $header, $payload, $jwk );
 		} catch ( \Throwable $e ) {
-			\wp_trigger_error( __METHOD__, 'DPoP proof generation failed: ' . self::describe_throwable( $e ) );
+			// wp_trigger_error() requires WP 6.4; the plugin supports 6.2.
+			if ( \function_exists( 'wp_trigger_error' ) ) {
+				\wp_trigger_error( __METHOD__, 'DPoP proof generation failed: ' . self::describe_throwable( $e ) );
+			}
 			return false;
 		}
 	}

--- a/tests/phpunit/tests/class-test-dpop.php
+++ b/tests/phpunit/tests/class-test-dpop.php
@@ -127,6 +127,60 @@ class Test_DPoP extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that create_proof() returns false when its try block throws.
+	 *
+	 * Omitting the nonce argument routes create_proof() through the
+	 * Nonce_Storage transient lookup inside its try block — the only
+	 * injectable throw site — so the short-circuit filter below forces
+	 * the catch path to run.
+	 */
+	public function test_create_proof_returns_false_when_nonce_lookup_throws() {
+		$jwk = DPoP::generate_key();
+		$url = 'https://pds.example.com/xrpc/test';
+
+		\add_filter(
+			'pre_transient_atmo_dpop_nonce_' . \md5( \Atmosphere\get_did() . '|' . $url ),
+			static function () {
+				throw new \RuntimeException( 'boom' );
+			}
+		);
+
+		// Swallow the E_USER_NOTICE wp_trigger_error() raises under WP_DEBUG.
+		\set_error_handler( '__return_true', E_USER_NOTICE ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+		try {
+			$result = DPoP::create_proof( $jwk, 'POST', $url );
+		} finally {
+			\restore_error_handler();
+		}
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that the logged throwable summary never includes the message.
+	 *
+	 * The create_proof() catch block runs with the private-key JWK in
+	 * scope, so the line it logs must carry only the exception class and
+	 * throw site — never the exception message, which is not guaranteed
+	 * to be free of key material.
+	 */
+	public function test_throwable_log_description_omits_message() {
+		$marker    = 'd=base64url-private-key-material';
+		$exception = new \RuntimeException( $marker );
+
+		$method      = new \ReflectionMethod( DPoP::class, 'describe_throwable' );
+		$description = $method->invoke( null, $exception );
+
+		$this->assertStringContainsString( 'RuntimeException', $description );
+		$this->assertStringContainsString( \basename( __FILE__ ) . ':', $description );
+		$this->assertStringNotContainsString(
+			$marker,
+			$description,
+			'Exception messages must never reach the log from the DPoP signing path.'
+		);
+	}
+
+	/**
 	 * Base64url decode helper.
 	 *
 	 * @param string $data Base64url-encoded string.


### PR DESCRIPTION
## Proposed changes:
* Stop logging `$e->getMessage()` from the catch block in `DPoP::create_proof()`. The exception is thrown with the private-key JWK in scope, and OpenSSL error strings are not guaranteed to be free of key material; the log line is visible under `WP_DEBUG` and on stderr.
* Log a safe summary instead — exception class plus `basename(file):line` of the throw site — built by a new `describe_throwable()` helper whose docblock forbids reintroducing the message.
* Cover the catch path with a test that throws from the nonce-transient lookup, and pin the no-message property directly on the helper (the wp-env tests environment runs with `WP_DEBUG` off, so the logged line is not observable end-to-end there).

Addresses finding ATM-M-05 from the in-house security audit. This is hardening — there is no known case of key material in these messages today.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Run `npm run env-test -- --filter=Test_DPoP` — all 7 tests pass, including the two new ones.
* Read the diff of `includes/oauth/class-dpop.php` and confirm the catch block no longer references `getMessage()`.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

</details>