### PR TITLE
Resolve link facets when importing Bluesky replies as comments

### DIFF
--- a/.github/changelog/fix-comment-link-facets
+++ b/.github/changelog/fix-comment-link-facets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Links in Bluesky replies now keep their full web address when imported as comments, instead of showing a shortened, unclickable preview.

--- a/includes/class-reaction-sync.php
+++ b/includes/class-reaction-sync.php
@@ -488,8 +488,13 @@ class Reaction_Sync {
 		 * target lives only in `facets`. Resolve those byte ranges back
 		 * into anchors before the text becomes comment content; otherwise
 		 * imported replies keep the lossy, unclickable display string.
+		 *
+		 * `facets` is untrusted PDS JSON: guard the type here so a
+		 * present-but-non-array value can't fatal the typed `apply()` call
+		 * and silently kill this notification's cron sync.
 		 */
-		$text = Facet::apply( $text, $record['facets'] ?? array() );
+		$facets = $record['facets'] ?? array();
+		$text   = Facet::apply( $text, \is_array( $facets ) ? $facets : array() );
 
 		/**
 		 * Filters whether a reply should be synced as a WordPress comment.

--- a/includes/class-reaction-sync.php
+++ b/includes/class-reaction-sync.php
@@ -11,6 +11,7 @@ namespace Atmosphere;
 \defined( 'ABSPATH' ) || exit;
 
 use Atmosphere\OAuth\Client;
+use Atmosphere\Transformer\Facet;
 use Atmosphere\Transformer\Post as BskyPost;
 
 /**
@@ -480,6 +481,15 @@ class Reaction_Sync {
 		if ( '' === $text ) {
 			return false;
 		}
+
+		/*
+		 * Bluesky stores `text` as the display string — long URLs are
+		 * truncated to e.g. `bsky.app/profile/jere...` and the real
+		 * target lives only in `facets`. Resolve those byte ranges back
+		 * into anchors before the text becomes comment content; otherwise
+		 * imported replies keep the lossy, unclickable display string.
+		 */
+		$text = Facet::apply( $text, $record['facets'] ?? array() );
 
 		/**
 		 * Filters whether a reply should be synced as a WordPress comment.

--- a/includes/transformer/class-facet.php
+++ b/includes/transformer/class-facet.php
@@ -77,6 +77,103 @@ class Facet {
 	}
 
 	/**
+	 * Reassemble rich text by applying facets back onto a plain-text string.
+	 *
+	 * The inverse of {@see Facet::extract()}. AT Protocol stores a post's
+	 * `text` as the *display* string — Bluesky truncates long URLs (e.g.
+	 * `bsky.app/profile/jere...`) — while the real target lives in the
+	 * `facets` array, which maps a byte range in `text` to a feature
+	 * (link `uri`, mention `did`, or `tag`). Without this step an imported
+	 * comment keeps only the lossy display string.
+	 *
+	 * Link and mention features become anchors; tags become hashtag-search
+	 * links; the byte ranges between facets are copied through untouched.
+	 * The result is an HTML fragment intended to be passed through
+	 * `wp_kses_post()` by the caller (as the reaction-sync path does), so
+	 * only the generated `href` attributes are escaped here.
+	 *
+	 * @since unreleased
+	 *
+	 * @param string $text   Plain-text display string from the record.
+	 * @param array  $facets Facet array from the record, as stored on the PDS.
+	 * @return string Text with facets resolved to anchors.
+	 */
+	public static function apply( string $text, array $facets ): string {
+		if ( empty( $facets ) ) {
+			return $text;
+		}
+
+		\usort(
+			$facets,
+			static fn( $a, $b ) => ( $a['index']['byteStart'] ?? 0 ) <=> ( $b['index']['byteStart'] ?? 0 )
+		);
+
+		// Facet indexes are UTF-8 byte offsets, so splice in byte space.
+		$length = \strlen( $text );
+		$cursor = 0;
+		$result = '';
+
+		foreach ( $facets as $facet ) {
+			$start = $facet['index']['byteStart'] ?? null;
+			$end   = $facet['index']['byteEnd'] ?? null;
+
+			/*
+			 * Skip ranges that are malformed, empty, out of bounds, or
+			 * that overlap a facet we've already consumed. Dropping a bad
+			 * range leaves its display text in place rather than corrupting
+			 * the surrounding bytes.
+			 */
+			if ( ! \is_int( $start ) || ! \is_int( $end ) || $start < $cursor || $start >= $end || $end > $length ) {
+				continue;
+			}
+
+			$result .= \substr( $text, $cursor, $start - $cursor );
+			$result .= self::render_feature( $facet['features'][0] ?? array(), \substr( $text, $start, $end - $start ) );
+			$cursor  = $end;
+		}
+
+		return $result . \substr( $text, $cursor );
+	}
+
+	/**
+	 * Render a single facet feature around its display text.
+	 *
+	 * Unknown feature types fall back to the display text unchanged, so a
+	 * facet type we don't handle never drops the text it annotated.
+	 *
+	 * @param array  $feature Facet feature (first entry of a facet's `features`).
+	 * @param string $display Display text the facet covers.
+	 * @return string HTML fragment, or the display text unchanged.
+	 */
+	private static function render_feature( array $feature, string $display ): string {
+		switch ( $feature['$type'] ?? '' ) {
+			case 'app.bsky.richtext.facet#link':
+				$uri = $feature['uri'] ?? '';
+				if ( '' === $uri ) {
+					return $display;
+				}
+				return '<a href="' . \esc_url( $uri ) . '">' . $display . '</a>';
+
+			case 'app.bsky.richtext.facet#mention':
+				$did = $feature['did'] ?? '';
+				if ( '' === $did ) {
+					return $display;
+				}
+				return '<a href="' . \esc_url( 'https://bsky.app/profile/' . $did ) . '">' . $display . '</a>';
+
+			case 'app.bsky.richtext.facet#tag':
+				$tag = $feature['tag'] ?? '';
+				if ( '' === $tag ) {
+					return $display;
+				}
+				return '<a href="' . \esc_url( 'https://bsky.app/hashtag/' . \rawurlencode( $tag ) ) . '">' . $display . '</a>';
+
+			default:
+				return $display;
+		}
+	}
+
+	/**
 	 * Find URLs in text and return link facets.
 	 *
 	 * @param string $text Plain text.

--- a/includes/transformer/class-facet.php
+++ b/includes/transformer/class-facet.php
@@ -146,6 +146,14 @@ class Facet {
 	 * @return string HTML fragment, or the display text unchanged.
 	 */
 	private static function render_feature( array $feature, string $display ): string {
+		/*
+		 * The display text is a slice of the remote record's `text`, so it
+		 * can contain HTML-significant characters (e.g. `</a>`). Escape it
+		 * before embedding so the anchor can't be broken out of and no
+		 * markup is injected, independent of any downstream wp_kses_post().
+		 */
+		$display = \esc_html( $display );
+
 		switch ( $feature['$type'] ?? '' ) {
 			case 'app.bsky.richtext.facet#link':
 				$uri = $feature['uri'] ?? '';

--- a/includes/transformer/class-facet.php
+++ b/includes/transformer/class-facet.php
@@ -99,13 +99,20 @@ class Facet {
 	 * @return string Text with facets resolved to anchors.
 	 */
 	public static function apply( string $text, array $facets ): string {
+		/*
+		 * Facets come from untrusted PDS JSON, so every nested shape is
+		 * treated as unknown: drop facet entries that aren't arrays before
+		 * touching them, otherwise a scalar entry fatals on array access.
+		 */
+		$facets = \array_filter( $facets, '\is_array' );
+
 		if ( empty( $facets ) ) {
 			return $text;
 		}
 
 		\usort(
 			$facets,
-			static fn( $a, $b ) => ( $a['index']['byteStart'] ?? 0 ) <=> ( $b['index']['byteStart'] ?? 0 )
+			static fn( $a, $b ) => self::byte_start( $a ) <=> self::byte_start( $b )
 		);
 
 		// Facet indexes are UTF-8 byte offsets, so splice in byte space.
@@ -114,8 +121,14 @@ class Facet {
 		$result = '';
 
 		foreach ( $facets as $facet ) {
-			$start = $facet['index']['byteStart'] ?? null;
-			$end   = $facet['index']['byteEnd'] ?? null;
+			$index = $facet['index'] ?? null;
+
+			if ( ! \is_array( $index ) ) {
+				continue;
+			}
+
+			$start = $index['byteStart'] ?? null;
+			$end   = $index['byteEnd'] ?? null;
 
 			/*
 			 * Skip ranges that are malformed, empty, out of bounds, or
@@ -127,12 +140,35 @@ class Facet {
 				continue;
 			}
 
+			/*
+			 * A facet may carry several features; in practice Bluesky emits
+			 * one, and a non-array `features` (again, untrusted JSON) must
+			 * not reach the array-typed renderer.
+			 */
+			$features = $facet['features'] ?? null;
+			$feature  = \is_array( $features ) && \is_array( $features[0] ?? null ) ? $features[0] : array();
+
 			$result .= \substr( $text, $cursor, $start - $cursor );
-			$result .= self::render_feature( $facet['features'][0] ?? array(), \substr( $text, $start, $end - $start ) );
+			$result .= self::render_feature( $feature, \substr( $text, $start, $end - $start ) );
 			$cursor  = $end;
 		}
 
 		return $result . \substr( $text, $cursor );
+	}
+
+	/**
+	 * Safely read a facet's `byteStart` for sorting.
+	 *
+	 * Tolerates malformed facet shapes from untrusted PDS JSON — a missing
+	 * or non-array `index` sorts as 0 rather than fataling on array access.
+	 *
+	 * @param array $facet Facet array.
+	 * @return int Byte offset, or 0 when absent/malformed.
+	 */
+	private static function byte_start( array $facet ): int {
+		$index = $facet['index'] ?? null;
+
+		return \is_array( $index ) && \is_int( $index['byteStart'] ?? null ) ? $index['byteStart'] : 0;
 	}
 
 	/**
@@ -156,29 +192,40 @@ class Facet {
 
 		switch ( $feature['$type'] ?? '' ) {
 			case 'app.bsky.richtext.facet#link':
-				$uri = $feature['uri'] ?? '';
-				if ( '' === $uri ) {
-					return $display;
-				}
-				return '<a href="' . \esc_url( $uri ) . '">' . $display . '</a>';
+				$href = \esc_url( $feature['uri'] ?? '' );
+				break;
 
 			case 'app.bsky.richtext.facet#mention':
-				$did = $feature['did'] ?? '';
-				if ( '' === $did ) {
-					return $display;
-				}
-				return '<a href="' . \esc_url( 'https://bsky.app/profile/' . $did ) . '">' . $display . '</a>';
+				/*
+				 * The mention facet only carries the DID, so link by DID.
+				 * bsky.app/profile/{did} resolves the same as the handle
+				 * form used elsewhere in Reaction_Sync.
+				 */
+				$did  = $feature['did'] ?? '';
+				$href = '' === $did ? '' : \esc_url( 'https://bsky.app/profile/' . $did );
+				break;
 
 			case 'app.bsky.richtext.facet#tag':
-				$tag = $feature['tag'] ?? '';
-				if ( '' === $tag ) {
-					return $display;
-				}
-				return '<a href="' . \esc_url( 'https://bsky.app/hashtag/' . \rawurlencode( $tag ) ) . '">' . $display . '</a>';
+				$tag  = $feature['tag'] ?? '';
+				$href = '' === $tag ? '' : \esc_url( 'https://bsky.app/hashtag/' . \rawurlencode( $tag ) );
+				break;
 
 			default:
-				return $display;
+				$href = '';
+				break;
 		}
+
+		/*
+		 * Fall back to the bare (escaped) display text when there's no
+		 * usable target — an unknown feature type, a missing value, or a
+		 * scheme `esc_url()` rejected — rather than emitting an empty
+		 * `href` that would link to the current page.
+		 */
+		if ( '' === $href ) {
+			return $display;
+		}
+
+		return '<a href="' . $href . '">' . $display . '</a>';
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-reaction-sync.php
+++ b/tests/phpunit/tests/class-test-reaction-sync.php
@@ -249,6 +249,44 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A reply whose record carries a malformed `facets` value (untrusted
+	 * PDS JSON) must still import as a plain comment rather than fataling
+	 * the cron sync with a TypeError. Regression test for PR #134.
+	 */
+	public function test_process_reply_tolerates_malformed_facets() {
+		$post_id  = self::factory()->post->create();
+		$post_uri = 'at://did:plc:me/app.bsky.feed.post/mypost';
+
+		\update_post_meta( $post_id, BskyPost::META_URI, $post_uri );
+
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'process_reply' );
+
+		$notification = array(
+			'uri'    => 'at://did:plc:replier/app.bsky.feed.post/badfacets',
+			'cid'    => 'bafyreibad',
+			'record' => array(
+				'text'      => 'Plain reply text.',
+				'createdAt' => '2026-06-11T18:31:10.876Z',
+				'facets'    => 'not-an-array',
+				'reply'     => array(
+					'parent' => array( 'uri' => $post_uri ),
+					'root'   => array( 'uri' => $post_uri ),
+				),
+			),
+			'author' => array(
+				'did'    => 'did:plc:replier',
+				'handle' => 'replier.bsky.social',
+			),
+		);
+
+		$comment_id = $method->invoke( null, $notification );
+
+		$this->assertIsInt( $comment_id );
+		$comment = \get_comment( $comment_id );
+		$this->assertSame( 'Plain reply text.', $comment->comment_content );
+	}
+
+	/**
 	 * Test that process_reply drops a reply when get_comment() returns
 	 * null for the resolved parent comment ID (race: comment deleted
 	 * between the meta lookup and the get_comment call). The previous

--- a/tests/phpunit/tests/class-test-reaction-sync.php
+++ b/tests/phpunit/tests/class-test-reaction-sync.php
@@ -190,6 +190,65 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A reply whose `text` contains a Bluesky-truncated link must be
+	 * stored with the real URL resolved from the record's facets, not
+	 * the lossy `bsky.app/profile/jere...` display string. Regression
+	 * test for issue #132.
+	 */
+	public function test_process_reply_resolves_truncated_link_facet() {
+		$post_id  = self::factory()->post->create();
+		$post_uri = 'at://did:plc:me/app.bsky.feed.post/mypost';
+
+		\update_post_meta( $post_id, BskyPost::META_URI, $post_uri );
+
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'process_reply' );
+
+		$notification = array(
+			'uri'    => 'at://did:plc:replier/app.bsky.feed.post/linkreply',
+			'cid'    => 'bafyrei789',
+			'record' => array(
+				'text'      => "An exact copy of my post :)\n\nbsky.app/profile/jere...",
+				'createdAt' => '2026-06-11T18:31:10.876Z',
+				'facets'    => array(
+					array(
+						'index'    => array(
+							'byteStart' => 29,
+							'byteEnd'   => 53,
+						),
+						'features' => array(
+							array(
+								'$type' => 'app.bsky.richtext.facet#link',
+								'uri'   => 'https://bsky.app/profile/jeremy.herve.bzh/post/3mnzu7nvcss2e',
+							),
+						),
+					),
+				),
+				'reply'     => array(
+					'parent' => array( 'uri' => $post_uri ),
+					'root'   => array( 'uri' => $post_uri ),
+				),
+			),
+			'author' => array(
+				'did'    => 'did:plc:replier',
+				'handle' => 'replier.bsky.social',
+			),
+		);
+
+		$comment_id = $method->invoke( null, $notification );
+
+		$this->assertIsInt( $comment_id );
+
+		$comment = \get_comment( $comment_id );
+
+		$this->assertStringContainsString(
+			'<a href="https://bsky.app/profile/jeremy.herve.bzh/post/3mnzu7nvcss2e">bsky.app/profile/jere...</a>',
+			$comment->comment_content
+		);
+		// The plain-text portion survives intact.
+		$this->assertStringContainsString( 'An exact copy of my post :)', $comment->comment_content );
+	}
+
+	/**
 	 * Test that process_reply drops a reply when get_comment() returns
 	 * null for the resolved parent comment ID (race: comment deleted
 	 * between the meta lookup and the get_comment call). The previous

--- a/tests/phpunit/tests/transformer/class-test-facet.php
+++ b/tests/phpunit/tests/transformer/class-test-facet.php
@@ -115,4 +115,129 @@ class Test_Facet extends WP_UnitTestCase {
 			);
 		}
 	}
+
+	/**
+	 * Applying a link facet must resolve Bluesky's truncated display
+	 * string back to the real URL. This is the exact record reported in
+	 * issue #132: the post `text` stores `bsky.app/profile/jere...` and
+	 * the full URL lives only in the facet's `uri`.
+	 */
+	public function test_apply_resolves_truncated_link() {
+		$text   = "And to put the new editor to the test, here is an exact copy of my post, just copied / pasted into SkyPress :)\n\nbsky.app/profile/jere...";
+		$facets = array(
+			array(
+				'index'    => array(
+					'byteStart' => 112,
+					'byteEnd'   => 136,
+				),
+				'features' => array(
+					array(
+						'$type' => 'app.bsky.richtext.facet#link',
+						'uri'   => 'https://bsky.app/profile/jeremy.herve.bzh/post/3mnzu7nvcss2e',
+					),
+				),
+			),
+		);
+
+		$result = Facet::apply( $text, $facets );
+
+		$this->assertStringContainsString(
+			'<a href="https://bsky.app/profile/jeremy.herve.bzh/post/3mnzu7nvcss2e">bsky.app/profile/jere...</a>',
+			$result
+		);
+		// Surrounding plain text is preserved verbatim.
+		$this->assertStringContainsString( 'just copied / pasted into SkyPress :)', $result );
+	}
+
+	/**
+	 * Text with no facets must come back byte-for-byte identical.
+	 */
+	public function test_apply_without_facets_is_identity() {
+		$text = 'Plain reply, no links here.';
+		$this->assertSame( $text, Facet::apply( $text, array() ) );
+	}
+
+	/**
+	 * Mention facets link to the author's profile by DID.
+	 */
+	public function test_apply_links_mention() {
+		$text   = 'Hi @alice.bsky.social!';
+		$facets = array(
+			array(
+				'index'    => array(
+					'byteStart' => 3,
+					'byteEnd'   => 21,
+				),
+				'features' => array(
+					array(
+						'$type' => 'app.bsky.richtext.facet#mention',
+						'did'   => 'did:plc:abc123',
+					),
+				),
+			),
+		);
+
+		$result = Facet::apply( $text, $facets );
+
+		$this->assertStringContainsString(
+			'<a href="https://bsky.app/profile/did:plc:abc123">@alice.bsky.social</a>',
+			$result
+		);
+	}
+
+	/**
+	 * Facet indexes are UTF-8 byte ranges. A multibyte character before
+	 * the facet must not shift the splice — reassembly is byte-based.
+	 */
+	public function test_apply_respects_byte_offsets_with_multibyte() {
+		// "héllo " is 7 bytes (é is 2 bytes); the link starts at byte 7.
+		$text = 'héllo https://example.com end';
+		$url  = 'https://example.com';
+
+		$facets = array(
+			array(
+				'index'    => array(
+					'byteStart' => 7,
+					'byteEnd'   => 7 + \strlen( $url ),
+				),
+				'features' => array(
+					array(
+						'$type' => 'app.bsky.richtext.facet#link',
+						'uri'   => $url,
+					),
+				),
+			),
+		);
+
+		$result = Facet::apply( $text, $facets );
+
+		$this->assertStringContainsString( '<a href="https://example.com">https://example.com</a>', $result );
+		$this->assertStringContainsString( 'héllo ', $result );
+		$this->assertStringContainsString( ' end', $result );
+	}
+
+	/**
+	 * Malformed or out-of-bounds facet ranges are skipped without
+	 * corrupting the surrounding text.
+	 */
+	public function test_apply_skips_invalid_ranges() {
+		$text   = 'Short text';
+		$facets = array(
+			// byteEnd past the end of the string.
+			array(
+				'index'    => array(
+					'byteStart' => 6,
+					'byteEnd'   => 999,
+				),
+				'features' => array(
+					array(
+						'$type' => 'app.bsky.richtext.facet#link',
+						'uri'   => 'https://example.com',
+					),
+				),
+			),
+		);
+
+		$this->assertSame( $text, Facet::apply( $text, $facets ) );
+	}
 }

--- a/tests/phpunit/tests/transformer/class-test-facet.php
+++ b/tests/phpunit/tests/transformer/class-test-facet.php
@@ -217,6 +217,38 @@ class Test_Facet extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Display text comes from the remote record, so HTML-significant
+	 * characters in it must be escaped — otherwise a crafted `text` could
+	 * break out of the anchor or inject markup before KSES runs.
+	 */
+	public function test_apply_escapes_anchor_display_text() {
+		$text   = 'evil</a><script>alert(1)</script>';
+		$facets = array(
+			array(
+				'index'    => array(
+					'byteStart' => 0,
+					'byteEnd'   => \strlen( $text ),
+				),
+				'features' => array(
+					array(
+						'$type' => 'app.bsky.richtext.facet#link',
+						'uri'   => 'https://example.com',
+					),
+				),
+			),
+		);
+
+		$result = Facet::apply( $text, $facets );
+
+		// The raw closing tag and script must not survive verbatim.
+		$this->assertStringNotContainsString( '</a><script>', $result );
+		$this->assertStringContainsString( '&lt;/a&gt;&lt;script&gt;', $result );
+		// Exactly one real anchor, opened and closed by us.
+		$this->assertSame( 1, \substr_count( $result, '<a href=' ) );
+		$this->assertSame( 1, \substr_count( $result, '</a>' ) );
+	}
+
+	/**
 	 * Malformed or out-of-bounds facet ranges are skipped without
 	 * corrupting the surrounding text.
 	 */

--- a/tests/phpunit/tests/transformer/class-test-facet.php
+++ b/tests/phpunit/tests/transformer/class-test-facet.php
@@ -272,4 +272,181 @@ class Test_Facet extends WP_UnitTestCase {
 
 		$this->assertSame( $text, Facet::apply( $text, $facets ) );
 	}
+
+	/**
+	 * Tag facets link to the Bluesky hashtag-search page.
+	 */
+	public function test_apply_links_hashtag() {
+		$text   = 'Love #WordPress here';
+		$facets = array(
+			array(
+				'index'    => array(
+					'byteStart' => 5,
+					'byteEnd'   => 15,
+				),
+				'features' => array(
+					array(
+						'$type' => 'app.bsky.richtext.facet#tag',
+						'tag'   => 'WordPress',
+					),
+				),
+			),
+		);
+
+		$result = Facet::apply( $text, $facets );
+
+		$this->assertStringContainsString(
+			'<a href="https://bsky.app/hashtag/WordPress">#WordPress</a>',
+			$result
+		);
+	}
+
+	/**
+	 * Two facets that touch (the second starts exactly where the first
+	 * ends) must both render — the boundary is inclusive on neither side.
+	 */
+	public function test_apply_handles_adjacent_facets() {
+		$text   = 'ab';
+		$facets = array(
+			array(
+				'index'    => array(
+					'byteStart' => 0,
+					'byteEnd'   => 1,
+				),
+				'features' => array(
+					array(
+						'$type' => 'app.bsky.richtext.facet#link',
+						'uri'   => 'https://a.example',
+					),
+				),
+			),
+			array(
+				'index'    => array(
+					'byteStart' => 1,
+					'byteEnd'   => 2,
+				),
+				'features' => array(
+					array(
+						'$type' => 'app.bsky.richtext.facet#link',
+						'uri'   => 'https://b.example',
+					),
+				),
+			),
+		);
+
+		$result = Facet::apply( $text, $facets );
+
+		$this->assertSame( 2, \substr_count( $result, '<a href=' ) );
+		$this->assertStringContainsString( '<a href="https://a.example">a</a>', $result );
+		$this->assertStringContainsString( '<a href="https://b.example">b</a>', $result );
+	}
+
+	/**
+	 * An unrecognised feature type keeps its display text rather than
+	 * dropping the bytes it annotated.
+	 */
+	public function test_apply_unknown_feature_type_keeps_text() {
+		$text   = 'hello world';
+		$facets = array(
+			array(
+				'index'    => array(
+					'byteStart' => 0,
+					'byteEnd'   => 5,
+				),
+				'features' => array(
+					array(
+						'$type' => 'app.bsky.richtext.facet#unknownFuture',
+					),
+				),
+			),
+		);
+
+		$result = Facet::apply( $text, $facets );
+
+		$this->assertSame( 'hello world', $result );
+		$this->assertStringNotContainsString( '<a', $result );
+	}
+
+	/**
+	 * A link whose scheme `esc_url()` strips (e.g. `javascript:`) must fall
+	 * back to bare display text, never an empty `href` to the current page.
+	 */
+	public function test_apply_unsafe_scheme_falls_back_to_text() {
+		$text   = 'click me';
+		$facets = array(
+			array(
+				'index'    => array(
+					'byteStart' => 0,
+					'byteEnd'   => 8,
+				),
+				'features' => array(
+					array(
+						'$type' => 'app.bsky.richtext.facet#link',
+						'uri'   => 'javascript:alert(1)',
+					),
+				),
+			),
+		);
+
+		$result = Facet::apply( $text, $facets );
+
+		$this->assertStringNotContainsString( '<a', $result );
+		$this->assertStringNotContainsString( 'href=""', $result );
+		$this->assertStringContainsString( 'click me', $result );
+	}
+
+	/**
+	 * Facets are untrusted PDS JSON. A facet entry that is a scalar rather
+	 * than an array must be skipped, not fatal with a TypeError.
+	 */
+	public function test_apply_tolerates_non_array_facet_entry() {
+		$text   = 'plain text';
+		$facets = array( 'not-an-array' );
+
+		$this->assertSame( $text, Facet::apply( $text, $facets ) );
+	}
+
+	/**
+	 * A present-but-non-array `features` value must not reach the
+	 * array-typed renderer — the facet is rendered as plain display text.
+	 * Regression test for the TypeError flagged on PR #134.
+	 */
+	public function test_apply_tolerates_non_array_features() {
+		$text   = 'hello world';
+		$facets = array(
+			array(
+				'index'    => array(
+					'byteStart' => 0,
+					'byteEnd'   => 5,
+				),
+				'features' => 'oops-a-string',
+			),
+		);
+
+		$result = Facet::apply( $text, $facets );
+
+		$this->assertSame( 'hello world', $result );
+		$this->assertStringNotContainsString( '<a', $result );
+	}
+
+	/**
+	 * A non-array `index` value must be skipped rather than fataling on
+	 * array access during the sort or the splice.
+	 */
+	public function test_apply_tolerates_non_array_index() {
+		$text   = 'hello world';
+		$facets = array(
+			array(
+				'index'    => 'oops',
+				'features' => array(
+					array(
+						'$type' => 'app.bsky.richtext.facet#link',
+						'uri'   => 'https://example.com',
+					),
+				),
+			),
+		);
+
+		$this->assertSame( $text, Facet::apply( $text, $facets ) );
+	}
 }


