### PR TITLE
Request the ATmosphere team as reviewer when opening PRs

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -44,8 +44,11 @@ git checkout -b fix/something
 ## Opening the PR
 
 ```bash
-gh pr create --assignee @me
+# Create PR (includes required assignment/reviewer).
+gh pr create --assignee @me --reviewer Automattic/atmosphere
 ```
+
+Copilot is requested as a reviewer automatically by the trunk branch ruleset — don't add it manually.
 
 Use `.github/PULL_REQUEST_TEMPLATE.md` as-is — don't invent custom formatting. The body must include:
 

--- a/docs/pull-request.md
+++ b/docs/pull-request.md
@@ -123,12 +123,13 @@ Walk this checklist. Required checks are blocking.
 Use the template at `.github/PULL_REQUEST_TEMPLATE.md` — don't invent custom formatting.
 
 ```bash
-gh pr create --assignee @me
+gh pr create --assignee @me --reviewer Automattic/atmosphere
 ```
 
 Every PR must:
 
 - Be assigned to the author (`--assignee @me`).
+- Request review from the `Automattic/atmosphere` team (`--reviewer Automattic/atmosphere`). Copilot is requested automatically by the trunk branch ruleset.
 - Include a changelog file **or** the `Skip Changelog` label.
 - Have PHPCS + PHPUnit green.
 - Merge cleanly with `trunk`.


### PR DESCRIPTION
## Proposed changes:
* Update the `pr` skill and `docs/pull-request.md` so PRs are created with `gh pr create --assignee @me --reviewer Automattic/atmosphere`, mirroring the `Automattic/fediverse` reviewer convention in the ActivityPub repo.
* Document that Copilot review is requested automatically by the trunk branch ruleset (a `copilot_code_review` rule was added to the ruleset in repo settings, alongside this change) and must not be added manually.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Confirm this PR itself has the `Automattic/atmosphere` team requested for review and a Copilot review requested automatically by the ruleset.
* Read the diff — the command in `.agents/skills/pr/SKILL.md` and `docs/pull-request.md` stays identical.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

</details>