### PR TITLE
Judge the percent-decoded host in the URL safety gate

### DIFF
--- a/.github/changelog/fix-decode-host-in-url-safety-gate
+++ b/.github/changelog/fix-decode-host-in-url-safety-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Hardened the Bluesky server address checks to also catch unsafe addresses hidden behind URL encoding.

--- a/includes/oauth/class-resolver.php
+++ b/includes/oauth/class-resolver.php
@@ -421,10 +421,16 @@ class Resolver {
 	 *    `authorization_endpoint` URL is handed straight to
 	 *    `wp_redirect()` with no host-safety net at all. Rejecting IP
 	 *    literals here closes both gaps in one place.
-	 *  - host carries no percent-encoding — the IP check judges the
-	 *    decoded form (`%31%32%37.0.0.1` is `127.0.0.1`), and a host
-	 *    still containing `%` after one decode pass is rejected as
-	 *    double-encoding.
+	 *  - the IP check judges the percent-decoded host, so an IP literal
+	 *    hidden behind one pass of encoding (`%31%32%37.0.0.1` is
+	 *    `127.0.0.1`) is still caught. A host that still contains `%`
+	 *    after that pass is rejected as double-encoding.
+	 *  - the decoded host contains no URL-structure delimiters
+	 *    (`@`, `:`, `/`, `?`, `#`, whitespace). Decoding can turn
+	 *    `user%40127.0.0.1` into `user@127.0.0.1`, which a downstream
+	 *    parser reinterprets as `userinfo@host`, routing to loopback
+	 *    with attacker-supplied credentials — the same smuggling the
+	 *    IP-literal decode closes, via the userinfo/port grammar.
 	 *  - no embedded `user:pass@` credentials (a known URL-injection
 	 *    vector that would otherwise be carried into the persisted
 	 *    connection)
@@ -476,6 +482,19 @@ class Resolver {
 		 */
 		$host_candidate = \trim( $host_candidate, '[]' );
 		if ( false !== \filter_var( $host_candidate, FILTER_VALIDATE_IP ) ) {
+			return false;
+		}
+
+		/*
+		 * Reject decoded hosts carrying URL-structure delimiters. A
+		 * bare DNS hostname never contains `@`, `/`, `?`, `#`, `:`, or
+		 * whitespace; if decoding produced one, a downstream parser can
+		 * reinterpret the URL — `user@127.0.0.1` as userinfo + host,
+		 * `host:1` as host + port — and route somewhere this gate never
+		 * vetted. (A legitimate IPv6 literal also contains `:`, but
+		 * those were already rejected by the IP check above.)
+		 */
+		if ( \preg_match( '#[@:/?\#\s]#', $host_candidate ) ) {
 			return false;
 		}
 

--- a/includes/oauth/class-resolver.php
+++ b/includes/oauth/class-resolver.php
@@ -421,6 +421,10 @@ class Resolver {
 	 *    `authorization_endpoint` URL is handed straight to
 	 *    `wp_redirect()` with no host-safety net at all. Rejecting IP
 	 *    literals here closes both gaps in one place.
+	 *  - host carries no percent-encoding — the IP check judges the
+	 *    decoded form (`%31%32%37.0.0.1` is `127.0.0.1`), and a host
+	 *    still containing `%` after one decode pass is rejected as
+	 *    double-encoding.
 	 *  - no embedded `user:pass@` credentials (a known URL-injection
 	 *    vector that would otherwise be carried into the persisted
 	 *    connection)
@@ -451,12 +455,26 @@ class Resolver {
 		}
 
 		/*
+		 * Percent-decode before validating: the gate sees the host as
+		 * parsed, but any layer that normalizes the URL after this
+		 * check (cURL, a proxy, a redirect target) may decode
+		 * `%31%32%37.0.0.1` back to `127.0.0.1`. A legitimate hostname
+		 * never carries a `%` — percent-encoded reg-names don't
+		 * survive DNS — so any `%` remaining after one decode pass
+		 * (i.e. double-encoding) is rejected outright.
+		 */
+		$host_candidate = \rawurldecode( $parts['host'] );
+		if ( false !== \strpos( $host_candidate, '%' ) ) {
+			return false;
+		}
+
+		/*
 		 * PHP's parse_url() preserves the brackets around IPv6 hosts
 		 * (host is `[::1]` for `https://[::1]/`), and
 		 * FILTER_VALIDATE_IP rejects bracketed forms — strip them
-		 * before validating.
+		 * after decoding so encoded brackets are covered too.
 		 */
-		$host_candidate = \trim( $parts['host'], '[]' );
+		$host_candidate = \trim( $host_candidate, '[]' );
 		if ( false !== \filter_var( $host_candidate, FILTER_VALIDATE_IP ) ) {
 			return false;
 		}

--- a/tests/phpunit/tests/oauth/class-test-resolver.php
+++ b/tests/phpunit/tests/oauth/class-test-resolver.php
@@ -495,6 +495,50 @@ class Test_Resolver extends WP_UnitTestCase {
 	}
 
 	/**
+	 * `pds_from_did_doc` rejects HTTPS URLs whose host hides an IP
+	 * literal behind percent-encoding. The gate validates the host as
+	 * parsed, but any layer that normalizes the URL afterwards (cURL,
+	 * a proxy, a redirect) may decode `%31%32%37.0.0.1` back to
+	 * `127.0.0.1` — so the gate has to judge the decoded form.
+	 *
+	 * @dataProvider provide_pct_encoded_ip_endpoints
+	 *
+	 * @param string $endpoint serviceEndpoint URL under test.
+	 */
+	public function test_pds_from_did_doc_rejects_pct_encoded_ip_endpoint( string $endpoint ) {
+		$did_doc = array(
+			'id'      => 'did:plc:test',
+			'service' => array(
+				array(
+					'id'              => '#atproto_pds',
+					'type'            => 'AtprotoPersonalDataServer',
+					'serviceEndpoint' => $endpoint,
+				),
+			),
+		);
+
+		$result = Resolver::pds_from_did_doc( $did_doc );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'atmosphere_unsafe_pds', $result->get_error_code() );
+	}
+
+	/**
+	 * Data provider — percent-encoded IP-literal hosts that must never
+	 * be accepted as a PDS / auth-server endpoint.
+	 *
+	 * @return array<string, array{0:string}>
+	 */
+	public function provide_pct_encoded_ip_endpoints(): array {
+		return array(
+			'encoded-ipv4-loopback' => array( 'https://%31%32%37.0.0.1' ),
+			'partially-encoded'     => array( 'https://127.0.0.%31' ),
+			'encoded-ipv6-loopback' => array( 'https://[%3A%3A1]' ),
+			'double-encoded'        => array( 'https://%2531%2532%2537.0.0.1' ),
+		);
+	}
+
+	/**
 	 * `pds_from_did_doc` rejects a `serviceEndpoint` that contains
 	 * embedded HTTP credentials. URLs with `user:pass@host` are a
 	 * known injection vector — the credentials would otherwise be

--- a/tests/phpunit/tests/oauth/class-test-resolver.php
+++ b/tests/phpunit/tests/oauth/class-test-resolver.php
@@ -539,6 +539,51 @@ class Test_Resolver extends WP_UnitTestCase {
 	}
 
 	/**
+	 * `pds_from_did_doc` rejects HTTPS URLs whose host hides a URL
+	 * delimiter behind percent-encoding. `wp_parse_url()` leaves the
+	 * delimiter encoded — so `user`/`pass` stay unset and the host
+	 * isn't a bare IP — but a downstream layer that decodes the host
+	 * reinterprets `user%40127.0.0.1` as `userinfo@host` (routing to
+	 * loopback) or `127.0.0.1%3A443` as `host:port`.
+	 *
+	 * @dataProvider provide_pct_encoded_delimiter_endpoints
+	 *
+	 * @param string $endpoint serviceEndpoint URL under test.
+	 */
+	public function test_pds_from_did_doc_rejects_pct_encoded_delimiter_endpoint( string $endpoint ) {
+		$did_doc = array(
+			'id'      => 'did:plc:test',
+			'service' => array(
+				array(
+					'id'              => '#atproto_pds',
+					'type'            => 'AtprotoPersonalDataServer',
+					'serviceEndpoint' => $endpoint,
+				),
+			),
+		);
+
+		$result = Resolver::pds_from_did_doc( $did_doc );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'atmosphere_unsafe_pds', $result->get_error_code() );
+	}
+
+	/**
+	 * Data provider — percent-encoded URL-delimiter hosts that must
+	 * never be accepted as a PDS / auth-server endpoint.
+	 *
+	 * @return array<string, array{0:string}>
+	 */
+	public function provide_pct_encoded_delimiter_endpoints(): array {
+		return array(
+			'encoded-userinfo-at' => array( 'https://user%40127.0.0.1' ),
+			'encoded-port-colon'  => array( 'https://127.0.0.1%3A443' ),
+			'encoded-path-slash'  => array( 'https://evil.example%2Fpds.lan' ),
+			'encoded-query-mark'  => array( 'https://evil.example%3Ffoo=bar.lan' ),
+		);
+	}
+
+	/**
 	 * `pds_from_did_doc` rejects a `serviceEndpoint` that contains
 	 * embedded HTTP credentials. URLs with `user:pass@host` are a
 	 * known injection vector — the credentials would otherwise be


### PR DESCRIPTION
## Proposed changes:
* `Resolver::is_safe_https_url()` validated the host exactly as parsed, so an IP literal hidden behind percent-encoding (`https://%31%32%37.0.0.1` is `127.0.0.1` to any layer that normalizes the URL after the gate) passed the safety check.
* The gate now percent-decodes the host once before the IP-literal check, and rejects any host still carrying a `%` after that pass — a legitimate DNS hostname never contains one, so anything left is double-encoding or garbage.
* Four new data-provider test cases (encoded IPv4, partially encoded, bracketed-encoded IPv6, double-encoded) — all four pass the gate on trunk and are rejected with this fix.

Addresses finding ATM-M-03 from the in-house security audit. All consumers of the gate (PDS endpoint, issuer, token/authorization/PAR/revocation endpoints) inherit the fix automatically.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Run `npm run env-test -- --filter=Test_Resolver` — all tests pass, including the four new `pct_encoded` cases.
* Optionally revert the `includes/oauth/class-resolver.php` hunk and re-run: the four new cases fail because the encoded hosts are accepted.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

</details>