### PR TITLE
Decouple post + document deletes from the comment-reply cascade

### DIFF
--- a/.github/changelog/fix-decouple-post-delete
+++ b/.github/changelog/fix-decouple-post-delete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Deleting a post now reliably removes it from Bluesky even when it has a large number of replies to clean up.

--- a/includes/class-publisher.php
+++ b/includes/class-publisher.php
@@ -1124,9 +1124,11 @@ class Publisher {
 	 * cascade semantics, so they have to be enumerated alongside the
 	 * post records or they orphan on Bluesky.
 	 *
-	 * Writes are chunked into bounded `applyWrites` calls (the lexicon
-	 * caps a single batch at 200), so a high-traffic post with a long
-	 * reply tail still cleans up cleanly.
+	 * The post + document deletes and the outbound comment-reply deletes
+	 * are submitted as two independent, individually-chunked `applyWrites`
+	 * batches (the lexicon caps a single batch at 200). The root batch
+	 * goes first: a long reply tail can neither inflate the root batch
+	 * past the cap nor, when it fails, block cleanup of the post itself.
 	 *
 	 * @param \WP_Post $post WordPress post.
 	 * @return array|\WP_Error
@@ -1174,48 +1176,67 @@ class Publisher {
 			);
 		}
 
-		$writes = array();
+		$root_writes = array();
 		foreach ( $stored as $record ) {
 			if ( empty( $record['tid'] ) ) {
 				continue;
 			}
-			$writes[] = array(
+			$root_writes[] = array(
 				'$type'      => 'com.atproto.repo.applyWrites#delete',
 				'collection' => 'app.bsky.feed.post',
 				'rkey'       => $record['tid'],
 			);
 		}
 		if ( $doc_tid ) {
-			$writes[] = array(
+			$root_writes[] = array(
 				'$type'      => 'com.atproto.repo.applyWrites#delete',
 				'collection' => 'site.standard.document',
 				'rkey'       => $doc_tid,
 			);
 		}
 
+		$comment_writes = array();
 		foreach ( $comment_tids as $comment_tid ) {
-			$writes[] = array(
+			$comment_writes[] = array(
 				'$type'      => 'com.atproto.repo.applyWrites#delete',
 				'collection' => 'app.bsky.feed.post',
 				'rkey'       => $comment_tid['tid'],
 			);
 		}
 
-		if ( empty( $writes ) ) {
+		if ( empty( $root_writes ) && empty( $comment_writes ) ) {
 			return new \WP_Error(
 				'atmosphere_not_published',
 				\__( 'Post has no AT Protocol records.', 'atmosphere' )
 			);
 		}
 
-		$result = self::apply_writes_chunked( $writes );
+		$outcome = self::delete_in_decoupled_batches( $root_writes, $comment_writes );
 
-		if ( \is_wp_error( $result ) ) {
-			// Leave meta intact so a retry can complete.
-			return $result;
+		if ( \is_wp_error( $outcome['root'] ) ) {
+			// Nothing was removed remotely; leave all meta intact so a retry can complete.
+			return $outcome['root'];
 		}
 
-		self::clear_all_record_meta( $post->ID );
+		/*
+		 * The post + document records are gone, so clear their local meta
+		 * now — before the comment-reply batch is even evaluated. This is
+		 * the decoupling guarantee: a comment cascade that overflows or
+		 * fails can no longer strand the post in a published-looking state.
+		 *
+		 * `$outcome['root']` is null only when there were no root writes —
+		 * i.e. a comment-only retry after a prior run already cleared the
+		 * post/document meta — so there is nothing left to clear and the
+		 * call is skipped.
+		 */
+		if ( null !== $outcome['root'] ) {
+			self::clear_all_record_meta( $post->ID );
+		}
+
+		if ( \is_wp_error( $outcome['comments'] ) ) {
+			// Comment-reply meta is left intact so a re-trash retries just those records.
+			return $outcome['comments'];
+		}
 
 		// Clean up comment meta for every reply we just deleted.
 		foreach ( $comment_tids as $comment_tid ) {
@@ -1225,7 +1246,7 @@ class Publisher {
 			\delete_comment_meta( $comment_tid['comment_id'], Reaction_Sync::META_SOURCE_ID );
 		}
 
-		return $result;
+		return self::merge_decoupled_results( $outcome );
 	}
 
 	/**
@@ -1290,8 +1311,13 @@ class Publisher {
 	 * accessible to `delete_post()`. Accepts either a single Bluesky TID
 	 * string (legacy single-record posts) or an array of TIDs
 	 * (thread-strategy posts), plus an optional list of outbound
-	 * comment-reply TIDs. All are issued in one atomic `applyWrites`
-	 * call so cleanup of root + thread + replies + document is atomic.
+	 * comment-reply TIDs. The post + document deletes and the
+	 * comment-reply deletes are submitted as two independent,
+	 * individually-chunked `applyWrites` batches (root first) so a long
+	 * reply tail can neither overflow the root batch nor block its
+	 * cleanup when it fails. Unlike `delete_post()`, this path has no
+	 * local meta to reconcile — the post row is already gone — so meta
+	 * cleanup is left entirely to the caller (`on_before_delete`).
 	 *
 	 * @param string|string[] $bsky_tids    Bluesky post TID or array of TIDs (may be empty).
 	 * @param string          $doc_tid      Document TID (may be empty).
@@ -1312,10 +1338,10 @@ class Publisher {
 			return new \WP_Error( 'atmosphere_not_published', \__( 'No TIDs provided.', 'atmosphere' ) );
 		}
 
-		$writes = array();
+		$root_writes = array();
 
 		foreach ( $bsky_tids as $bsky_tid ) {
-			$writes[] = array(
+			$root_writes[] = array(
 				'$type'      => 'com.atproto.repo.applyWrites#delete',
 				'collection' => 'app.bsky.feed.post',
 				'rkey'       => $bsky_tid,
@@ -1323,22 +1349,34 @@ class Publisher {
 		}
 
 		if ( $doc_tid ) {
-			$writes[] = array(
+			$root_writes[] = array(
 				'$type'      => 'com.atproto.repo.applyWrites#delete',
 				'collection' => 'site.standard.document',
 				'rkey'       => $doc_tid,
 			);
 		}
 
+		$comment_writes = array();
+
 		foreach ( $comment_tids as $comment_tid ) {
-			$writes[] = array(
+			$comment_writes[] = array(
 				'$type'      => 'com.atproto.repo.applyWrites#delete',
 				'collection' => 'app.bsky.feed.post',
 				'rkey'       => $comment_tid,
 			);
 		}
 
-		return self::apply_writes_chunked( $writes );
+		$outcome = self::delete_in_decoupled_batches( $root_writes, $comment_writes );
+
+		if ( \is_wp_error( $outcome['root'] ) ) {
+			return $outcome['root'];
+		}
+
+		if ( \is_wp_error( $outcome['comments'] ) ) {
+			return $outcome['comments'];
+		}
+
+		return self::merge_decoupled_results( $outcome );
 	}
 
 	/**
@@ -1392,6 +1430,65 @@ class Publisher {
 			}
 
 			++$succeeded;
+		}
+
+		return array( 'results' => $results );
+	}
+
+	/**
+	 * Submit record deletes as two decoupled `applyWrites` batches: the
+	 * post + document first, the outbound comment replies second.
+	 *
+	 * The two batches are chunked and submitted independently so a long
+	 * comment-reply tail can neither push the root batch past the lexicon
+	 * write cap nor, when it fails, block cleanup of the post + document
+	 * themselves. The root batch is submitted first; callers key local
+	 * record-meta cleanup on its success and comment-meta cleanup on the
+	 * comment batch's success.
+	 *
+	 * The comment batch is not attempted when the root batch fails — there
+	 * is nothing local to reconcile yet, and a retry re-runs both.
+	 *
+	 * @param array $root_writes    Post + document delete writes (may be empty).
+	 * @param array $comment_writes Outbound comment-reply delete writes (may be empty).
+	 * @return array{root: array|\WP_Error|null, comments: array|\WP_Error|null}
+	 *               Per-batch outcome; an element is null when that batch
+	 *               had no writes, and `comments` is null when the root
+	 *               batch failed and the comment batch was skipped.
+	 */
+	private static function delete_in_decoupled_batches( array $root_writes, array $comment_writes ): array {
+		$root_result = empty( $root_writes ) ? null : self::apply_writes_chunked( $root_writes );
+
+		if ( \is_wp_error( $root_result ) ) {
+			return array(
+				'root'     => $root_result,
+				'comments' => null,
+			);
+		}
+
+		$comment_result = empty( $comment_writes ) ? null : self::apply_writes_chunked( $comment_writes );
+
+		return array(
+			'root'     => $root_result,
+			'comments' => $comment_result,
+		);
+	}
+
+	/**
+	 * Flatten a decoupled-delete outcome into the single
+	 * `array{results: array}` shape callers expect from a successful
+	 * `applyWrites`. Batches that were empty or errored contribute nothing.
+	 *
+	 * @param array $outcome Result of {@see self::delete_in_decoupled_batches()}.
+	 * @return array
+	 */
+	private static function merge_decoupled_results( array $outcome ): array {
+		$results = array();
+
+		foreach ( array( $outcome['root'] ?? null, $outcome['comments'] ?? null ) as $batch ) {
+			if ( \is_array( $batch ) && isset( $batch['results'] ) && \is_array( $batch['results'] ) ) {
+				$results = \array_merge( $results, $batch['results'] );
+			}
 		}
 
 		return array( 'results' => $results );

--- a/tests/phpunit/tests/class-test-publisher.php
+++ b/tests/phpunit/tests/class-test-publisher.php
@@ -528,12 +528,12 @@ class Test_Publisher extends WP_UnitTestCase {
 		\update_comment_meta( $c3, Comment::META_TID, 'stale-tid' );
 		// No META_URI — previously-failed publish; must not be in the delete batch.
 
-		$captured_body = null;
+		$captured_bodies = array();
 		\add_filter(
 			'pre_http_request',
-			static function ( $response, $args, $url ) use ( &$captured_body ) {
+			static function ( $response, $args, $url ) use ( &$captured_bodies ) {
 				if ( false !== \strpos( $url, 'applyWrites' ) ) {
-					$captured_body = \json_decode( $args['body'], true );
+					$captured_bodies[] = \json_decode( $args['body'], true );
 
 					return array(
 						'response' => array( 'code' => 200 ),
@@ -549,22 +549,120 @@ class Test_Publisher extends WP_UnitTestCase {
 		Publisher::delete_post( $post );
 		\remove_all_filters( 'pre_http_request' );
 
-		if ( null === $captured_body ) {
+		if ( empty( $captured_bodies ) ) {
 			$this->markTestSkipped( 'API layer rejected request before stub.' );
 		}
 
-		$rkeys = \array_column( $captured_body['writes'], 'rkey' );
-		$this->assertContains( 'post-tid', $rkeys );
-		$this->assertContains( 'doc-tid', $rkeys );
-		$this->assertContains( 'reply-tid-1', $rkeys );
-		$this->assertContains( 'reply-tid-2', $rkeys );
-		$this->assertNotContains( 'stale-tid', $rkeys, 'Stale TID without URI must not be included.' );
+		/*
+		 * The post + document deletes and the comment-reply deletes go out
+		 * as two decoupled batches (root first), so cleanup of the post
+		 * itself is never entangled with the comment cascade.
+		 */
+		$this->assertCount( 2, $captured_bodies, 'Root and comment deletes must be separate batches.' );
+
+		$root_rkeys    = \array_column( $captured_bodies[0]['writes'], 'rkey' );
+		$comment_rkeys = \array_column( $captured_bodies[1]['writes'], 'rkey' );
+
+		$this->assertContains( 'post-tid', $root_rkeys );
+		$this->assertContains( 'doc-tid', $root_rkeys );
+		$this->assertNotContains( 'reply-tid-1', $root_rkeys, 'Comment replies must not ride in the root batch.' );
+
+		$this->assertContains( 'reply-tid-1', $comment_rkeys );
+		$this->assertContains( 'reply-tid-2', $comment_rkeys );
+		$this->assertNotContains( 'stale-tid', $comment_rkeys, 'Stale TID without URI must not be included.' );
 
 		// Meta cleanup on both the post and the published replies.
 		$this->assertSame( '', \get_comment_meta( $c1, Comment::META_URI, true ) );
 		$this->assertSame( '', \get_comment_meta( $c2, Comment::META_TID, true ) );
 		// Stale comment's TID is left alone — we did not touch its record.
 		$this->assertSame( 'stale-tid', \get_comment_meta( $c3, Comment::META_TID, true ) );
+	}
+
+	/**
+	 * When the comment-reply batch fails, the post + document deletes are
+	 * already done, so their meta is cleared regardless — the decoupling
+	 * guarantee. The comment meta is left intact so a re-trash retries
+	 * just the replies. Without decoupling, a failing comment cascade
+	 * would strand the post in a published-looking state.
+	 */
+	public function test_delete_post_clears_root_meta_when_comment_batch_fails() {
+		$post = self::factory()->post->create_and_get(
+			array( 'post_status' => 'trash' )
+		);
+		\update_post_meta( $post->ID, Post::META_TID, 'post-tid' );
+		\update_post_meta( $post->ID, Post::META_URI, 'at://did:plc:test123/app.bsky.feed.post/post-tid' );
+		\update_post_meta( $post->ID, Post::META_CID, 'bafyreibpost' );
+		\update_post_meta( $post->ID, Document::META_TID, 'doc-tid' );
+		\update_post_meta( $post->ID, Document::META_URI, 'at://did:plc:test123/site.standard.document/doc-tid' );
+
+		$c1 = self::factory()->comment->create( array( 'comment_post_ID' => $post->ID ) );
+		\update_comment_meta( $c1, Comment::META_TID, 'reply-tid-1' );
+		\update_comment_meta( $c1, Comment::META_URI, 'at://did:plc:test123/app.bsky.feed.post/reply-tid-1' );
+
+		// Call 1 is the root batch (succeeds); call 2 is the comment batch (fails).
+		$this->fail_call_indexes = array(
+			2 => new \WP_Error( 'atmosphere_pds_500', 'PDS rejected comment batch.' ),
+		);
+		$this->register_capture( $post->ID );
+
+		$result = Publisher::delete_post( $post );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'atmosphere_pds_500', $result->get_error_code() );
+
+		// Two batches were attempted, root first.
+		$this->assertCount( 2, $this->captured_calls );
+
+		// Root batch succeeded → the full post + document meta surface is cleared.
+		$this->assertSame( '', \get_post_meta( $post->ID, Post::META_TID, true ) );
+		$this->assertSame( '', \get_post_meta( $post->ID, Post::META_URI, true ) );
+		$this->assertSame( '', \get_post_meta( $post->ID, Post::META_CID, true ) );
+		$this->assertSame( '', \get_post_meta( $post->ID, Document::META_TID, true ) );
+		$this->assertSame( '', \get_post_meta( $post->ID, Document::META_URI, true ) );
+
+		// Comment batch failed → its meta is retained for a retry.
+		$this->assertSame( 'reply-tid-1', \get_comment_meta( $c1, Comment::META_TID, true ) );
+		$this->assertSame(
+			'at://did:plc:test123/app.bsky.feed.post/reply-tid-1',
+			\get_comment_meta( $c1, Comment::META_URI, true )
+		);
+	}
+
+	/**
+	 * When the root (post + document) batch fails, nothing was removed
+	 * remotely: all meta stays intact and the comment-reply batch is not
+	 * even attempted, so a retry re-runs the whole cascade cleanly.
+	 */
+	public function test_delete_post_root_batch_failure_leaves_all_meta_intact() {
+		$post = self::factory()->post->create_and_get(
+			array( 'post_status' => 'trash' )
+		);
+		\update_post_meta( $post->ID, Post::META_TID, 'post-tid' );
+		\update_post_meta( $post->ID, Post::META_URI, 'at://did:plc:test123/app.bsky.feed.post/post-tid' );
+		\update_post_meta( $post->ID, Document::META_TID, 'doc-tid' );
+
+		$c1 = self::factory()->comment->create( array( 'comment_post_ID' => $post->ID ) );
+		\update_comment_meta( $c1, Comment::META_TID, 'reply-tid-1' );
+		\update_comment_meta( $c1, Comment::META_URI, 'at://did:plc:test123/app.bsky.feed.post/reply-tid-1' );
+
+		// Fail the root batch (call 1). The comment batch must not be attempted.
+		$this->fail_call_indexes = array(
+			1 => new \WP_Error( 'atmosphere_pds_500', 'PDS rejected root batch.' ),
+		);
+		$this->register_capture( $post->ID );
+
+		$result = Publisher::delete_post( $post );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'atmosphere_pds_500', $result->get_error_code() );
+
+		// Only the root batch was attempted; the comment batch was skipped.
+		$this->assertCount( 1, $this->captured_calls );
+
+		// Nothing removed remotely → every meta value intact.
+		$this->assertSame( 'post-tid', \get_post_meta( $post->ID, Post::META_TID, true ) );
+		$this->assertSame( 'doc-tid', \get_post_meta( $post->ID, Document::META_TID, true ) );
+		$this->assertSame( 'reply-tid-1', \get_comment_meta( $c1, Comment::META_TID, true ) );
 	}
 
 	/**
@@ -2089,6 +2187,9 @@ class Test_Publisher extends WP_UnitTestCase {
 	 * `applyWrites` calls. The lexicon caps a single batch at 200 writes;
 	 * a high-traffic post with hundreds of outbound comment replies must
 	 * still clean up cleanly rather than failing the whole cascade.
+	 *
+	 * The root (post + document) deletes are their own batch, so the
+	 * 250-reply tail chunks independently of them.
 	 */
 	public function test_delete_post_by_tids_chunks_oversized_batches() {
 		$this->fail_call_indexes = array();
@@ -2106,8 +2207,12 @@ class Test_Publisher extends WP_UnitTestCase {
 		);
 
 		$this->assertIsArray( $result );
-		// 252 total writes / 100 per chunk = 3 calls.
-		$this->assertCount( 3, $this->captured_calls );
+		// Root batch (1 call: root-tid + doc-tid) + 250 replies / 100 (3 calls) = 4 calls.
+		$this->assertCount( 4, $this->captured_calls );
+
+		// First call is the decoupled root batch: just the post + document.
+		$root_rkeys = \array_column( $this->captured_calls[0]['writes'], 'rkey' );
+		$this->assertSame( array( 'root-tid', 'doc-tid' ), $root_rkeys );
 
 		$total_writes = 0;
 		foreach ( $this->captured_calls as $call ) {
@@ -2124,8 +2229,14 @@ class Test_Publisher extends WP_UnitTestCase {
 	 * it as a clean failure.
 	 */
 	public function test_delete_post_by_tids_chunked_failure_carries_progress_data() {
+		/*
+		 * Call 1 is the root batch (root-tid + doc-tid); calls 2-4 are the
+		 * three comment chunks. Fail the second comment chunk (call 3) so
+		 * the progress data is reported relative to the comment batch:
+		 * chunk index 1 of 3, with 1 chunk already succeeded.
+		 */
 		$this->fail_call_indexes = array(
-			2 => new \WP_Error( 'atmosphere_pds_500', 'PDS rejected batch.' ),
+			3 => new \WP_Error( 'atmosphere_pds_500', 'PDS rejected batch.' ),
 		);
 		$this->register_capture( 0 );
 
@@ -2151,10 +2262,11 @@ class Test_Publisher extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Small batches (<= chunk size) take the single-call path and do
-	 * not touch the chunking layer's results-merging.
+	 * Even a small batch is split into a decoupled root batch (post +
+	 * document) and a comment batch, so the post's own cleanup never
+	 * shares an `applyWrites` call with the comment cascade.
 	 */
-	public function test_delete_post_by_tids_small_batch_uses_single_call() {
+	public function test_delete_post_by_tids_decouples_root_and_comment_batches() {
 		$this->fail_call_indexes = array();
 		$this->register_capture( 0 );
 
@@ -2165,8 +2277,38 @@ class Test_Publisher extends WP_UnitTestCase {
 		);
 
 		$this->assertIsArray( $result );
-		$this->assertCount( 1, $this->captured_calls );
-		$this->assertCount( 4, $this->captured_calls[0]['writes'] );
+		$this->assertCount( 2, $this->captured_calls );
+
+		$this->assertSame(
+			array( 'root-tid', 'doc-tid' ),
+			\array_column( $this->captured_calls[0]['writes'], 'rkey' )
+		);
+		$this->assertSame(
+			array( 'reply-1', 'reply-2' ),
+			\array_column( $this->captured_calls[1]['writes'], 'rkey' )
+		);
+	}
+
+	/**
+	 * If the root batch fails on the permanent-delete path, the comment
+	 * batch is not attempted — the failure short-circuits before the
+	 * comment cascade, mirroring the trash path.
+	 */
+	public function test_delete_post_by_tids_skips_comment_batch_when_root_fails() {
+		$this->fail_call_indexes = array(
+			1 => new \WP_Error( 'atmosphere_pds_500', 'PDS rejected root batch.' ),
+		);
+		$this->register_capture( 0 );
+
+		$result = Publisher::delete_post_by_tids(
+			array( 'root-tid' ),
+			'doc-tid',
+			array( 'reply-1', 'reply-2' )
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'atmosphere_pds_500', $result->get_error_code() );
+		$this->assertCount( 1, $this->captured_calls, 'Comment batch must be skipped when the root batch fails.' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #48

## Proposed changes:

`Publisher::delete_post()` (trash) and `delete_post_by_tids()` (permanent delete) used to bundle the post, the `site.standard.document`, and one delete per outbound comment reply into a single `applyWrites` batch. On a popular post that batch scales with thread length, and an atomic failure (or a write-count overflow) in the comment cascade would block cleanup of the post itself — leaving the root records orphaned on Bluesky while the post looks deleted locally.

This PR decouples the two:

* The post + document deletes and the comment-reply deletes are now submitted as **two independent, individually-chunked** `applyWrites` batches via a new `delete_in_decoupled_batches()` helper. Chunking (introduced in #32) is unchanged; it now runs per-batch.
* The **root batch goes first**. On `delete_post()`, the post/document meta is cleared as soon as that batch succeeds — independent of the comment batch — so a failing or oversized reply cascade can no longer strand the post in a published-looking state. If the comment batch then fails, only the reply meta is kept, so a re-trash retries just the replies.
* If the root batch itself fails, nothing is removed remotely, all meta is left intact, and the comment batch is skipped so a retry re-runs the whole cascade cleanly.

This addresses the "decouple" half of #48; the chunking half already landed in #32.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Connect the plugin to a Bluesky account and publish a post.
* Reply to that post from Bluesky and run the reaction sync (`wp atmosphere sync-reactions`) so the post has at least one synced outbound comment reply.
* Trash the post. Confirm the post, its document, and the reply records are all removed from Bluesky.
* To exercise the decoupling guarantee directly, run the suite:
  ```
  npm run env-test -- --filter=delete
  ```
  The new tests assert that a failing comment batch still clears the post/document meta (`test_delete_post_clears_root_meta_when_comment_batch_fails`), that a failing root batch leaves everything intact and skips the comment batch (`test_delete_post_root_batch_failure_leaves_all_meta_intact`), and that root and comment deletes are always separate batches.

### Changelog entry

A changelog entry is already committed on this branch (`.github/changelog/fix-decouple-post-delete`), so no auto-entry is needed.

-   [ ] Automatically create a changelog entry from the details below.