### PR DESCRIPTION
Fixes #132

## Proposed changes:

* Bluesky stores a reply's `text` as a *display* string — long URLs are truncated to e.g. `bsky.app/profile/jere...` while the real target lives only in the record's `facets` array — so `Reaction_Sync` was importing the lossy, unclickable preview.
* Adds `Facet::apply()` (the inverse of `Facet::extract()`), which splices the facet byte ranges back into the text as anchors for links, mentions, and hashtags, and calls it on the inbound reply path before the text becomes comment content.
* Reassembly is byte-based to match AT Protocol's UTF-8 facet offsets, and malformed or out-of-bounds ranges are skipped rather than corrupting surrounding text; only generated `href`s are escaped, with the result still flowing through the existing `wp_kses_post()` gate.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Connect the plugin to a Bluesky account and publish a post.
* From Bluesky, reply to that post with a message containing a long link (long enough that Bluesky truncates it to `…`), e.g. paste another post's URL.
* Run the reaction sync (`wp atmosphere sync-reactions`, or wait for the scheduled run) and open the imported comment.
* **Before:** the comment ends with a dead `bsky.app/profile/jere...` string. **After:** it shows a working link to the full URL.
* Existing comments imported before this change keep their old text — the fix applies to new imports.

### Changelog entry

A changelog entry is already committed on this branch (`.github/changelog/fix-comment-link-facets`), so no auto-entry is needed.

-   [ ] Automatically create a changelog entry from the details below.
