### PR TITLE
Fixed: add $type to publication's basicTheme so link cards render

### DIFF
--- a/.github/changelog/fix-publication-basic-theme-type
+++ b/.github/changelog/fix-publication-basic-theme-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Your site's theme colours now display correctly in enhanced link cards on Bluesky and other apps, instead of being dropped because the publication record failed validation.

--- a/includes/transformer/class-publication.php
+++ b/includes/transformer/class-publication.php
@@ -197,7 +197,8 @@ class Publication extends Base {
 	 *
 	 * Pure transformation — accepts the WP-resolved inputs as arguments
 	 * so the unit tests can drive it without standing up a real
-	 * theme.json merge.
+	 * theme.json merge. The record carries the `site.standard.theme.basic`
+	 * `$type` discriminator so it passes lexicon validation.
 	 *
 	 * @param array                $styles  Output of `wp_get_global_styles()`.
 	 * @param array<string,string> $palette Slug => hex map from the theme palette.
@@ -228,6 +229,7 @@ class Publication extends Base {
 		}
 
 		return array(
+			'$type'            => 'site.standard.theme.basic',
 			'background'       => self::color_object( $background ),
 			'foreground'       => self::color_object( $foreground ),
 			'accent'           => self::color_object( $accent ),

--- a/tests/phpunit/tests/transformer/class-test-publication.php
+++ b/tests/phpunit/tests/transformer/class-test-publication.php
@@ -235,7 +235,8 @@ class Test_Publication extends \WP_UnitTestCase {
 	/**
 	 * `build_basic_theme()` produces the spec-shaped record with all
 	 * four required colours when background/foreground/accent are
-	 * resolvable from the supplied styles. Each colour carries the
+	 * resolvable from the supplied styles. The record carries the
+	 * `site.standard.theme.basic` `$type`, and each colour carries the
 	 * `site.standard.theme.color#rgb` union discriminator.
 	 */
 	public function test_build_basic_theme_returns_spec_shape_with_all_four_colors() {
@@ -260,12 +261,22 @@ class Test_Publication extends \WP_UnitTestCase {
 		 * required fields in a different `transform()` insertion order.
 		 */
 		$this->assertEqualsCanonicalizing(
-			array( 'background', 'foreground', 'accent', 'accentForeground' ),
+			array( '$type', 'background', 'foreground', 'accent', 'accentForeground' ),
 			\array_keys( $record ),
-			'basicTheme must carry all four required colours.'
+			'basicTheme must carry its `$type` plus all four required colours.'
+		);
+
+		$this->assertSame(
+			'site.standard.theme.basic',
+			$record['$type'],
+			'basicTheme must carry the `site.standard.theme.basic` `$type` so it passes lexicon validation.'
 		);
 
 		foreach ( $record as $key => $color ) {
+			if ( '$type' === $key ) {
+				continue;
+			}
+
 			$this->assertSame(
 				'site.standard.theme.color#rgb',
 				$color['$type'],


### PR DESCRIPTION
Fixes #153

## Proposed changes:

The `site.standard.publication` record built by the plugin was emitting a `basicTheme` object without its `$type` field. AT Protocol union/record members must carry a `$type` discriminator, so the record failed lexicon validation — and records that fail validation can't be rendered as enhanced link cards in Bluesky and other Atmosphere apps, which is why affected sites' theme colours never showed up.

* Add `'$type' => 'site.standard.theme.basic'` to the array returned by `Publication::build_basic_theme()`. This mirrors the discriminator that `color_object()` already emits for each colour (`site.standard.theme.color#rgb`), and the value was confirmed against a correctly-validating published record.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* On a block theme whose global styles resolve a background, text, and link (accent) colour, connect the site via the plugin's settings and publish/sync the publication record.
* Inspect the resulting `site.standard.publication` record (e.g. via pdsls.dev or `com.atproto.repo.getRecord`) and confirm its `basicTheme` object now contains `"$type": "site.standard.theme.basic"` alongside the four colour fields.
* The record should now pass lexicon validation and render theme colours in Bluesky link cards.

Automated coverage:

* `npm run env-test -- --filter=Publication` — 37 tests pass; `test_build_basic_theme_returns_spec_shape_with_all_four_colors` now asserts the `$type`.
* Full suite: 734 tests pass.

### Changelog entry

A changelog entry is included on the branch (`.github/changelog/fix-publication-basic-theme-type`).
