### PR TITLE
Detach the scoped allowed_redirect_hosts filter even when the redirect throws

### DIFF
--- a/.github/changelog/fix-scope-redirect-hosts-filter
+++ b/.github/changelog/fix-scope-redirect-hosts-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Hardened the Bluesky connect flow so a redirect interruption cannot loosen redirect safety checks for the rest of the request.

--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -72,7 +72,9 @@ class Sanitize {
 		 * so it can't affect any subsequent redirect — the `exit`
 		 * makes that production-redundant, but pinning the invariant
 		 * here keeps it intact if a test or a `wp_die()` handler ever
-		 * intercepts the redirect before `exit` fires.
+		 * intercepts the redirect before `exit` fires. The `finally`
+		 * guarantees detachment even when a `wp_redirect` filter throws
+		 * instead of returning.
 		 */
 		$auth_host   = \is_string( $auth_url ) ? \wp_parse_url( $auth_url, PHP_URL_HOST ) : '';
 		$auth_scheme = \is_string( $auth_url ) ? \wp_parse_url( $auth_url, PHP_URL_SCHEME ) : '';
@@ -92,8 +94,11 @@ class Sanitize {
 		};
 
 		\add_filter( 'allowed_redirect_hosts', $allow_auth_host );
-		\wp_safe_redirect( $auth_url );
-		\remove_filter( 'allowed_redirect_hosts', $allow_auth_host );
+		try {
+			\wp_safe_redirect( $auth_url );
+		} finally {
+			\remove_filter( 'allowed_redirect_hosts', $allow_auth_host );
+		}
 		exit;
 	}
 

--- a/tests/phpunit/tests/wp-admin/class-test-sanitize-handle.php
+++ b/tests/phpunit/tests/wp-admin/class-test-sanitize-handle.php
@@ -254,6 +254,37 @@ class Test_Sanitize_Handle extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A throwing `wp_redirect` filter must not leave the auth-server
+	 * host attached to `allowed_redirect_hosts` for the rest of the
+	 * request. The redirect is wrapped in try/finally so the scoped
+	 * filter is detached on the exception path, too.
+	 */
+	public function test_allowed_redirect_hosts_filter_is_removed_when_redirect_throws(): void {
+		$this->become_admin();
+		$this->stub_resolver_chain( 'https://auth.example.com/oauth/authorize' );
+
+		$this->add_filter_tracked(
+			'wp_redirect',
+			static function () {
+				throw new WPDieException( 'redirect_intercepted' );
+			}
+		);
+
+		try {
+			Sanitize::handle( 'alice.bsky-test-handle.io' );
+			$this->fail( 'Expected redirect to be intercepted.' );
+		} catch ( WPDieException $e ) {
+			$this->assertSame( 'redirect_intercepted', $e->getMessage() );
+		}
+
+		$this->assertNotContains(
+			'auth.example.com',
+			\apply_filters( 'allowed_redirect_hosts', array(), '' ),
+			'The scoped allowed_redirect_hosts filter must be detached even when the redirect throws.'
+		);
+	}
+
+	/**
 	 * A leading "@" is stripped before resolution. People copy handles
 	 * from Bluesky as "@alice.bsky.social", but the resolver rejects the
 	 * "@"-prefixed form as an invalid DNS-style identifier. If the "@"


### PR DESCRIPTION
## Proposed changes:
* Wrap the `wp_safe_redirect()` call in `Sanitize::handle()` in `try`/`finally` so the scoped `allowed_redirect_hosts` filter is detached even when a `wp_redirect` filter throws instead of returning (a test interceptor or a custom `wp_die` handler). Previously the exception propagated past `remove_filter()`, leaving the auth-server host allowed for any later redirect in the same request.
* Add a regression test that throws from the `wp_redirect` filter and asserts the host is no longer in `allowed_redirect_hosts` afterwards — it fails on trunk and passes with the fix.

Addresses finding ATM-M-07 from the in-house security audit. Production behavior on the happy path is unchanged (`exit` still ends the request).

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Run `npm run env-test -- --filter=Test_Sanitize_Handle` — all 5 tests pass, including the new one.
* Optionally revert the `includes/class-sanitize.php` hunk and re-run: the new test fails with `auth.example.com` still present in `allowed_redirect_hosts`.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

</details>