### PR TITLE
Gate all error_log() output behind WP_DEBUG

### DIFF
--- a/.agents/skills/code-style/SKILL.md
+++ b/.agents/skills/code-style/SKILL.md
@@ -15,6 +15,7 @@ Quick-reference for everyday work. Full reference: [`docs/php-coding-standards.m
 - **Use** imports for cross-namespace references — never inline `\Atmosphere\OAuth\Client`.
 - **Yoda conditions** for value-vs-variable comparisons: `if ( 'value' === $variable )`.
 - **`unreleased`** for `@since` / `@deprecated` tags on new code — the release script rewrites them.
+- **Never call `\error_log()` directly** — route every log line through `Atmosphere\debug_log()`, which gates on `WP_DEBUG`, adds the `[atmosphere]` prefix, and collapses CRLF. Pass the message without the prefix.
 
 ## File and Class Layout
 
@@ -63,6 +64,8 @@ Always reserve the rkey via meta in `get_rkey()` — that meta key is the marker
 
 **Actions:** `atmosphere_publishing`, `atmosphere_publish_post_result`, `atmosphere_publish_comment_result`, `atmosphere_update_skipped_unsynced_post`, `atmosphere_long_form_strategy_downgraded`, `atmosphere_reaction_synced`. `atmosphere_publishing` receives the current `WP_Post` and is not a request-wide guard.
 
+**Logging:** `atmosphere_debug_log` — `(bool $enabled, string $message)`; defaults to the `WP_DEBUG` state, lets operators opt log lines in/out independently of `WP_DEBUG`.
+
 **Test-only:** `atmosphere_pre_apply_writes` — Publisher fixture uses this to short-circuit `apply_writes` before the HTTP layer.
 
 Full signatures and docblocks: [`docs/php-coding-standards.md → Hook Patterns`](../../../docs/php-coding-standards.md#hook-patterns).
@@ -91,7 +94,7 @@ This pattern was extracted in PR #32 (review by @kraftbj). Full rationale: [`doc
 
 ## Cron Handler Errors — Never Swallow `WP_Error`
 
-Cron handlers in `register_async_hooks()` MUST surface `Publisher::*` errors via `error_log()` — typically through `log_cron_error()`. `wp_schedule_single_event` does not retry, so a silent drop loses the only signal operators have for transient PDS failures, expired refresh tokens, or DPoP nonce drift.
+Cron handlers in `register_async_hooks()` MUST surface `Publisher::*` errors via `debug_log()` — typically through `log_cron_error()`. `wp_schedule_single_event` does not retry, so a silent drop loses the only signal operators have for transient PDS failures, expired refresh tokens, or DPoP nonce drift. `debug_log()` gates the line behind `WP_DEBUG` (operators can opt in on production via the `atmosphere_debug_log` filter).
 
 When the handler operates on records the caller has already lost local state for (e.g. `atmosphere_delete_comment_record` after the WP comment row is gone), include the TID/identifier in the log line so the orphan is recoverable manually.
 

--- a/.github/changelog/gate-debug-logging-behind-wp-debug
+++ b/.github/changelog/gate-debug-logging-behind-wp-debug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Keep diagnostic messages out of your site's error log unless WordPress debugging (WP_DEBUG) is turned on.

--- a/docs/php-coding-standards.md
+++ b/docs/php-coding-standards.md
@@ -503,11 +503,18 @@ if ( $errors->has_errors() ) {
 try {
     $result = self::risky_operation();
 } catch ( \Exception $e ) {
-    // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- log for operators.
-    \error_log( '[atmosphere] ' . $e->getMessage() );
+    debug_log( $e->getMessage() );
     return new \WP_Error( 'atmosphere_exception', $e->getMessage(), array( 'code' => $e->getCode() ) );
 }
 ```
+
+### Logging
+
+Never call `\error_log()` directly. Route every log line through `Atmosphere\debug_log( string $message )` (`includes/functions.php`). `error_log()` honours the server's `log_errors` / `error_log` directives independently of `WP_DEBUG`, so unconditional calls land in production logs on any site with PHP error logging enabled. `debug_log()`:
+
+- No-ops unless `WP_DEBUG` is true, so production stays quiet by default.
+- Adds the `[atmosphere]` prefix and collapses CRLF (PDS-supplied error strings can carry attacker-controlled newlines / forged prefixes) in one place — pass the message **without** the prefix and **without** pre-stripping newlines.
+- Exposes the `atmosphere_debug_log` filter (`bool $enabled, string $message`) so operators can opt into the genuine anomaly breadcrumbs — failed cron PDS writes, thread-rollback orphans — without enabling `WP_DEBUG` site-wide.
 
 ## Cron-Specific Rules
 
@@ -529,7 +536,7 @@ This pattern was extracted in PR #32; see review by @kraftbj for the cross-insta
 
 ### Never Swallow `WP_Error`
 
-Cron handlers in `register_async_hooks()` MUST surface `Publisher::*` errors via `error_log()` — typically through `log_cron_error()`. `wp_schedule_single_event` does not retry, so a silent drop loses the only signal operators have for transient PDS failures, expired refresh tokens, or DPoP nonce drift.
+Cron handlers in `register_async_hooks()` MUST surface `Publisher::*` errors via `debug_log()` — typically through `log_cron_error()`. `wp_schedule_single_event` does not retry, so a silent drop loses the only signal operators have for transient PDS failures, expired refresh tokens, or DPoP nonce drift. The line is gated behind `WP_DEBUG` by default; operators who need these breadcrumbs on production without enabling debugging site-wide can opt in via the `atmosphere_debug_log` filter (see [Logging](#logging)).
 
 When the handler operates on records the caller has already lost local state for (e.g. `atmosphere_delete_comment_record` after the WP comment row is gone), include the TID/identifier in the log line so the orphan is recoverable manually.
 

--- a/docs/php-coding-standards.md
+++ b/docs/php-coding-standards.md
@@ -503,7 +503,7 @@ if ( $errors->has_errors() ) {
 try {
     $result = self::risky_operation();
 } catch ( \Exception $e ) {
-    debug_log( $e->getMessage() );
+    \Atmosphere\debug_log( $e->getMessage() );
     return new \WP_Error( 'atmosphere_exception', $e->getMessage(), array( 'code' => $e->getCode() ) );
 }
 ```

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -1267,10 +1267,9 @@ class Atmosphere {
 		}
 
 		if ( ! \get_transient( 'atmosphere_invalid_long_form_composition_logged' ) ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			\error_log(
+			debug_log(
 				\sprintf(
-					'[atmosphere] invalid `atmosphere_long_form_composition` option value %s; falling through to default',
+					'invalid `atmosphere_long_form_composition` option value %s; falling through to default',
 					\wp_json_encode( $option )
 				)
 			);
@@ -1385,9 +1384,9 @@ class Atmosphere {
 					 * replies + outbound comment replies + document) on the
 					 * PDS with no operator-visible breadcrumb.
 					 */
-					\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					debug_log(
 						\sprintf(
-							'[atmosphere] delete_records failed (bsky=%d, doc=%s, comments=%d): %s — %s',
+							'delete_records failed (bsky=%d, doc=%s, comments=%d): %s — %s',
 							\is_array( $bsky_tids ) ? \count( $bsky_tids ) : (int) ! empty( $bsky_tids ),
 							$doc_tid ? 'yes' : 'no',
 							\count( $comment_tids ),
@@ -1501,9 +1500,9 @@ class Atmosphere {
 					// Worst-case path: the WP comment row is already gone,
 					// so operators need the TID to clean up the orphan
 					// record manually.
-					\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					debug_log(
 						\sprintf(
-							'[atmosphere] delete_comment_record tid=%s failed: %s — %s',
+							'delete_comment_record tid=%s failed: %s — %s',
 							$tid,
 							$result->get_error_code(),
 							$result->get_error_message()
@@ -1672,19 +1671,17 @@ class Atmosphere {
 		 * PDS error messages flow through `WP_Error::get_error_message()`
 		 * via `API::apply_writes` and can include attacker-controlled
 		 * bytes (CRLF, ANSI escapes, fake `[atmosphere]` prefixes that
-		 * imitate other log lines). `error_log` does not escape them,
-		 * so a misbehaving PDS could otherwise smuggle multiline noise
+		 * imitate other log lines). `debug_log()` collapses CRLF before
+		 * writing, so a misbehaving PDS cannot smuggle multiline noise
 		 * into log-shipping pipelines that parse line prefixes.
 		 */
-		$message = \str_replace( array( "\r", "\n" ), ' ', $result->get_error_message() );
-
-		\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		debug_log(
 			\sprintf(
-				'[atmosphere] %s %d failed: %s — %s',
+				'%s %d failed: %s — %s',
 				$op,
 				$object_id,
 				$result->get_error_code(),
-				$message
+				$result->get_error_message()
 			)
 		);
 	}

--- a/includes/class-publisher.php
+++ b/includes/class-publisher.php
@@ -160,10 +160,9 @@ class Publisher {
 				 * `source` / `associatedProfiles` enrichment for this
 				 * one record.
 				 */
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-				\error_log(
+				debug_log(
 					\sprintf(
-						'[atmosphere] post %d: document CID precompute failed (%s) — publishing without document associatedRef',
+						'post %d: document CID precompute failed (%s) — publishing without document associatedRef',
 						$post->ID,
 						$doc_cid->get_error_code()
 					)
@@ -672,10 +671,9 @@ class Publisher {
 
 		\update_post_meta( $post_id, Post::META_ORPHAN_RECORDS, $existing );
 
-		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-		\error_log(
+		debug_log(
 			\sprintf(
-				'[atmosphere] thread rollback failed for post %d; orphans persisted to %s: %s',
+				'thread rollback failed for post %d; orphans persisted to %s: %s',
 				$post_id,
 				Post::META_ORPHAN_RECORDS,
 				\wp_json_encode( $entry )
@@ -1096,10 +1094,9 @@ class Publisher {
 
 		\update_post_meta( $post_id, Post::META_ORPHAN_RECORDS, $existing );
 
-		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-		\error_log(
+		debug_log(
 			\sprintf(
-				'[atmosphere] rewrite_thread republish failed for post %d; deleted records logged to %s: %s',
+				'rewrite_thread republish failed for post %d; deleted records logged to %s: %s',
 				$post_id,
 				Post::META_ORPHAN_RECORDS,
 				$publish_error->get_error_message()
@@ -1780,10 +1777,9 @@ class Publisher {
 			)
 		);
 
-		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-		\error_log(
+		debug_log(
 			\sprintf(
-				'[atmosphere] post %d: doc-ref update failed during thread publish (%s); continuing with replies',
+				'post %d: doc-ref update failed during thread publish (%s); continuing with replies',
 				$post_id,
 				$error->get_error_code()
 			)

--- a/includes/class-reaction-sync.php
+++ b/includes/class-reaction-sync.php
@@ -196,9 +196,9 @@ class Reaction_Sync {
 		 */
 		$token = Client::access_token();
 		if ( \is_wp_error( $token ) ) {
-			\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			debug_log(
 				\sprintf(
-					'[atmosphere] reaction sync aborted: %s — %s',
+					'reaction sync aborted: %s — %s',
 					$token->get_error_code(),
 					$token->get_error_message()
 				)
@@ -270,9 +270,9 @@ class Reaction_Sync {
 				 * stopped making progress (rate limit, OAuth refresh
 				 * failure, transient 5xx all surface here identically).
 				 */
-				\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				debug_log(
 					\sprintf(
-						'[atmosphere] reaction sync (%s) fetch failed: %s — %s',
+						'reaction sync (%s) fetch failed: %s — %s',
 						$option_key,
 						$response->get_error_code(),
 						$response->get_error_message()

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -388,3 +388,54 @@ function is_post_publishable( \WP_Post $post ): bool {
 		&& '' === (string) $post->post_password
 		&& is_supported_post_type( $post->post_type );
 }
+
+/**
+ * Write a debug message to the PHP error log, gated behind WP_DEBUG.
+ *
+ * `error_log()` honours the server's `log_errors` / `error_log` directives
+ * independently of `WP_DEBUG`, so unconditional calls land in production logs
+ * on any site that has PHP error logging enabled but has not opted into
+ * debugging. Routing every plugin log line through this helper keeps that
+ * noise out of production unless debugging is intentionally turned on.
+ *
+ * Centralising the call also means the `[atmosphere]` prefix and the
+ * newline stripping (PDS-supplied error strings can carry attacker-controlled
+ * CRLF / fake prefixes that would otherwise forge log lines) live in one
+ * place rather than being repeated at every call site.
+ *
+ * @since unreleased
+ *
+ * @param string $message Message to log, without the `[atmosphere]` prefix.
+ * @return void
+ */
+function debug_log( string $message ): void {
+	/**
+	 * Filters whether an ATmosphere debug message is written to the error log.
+	 *
+	 * Defaults to the `WP_DEBUG` state. Return true to surface ATmosphere log
+	 * lines independently of `WP_DEBUG` (useful for operators who want the
+	 * genuine anomaly breadcrumbs — failed cron PDS writes, thread-rollback
+	 * orphans — without enabling debugging site-wide), or false to silence
+	 * them entirely.
+	 *
+	 * @since unreleased
+	 *
+	 * @param bool   $enabled Whether to write the message. Defaults to `WP_DEBUG`.
+	 * @param string $message The message about to be logged (without the `[atmosphere]` prefix).
+	 */
+	$enabled = (bool) \apply_filters(
+		'atmosphere_debug_log',
+		\defined( 'WP_DEBUG' ) && \WP_DEBUG,
+		$message
+	);
+
+	if ( ! $enabled ) {
+		return;
+	}
+
+	// Collapse CRLF so a single logged message can't forge extra log lines.
+	$message = \str_replace( array( "\r", "\n" ), ' ', $message );
+
+	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+	\error_log( '[atmosphere] ' . $message );
+}

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -14,6 +14,7 @@ namespace Atmosphere\OAuth;
 
 use Atmosphere\Atmosphere;
 use function Atmosphere\clear_scheduled_hooks;
+use function Atmosphere\debug_log;
 use function Atmosphere\get_connection;
 
 /**
@@ -1380,9 +1381,9 @@ class Client {
 		);
 
 		if ( \is_wp_error( $response ) ) {
-			\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			debug_log(
 				\sprintf(
-					'[atmosphere] refresh-token revocation failed: %s',
+					'refresh-token revocation failed: %s',
 					$response->get_error_message()
 				)
 			);
@@ -1422,9 +1423,9 @@ class Client {
 			);
 
 			if ( \is_wp_error( $response ) ) {
-				\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				debug_log(
 					\sprintf(
-						'[atmosphere] refresh-token revocation retry failed: %s',
+						'refresh-token revocation retry failed: %s',
 						$response->get_error_message()
 					)
 				);
@@ -1446,9 +1447,9 @@ class Client {
 		 * way disconnect proceeds.
 		 */
 		if ( $status >= 400 ) {
-			\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			debug_log(
 				\sprintf(
-					'[atmosphere] refresh-token revocation returned status %d',
+					'refresh-token revocation returned status %d',
 					$status
 				)
 			);

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -14,6 +14,7 @@ namespace Atmosphere\Transformer;
 \defined( 'ABSPATH' ) || exit;
 
 use Atmosphere\API;
+use function Atmosphere\debug_log;
 use function Atmosphere\sanitize_text;
 use function Atmosphere\truncate_text;
 
@@ -676,10 +677,9 @@ class Post extends Base {
 		list( $file, $is_temp, $upload_mime ) = self::resolve_uploadable_image( $attachment_id, $mime );
 
 		if ( null === $file ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			\error_log(
+			debug_log(
 				\sprintf(
-					'[atmosphere] could not resolve an uploadable image for attachment %d (no readable local file and no fetchable size URL under the 1 MB cap); the image blob will be omitted',
+					'could not resolve an uploadable image for attachment %d (no readable local file and no fetchable size URL under the 1 MB cap); the image blob will be omitted',
 					$attachment_id
 				)
 			);
@@ -1015,14 +1015,12 @@ class Post extends Base {
 	 * @return void
 	 */
 	private static function log_image_blob_upload_error( int $attachment_id, \WP_Error $error ): void {
-		$message = \str_replace( array( "\r", "\n" ), ' ', $error->get_error_message() );
-
-		\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		debug_log(
 			\sprintf(
-				'[atmosphere] image blob upload failed for attachment %d: %s — %s',
+				'image blob upload failed for attachment %d: %s — %s',
 				$attachment_id,
 				$error->get_error_code(),
-				$message
+				$error->get_error_message()
 			)
 		);
 	}
@@ -1331,10 +1329,9 @@ class Post extends Base {
 		if ( \in_array( $strategy, array( 'teaser-thread', 'truncate-link' ), true )
 			&& ! $this->has_composable_body()
 		) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			\error_log(
+			debug_log(
 				\sprintf(
-					'[atmosphere] post %d has no composable body/excerpt; downgrading "%s" to "link-card"',
+					'post %d has no composable body/excerpt; downgrading "%s" to "link-card"',
 					$this->object->ID,
 					$strategy
 				)

--- a/tests/phpunit/tests/class-test-functions.php
+++ b/tests/phpunit/tests/class-test-functions.php
@@ -15,6 +15,7 @@ use function Atmosphere\truncate_graphemes;
 use function Atmosphere\to_iso8601;
 use function Atmosphere\is_post_publishable;
 use function Atmosphere\get_connection;
+use function Atmosphere\debug_log;
 
 /**
  * Function tests.
@@ -304,5 +305,108 @@ class Test_Functions extends \WP_UnitTestCase {
 		$this->assertSame( array(), $conn );
 
 		\delete_option( 'atmosphere_connection' );
+	}
+
+	/**
+	 * Capture everything `debug_log()` writes to the PHP error log while
+	 * running `$callback`, returning the raw log contents.
+	 *
+	 * @param callable $callback Code to run with the error log redirected.
+	 * @return string Captured error-log contents.
+	 */
+	private function capture_debug_log( callable $callback ): string {
+		$tmp  = \tempnam( \sys_get_temp_dir(), 'atmosphere-log' );
+		$orig = \ini_get( 'error_log' );
+		// Redirect error_log() to a temp file so the write is observable; restored below.
+		\ini_set( 'error_log', $tmp ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+
+		try {
+			$callback();
+		} finally {
+			\ini_set( 'error_log', false === $orig ? '' : $orig ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$contents = (string) \file_get_contents( $tmp );
+		\unlink( $tmp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+
+		return $contents;
+	}
+
+	/**
+	 * `debug_log()` writes a prefixed line when logging is enabled.
+	 */
+	public function test_debug_log_writes_when_enabled() {
+		$contents = $this->capture_debug_log(
+			function () {
+				\add_filter( 'atmosphere_debug_log', '__return_true' );
+				debug_log( 'something happened' );
+				\remove_filter( 'atmosphere_debug_log', '__return_true' );
+			}
+		);
+
+		$this->assertStringContainsString( '[atmosphere] something happened', $contents );
+	}
+
+	/**
+	 * `debug_log()` is a no-op when logging is disabled, regardless of the
+	 * server's `log_errors` / `error_log` directives.
+	 */
+	public function test_debug_log_noop_when_disabled() {
+		$contents = $this->capture_debug_log(
+			function () {
+				\add_filter( 'atmosphere_debug_log', '__return_false' );
+				debug_log( 'should not be logged' );
+				\remove_filter( 'atmosphere_debug_log', '__return_false' );
+			}
+		);
+
+		$this->assertStringNotContainsString( 'should not be logged', $contents );
+	}
+
+	/**
+	 * The `atmosphere_debug_log` filter receives the WP_DEBUG default and the
+	 * unprefixed message, and its return value controls whether logging runs.
+	 */
+	public function test_debug_log_filter_receives_default_and_message() {
+		$received = array();
+
+		$capture = function ( $enabled, $message ) use ( &$received ) {
+			$received['enabled'] = $enabled;
+			$received['message'] = $message;
+			return false;
+		};
+
+		$this->capture_debug_log(
+			function () use ( $capture ) {
+				\add_filter( 'atmosphere_debug_log', $capture, 10, 2 );
+				debug_log( 'filter payload' );
+				\remove_filter( 'atmosphere_debug_log', $capture, 10 );
+			}
+		);
+
+		$this->assertArrayHasKey( 'enabled', $received );
+		$this->assertSame( \defined( 'WP_DEBUG' ) && \WP_DEBUG, $received['enabled'] );
+		$this->assertSame( 'filter payload', $received['message'] );
+	}
+
+	/**
+	 * `debug_log()` collapses CRLF so a single message cannot forge extra
+	 * log lines (PDS-supplied error strings can carry attacker-controlled
+	 * newlines and fake `[atmosphere]` prefixes).
+	 */
+	public function test_debug_log_collapses_newlines() {
+		$contents = $this->capture_debug_log(
+			function () {
+				\add_filter( 'atmosphere_debug_log', '__return_true' );
+				debug_log( "first line\r\n[atmosphere] forged second line" );
+				\remove_filter( 'atmosphere_debug_log', '__return_true' );
+			}
+		);
+
+		// Exactly one logged line carries the prefix; the forged one is folded in.
+		$this->assertSame( 1, \substr_count( $contents, '[atmosphere] first line' ) );
+		$this->assertStringNotContainsString( "first line\n", $contents );
+		$this->assertStringNotContainsString( "first line\r", $contents );
 	}
 }


### PR DESCRIPTION
Fixes #115

## Proposed changes:

* Add an `Atmosphere\debug_log()` helper that no-ops unless `WP_DEBUG` is enabled, then route all 16 existing `\error_log()` call sites across `includes/` through it — so the plugin no longer pollutes production logs on sites that have PHP error logging on but aren't debugging.
* The helper centralizes the `[atmosphere]` prefix and CRLF collapsing (dropping the duplicated newline-stripping in `log_cron_error()` and `log_image_blob_upload_error()`), and exposes a new `atmosphere_debug_log` filter so operators can opt the anomaly breadcrumbs back in independently of `WP_DEBUG`.
* Docs (`docs/php-coding-standards.md`, code-style skill) updated to make `debug_log()` the standard and forbid raw `\error_log()`.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* With `WP_DEBUG` **off**: trigger a logged path (e.g. publish a long-form post with no composable body so the strategy downgrades) and confirm **nothing** is written to the PHP error log.
* Set `define( 'WP_DEBUG', true );` and repeat — confirm a single `[atmosphere] …` line appears.
* With `WP_DEBUG` off, add `add_filter( 'atmosphere_debug_log', '__return_true' );` and confirm the line appears again (operator opt-in path).
* Run the suite: `npm run env-test -- --filter=Test_Functions` (the new `debug_log` cases) — full suite is 657 passing locally.

### Changelog entry

<!-- A changelog entry is already committed at .github/changelog/gate-debug-logging-behind-wp-debug (Patch / Changed). -->

-   [ ] Automatically create a changelog entry from the details below.