### PR TITLE
Fixed: count graphemes, not code points, against Bluesky's 300-character limit

### DIFF
--- a/.github/changelog/fix-grapheme-truncation
+++ b/.github/changelog/fix-grapheme-truncation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Emoji now count as a single character against Bluesky's 300-character limit, the same way Bluesky's own composer counts them. Posts with emoji are no longer trimmed earlier than necessary, and the editor's character count matches what you would see on Bluesky.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -130,14 +130,69 @@ function truncate_graphemes( string $text, int $max_graphemes ): string {
 }
 
 /**
- * Truncate text to a character limit, breaking at word boundaries.
+ * Count the graphemes in a string the way Bluesky's composer does.
+ *
+ * Bluesky measures its 300-character post cap in graphemes, so a ZWJ
+ * family emoji (`👨‍👩‍👧‍👦`, many code points) counts as one. Falls back to
+ * `mb_strlen()` (code points) when the `intl` extension is missing or the
+ * string is invalid UTF-8 — code points are always >= graphemes, so the
+ * fallback stays conservative and never under-counts a real grapheme.
+ *
+ * @param string $text Text to measure.
+ * @return int Grapheme count.
+ */
+function grapheme_length( string $text ): int {
+	if ( \function_exists( 'grapheme_strlen' ) ) {
+		$length = \grapheme_strlen( $text );
+		if ( \is_int( $length ) ) {
+			return $length;
+		}
+	}
+
+	return \mb_strlen( $text );
+}
+
+/**
+ * Truncate text to a grapheme limit, breaking at word boundaries.
+ *
+ * Counts graphemes (not code points), so the cut matches Bluesky's own
+ * 300-character measurement — a multi-code-point cluster like a ZWJ emoji
+ * costs one against the limit and is never split into mojibake. Falls back
+ * to code-point counting when `intl` is unavailable or the string is
+ * invalid UTF-8.
  *
  * @param string $text   Text to truncate.
- * @param int    $limit  Maximum characters (mb_strlen code points).
+ * @param int    $limit  Maximum length in graphemes.
  * @param string $marker Ellipsis marker.
  * @return string
  */
 function truncate_text( string $text, int $limit = 300, string $marker = '...' ): string {
+	if ( \function_exists( 'grapheme_strlen' ) ) {
+		$length = \grapheme_strlen( $text );
+
+		if ( \is_int( $length ) ) {
+			if ( $length <= $limit ) {
+				return $text;
+			}
+
+			$cut = \grapheme_substr( $text, 0, $limit - \grapheme_strlen( $marker ) );
+
+			if ( \is_string( $cut ) ) {
+				$last_word = \grapheme_strrpos( $cut, ' ' );
+
+				if ( false !== $last_word && $last_word > $limit * 0.8 ) {
+					$clipped = \grapheme_substr( $cut, 0, $last_word );
+					if ( \is_string( $clipped ) ) {
+						$cut = $clipped;
+					}
+				}
+
+				return $cut . $marker;
+			}
+		}
+	}
+
+	// Fallback: code-point counting (intl missing or invalid UTF-8).
 	if ( \mb_strlen( $text ) <= $limit ) {
 		return $text;
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -167,6 +167,21 @@ function grapheme_length( string $text ): int {
  * @return string
  */
 function truncate_text( string $text, int $limit = 300, string $marker = '...' ): string {
+	if ( $limit <= 0 ) {
+		return '';
+	}
+
+	/*
+	 * No room for the marker (e.g. a 1-grapheme budget with a "..." marker):
+	 * hard-clamp to the limit without one. Skipping this guard would leave
+	 * the cut length below negative, and `grapheme_substr()` / `mb_substr()`
+	 * read a negative length as "drop the last N" — returning almost the
+	 * whole string and overshooting the limit.
+	 */
+	if ( $limit <= grapheme_length( $marker ) ) {
+		return truncate_graphemes( $text, $limit );
+	}
+
 	if ( \function_exists( 'grapheme_strlen' ) ) {
 		$length = \grapheme_strlen( $text );
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -175,7 +175,7 @@ function truncate_text( string $text, int $limit = 300, string $marker = '...' )
 				return $text;
 			}
 
-			$cut = \grapheme_substr( $text, 0, $limit - \grapheme_strlen( $marker ) );
+			$cut = \grapheme_substr( $text, 0, $limit - grapheme_length( $marker ) );
 
 			if ( \is_string( $cut ) ) {
 				$last_word = \grapheme_strrpos( $cut, ' ' );

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -15,7 +15,9 @@ namespace Atmosphere\Transformer;
 
 use Atmosphere\API;
 use function Atmosphere\debug_log;
+use function Atmosphere\grapheme_length;
 use function Atmosphere\sanitize_text;
+use function Atmosphere\truncate_graphemes;
 use function Atmosphere\truncate_text;
 
 /**
@@ -234,9 +236,10 @@ class Post extends Base {
 	 * touched.
 	 *
 	 * Counts are reported in the same unit the publish path clamps on —
-	 * code points (`mb_strlen`), as used by `truncate_text()` — so the
-	 * preview never says "within limit" for text the publisher would
-	 * shorten. They are measured against the user's *untruncated* text: a
+	 * graphemes, as used by `truncate_text()` and Bluesky's own composer — so
+	 * the preview's "X / 300" matches what the author sees on Bluesky and
+	 * never says "within limit" for text the publisher would shorten. They
+	 * are measured against the user's *untruncated* text: a
 	 * short-form post longer than the limit still publishes a clamped
 	 * record, but the panel surfaces the real length (e.g. "340 / 300") so
 	 * the author knows truncation will happen before they publish. Composed
@@ -297,7 +300,7 @@ class Post extends Base {
 				$measured = (string) ( $record['text'] ?? '' );
 			}
 
-			$characters  = \mb_strlen( $measured );
+			$characters  = grapheme_length( $measured );
 			$projected[] = array(
 				'characters' => $characters,
 				'over_limit' => $characters > $limit,
@@ -425,10 +428,10 @@ class Post extends Base {
 	/**
 	 * The custom text shaped into a Bluesky post body.
 	 *
-	 * Hard-clamped toward Bluesky's 300-grapheme limit via `truncate_text()`,
-	 * which clamps by `mb_strlen()` code points (conservative — every grapheme
-	 * is at least one code point), the same clamp the short-form path uses, so
-	 * an over-long custom text is shortened rather than rejected.
+	 * Hard-clamped to Bluesky's 300-grapheme limit via `truncate_text()`,
+	 * which counts graphemes the way Bluesky's composer does — the same clamp
+	 * the short-form path uses, so an over-long custom text is shortened
+	 * rather than rejected.
 	 *
 	 * @return string
 	 */
@@ -663,12 +666,12 @@ class Post extends Base {
 		$parts = \array_filter( array( $title, $excerpt, $permalink ) );
 		$text  = \implode( "\n\n", $parts );
 
-		if ( \mb_strlen( $text ) <= self::BLUESKY_MAX_GRAPHEMES ) {
+		if ( grapheme_length( $text ) <= self::BLUESKY_MAX_GRAPHEMES ) {
 			return $text;
 		}
 
 		// Reserve space for permalink + separators.
-		$reserved  = \mb_strlen( $permalink ) + 4;
+		$reserved  = grapheme_length( $permalink ) + 4;
 		$available = self::BLUESKY_MAX_GRAPHEMES - $reserved;
 
 		if ( $available <= 0 ) {
@@ -1506,7 +1509,7 @@ class Post extends Base {
 	 * cannot fit is not really "short", and routing it to the long-form
 	 * composition (excerpt + permalink + external card) gives the reader a
 	 * teaser plus a route back to the original instead of a sentence fragment
-	 * with no link home. The overflow length is measured with `mb_strlen` to
+	 * with no link home. The overflow length is measured in graphemes to
 	 * match `build_short_form_text()`'s own `truncate_text()` cap, so the gate
 	 * and the truncation it avoids agree.
 	 *
@@ -1524,7 +1527,7 @@ class Post extends Base {
 			return false;
 		}
 
-		if ( \mb_strlen( $this->render_post_content_plain( $post ) ) <= self::BLUESKY_MAX_GRAPHEMES ) {
+		if ( grapheme_length( $this->render_post_content_plain( $post ) ) <= self::BLUESKY_MAX_GRAPHEMES ) {
 			return true;
 		}
 
@@ -2045,14 +2048,14 @@ class Post extends Base {
 	 *   3. Hard cap: `$max - 1` chars + trailing ellipsis (a single
 	 *      unbroken token longer than the budget).
 	 *
-	 * Character length uses `mb_strlen`, matching the convention of
-	 * the existing `truncate_text()` helper. Preg offsets are byte
-	 * offsets against the `mb_substr`-clamped string; substr on a
-	 * match's byte-end is UTF-8-safe because matches end on valid
-	 * sequence boundaries.
+	 * Character length is measured in graphemes, matching the convention of
+	 * the `truncate_text()` helper and Bluesky's 300-character cap. Preg
+	 * offsets are byte offsets against the grapheme-clamped string; substr on
+	 * a match's byte-end is UTF-8-safe because matches end on valid sequence
+	 * boundaries.
 	 *
 	 * @param string $text            Input text.
-	 * @param int    $max             Maximum character length (mb_strlen).
+	 * @param int    $max             Maximum length in graphemes.
 	 * @param bool   $prefer_sentence Prefer a sentence boundary over a word boundary.
 	 * @return string
 	 */
@@ -2061,7 +2064,7 @@ class Post extends Base {
 			return '';
 		}
 
-		if ( \mb_strlen( $text ) <= $max ) {
+		if ( grapheme_length( $text ) <= $max ) {
 			return $text;
 		}
 
@@ -2069,7 +2072,7 @@ class Post extends Base {
 			return '…';
 		}
 
-		$clamped = \mb_substr( $text, 0, $max );
+		$clamped = truncate_graphemes( $text, $max );
 
 		if ( $prefer_sentence
 			&& \preg_match_all(
@@ -2089,8 +2092,8 @@ class Post extends Base {
 			return $word_cut;
 		}
 
-		// Hard cap. Reserve one character for the ellipsis.
-		return \mb_substr( $text, 0, \max( 1, $max - 1 ) ) . '…';
+		// Hard cap. Reserve one grapheme for the ellipsis.
+		return truncate_graphemes( $text, \max( 1, $max - 1 ) ) . '…';
 	}
 
 	/**
@@ -2102,7 +2105,7 @@ class Post extends Base {
 	 * @return bool
 	 */
 	private function requires_link_card_for_long_permalink(): bool {
-		return \mb_strlen( \get_permalink( $this->object ) ) >= self::BLUESKY_MAX_GRAPHEMES;
+		return grapheme_length( \get_permalink( $this->object ) ) >= self::BLUESKY_MAX_GRAPHEMES;
 	}
 
 	/**
@@ -2118,7 +2121,7 @@ class Post extends Base {
 	 * @return bool
 	 */
 	private function requires_link_card_for_teaser_thread(): bool {
-		return \mb_strlen( $this->teaser_thread_cta_text() ) > self::BLUESKY_MAX_GRAPHEMES;
+		return grapheme_length( $this->teaser_thread_cta_text() ) > self::BLUESKY_MAX_GRAPHEMES;
 	}
 
 	/**
@@ -2154,17 +2157,17 @@ class Post extends Base {
 		$permalink  = \get_permalink( $this->object );
 		$plain      = $this->render_post_content_plain( $this->object );
 
-		if ( \mb_strlen( $permalink ) >= $max_length ) {
+		if ( grapheme_length( $permalink ) >= $max_length ) {
 			return $this->truncate_to_budget( $permalink, $max_length, false );
 		}
 
-		$budget = $max_length - \mb_strlen( $permalink );
+		$budget = $max_length - grapheme_length( $permalink );
 
-		if ( $budget <= \mb_strlen( $separator ) ) {
+		if ( $budget <= grapheme_length( $separator ) ) {
 			return $permalink;
 		}
 
-		$body = $this->truncate_to_budget( $plain, $budget - \mb_strlen( $separator ), false );
+		$body = $this->truncate_to_budget( $plain, $budget - grapheme_length( $separator ), false );
 
 		return $body . $separator . $permalink;
 	}

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -670,8 +670,12 @@ class Post extends Base {
 			return $text;
 		}
 
-		// Reserve space for permalink + separators.
-		$reserved  = grapheme_length( $permalink ) + 4;
+		/*
+		 * Reserve space for the permalink plus the one "\n\n" separator that
+		 * joins it to the prose below (the title/excerpt separator is already
+		 * inside $prose).
+		 */
+		$reserved  = grapheme_length( $permalink ) + 2;
 		$available = self::BLUESKY_MAX_GRAPHEMES - $reserved;
 
 		if ( $available <= 0 ) {

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -2424,9 +2424,10 @@ class Post extends Base {
 
 		// Confirm the hook IS the whole body, not a truncated prefix.
 		// 280 mirrors `compute_default_teaser_thread()`'s body-as-hook
-		// budget; for a body at or below that length the hook
-		// equals the body verbatim and `chunk_source` is empty.
-		return \mb_strlen( $this->render_post_content_plain( $this->object ) ) <= 280;
+		// budget, which `truncate_to_budget()` measures in graphemes; for a
+		// body at or below that length the hook equals the body verbatim and
+		// `chunk_source` is empty.
+		return grapheme_length( $this->render_post_content_plain( $this->object ) ) <= 280;
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-functions.php
+++ b/tests/phpunit/tests/class-test-functions.php
@@ -255,6 +255,17 @@ class Test_Functions extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A budget too small to hold the marker hard-clamps to the limit
+	 * without one, rather than letting a negative cut length return nearly
+	 * the whole string and overshoot the limit.
+	 */
+	public function test_truncate_text_budget_smaller_than_marker() {
+		$this->assertSame( '', truncate_text( 'Hello world', 0 ) );
+		$this->assertSame( 'H', truncate_text( 'Hello world', 1 ) );
+		$this->assertSame( 'He', truncate_text( 'Hello world', 2 ) );
+	}
+
+	/**
 	 * The grapheme_length() helper counts a ZWJ family emoji as one, where
 	 * mb_strlen would report its five code points.
 	 */

--- a/tests/phpunit/tests/class-test-functions.php
+++ b/tests/phpunit/tests/class-test-functions.php
@@ -12,6 +12,7 @@ use function Atmosphere\build_at_uri;
 use function Atmosphere\sanitize_text;
 use function Atmosphere\truncate_text;
 use function Atmosphere\truncate_graphemes;
+use function Atmosphere\grapheme_length;
 use function Atmosphere\to_iso8601;
 use function Atmosphere\is_post_publishable;
 use function Atmosphere\is_sharing_enabled;
@@ -208,6 +209,64 @@ class Test_Functions extends \WP_UnitTestCase {
 
 		$this->assertLessThanOrEqual( 50, \mb_strlen( $result ) );
 		$this->assertStringEndsWith( '...', $result );
+	}
+
+	/**
+	 * Emoji-heavy text within the grapheme budget is returned untouched,
+	 * even when its code-point count exceeds the limit. Bluesky measures
+	 * the 300-cap in graphemes, so a family emoji (five code points) must
+	 * count as one against the limit — not five.
+	 */
+	public function test_truncate_text_counts_emoji_as_graphemes() {
+		if ( ! \function_exists( 'grapheme_strlen' ) ) {
+			$this->markTestSkipped( 'intl extension required for grapheme counting.' );
+		}
+
+		// 50 family emoji: 50 graphemes, but 250 code points.
+		$family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
+		$text   = \str_repeat( $family, 50 );
+
+		$this->assertGreaterThan( 100, \mb_strlen( $text ) );
+		$this->assertSame( $text, truncate_text( $text, 100 ) );
+	}
+
+	/**
+	 * When emoji text does exceed the grapheme budget, the cut lands on a
+	 * cluster boundary — never splitting a family emoji into mojibake — and
+	 * the result, marker included, stays within the grapheme limit.
+	 */
+	public function test_truncate_text_truncates_on_grapheme_boundary() {
+		if ( ! \function_exists( 'grapheme_strlen' ) ) {
+			$this->markTestSkipped( 'intl extension required for grapheme counting.' );
+		}
+
+		$family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
+		$text   = \str_repeat( $family, 200 ); // 200 graphemes.
+
+		$result = truncate_text( $text, 100 );
+
+		$this->assertLessThanOrEqual( 100, \grapheme_strlen( $result ) );
+		$this->assertStringEndsWith( '...', $result );
+
+		// The emoji body (marker stripped) is whole families, never a
+		// half-cluster: stripping '...' leaves a clean run of families.
+		$body = \substr( $result, 0, -3 );
+		$this->assertSame( \str_repeat( $family, \grapheme_strlen( $body ) ), $body );
+	}
+
+	/**
+	 * The grapheme_length() helper counts a ZWJ family emoji as one, where
+	 * mb_strlen would report its five code points.
+	 */
+	public function test_grapheme_length_counts_emoji_as_one() {
+		if ( ! \function_exists( 'grapheme_strlen' ) ) {
+			$this->markTestSkipped( 'intl extension required for grapheme counting.' );
+		}
+
+		$family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
+
+		$this->assertSame( 1, grapheme_length( $family ) );
+		$this->assertSame( 3, grapheme_length( 'abc' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-functions.php
+++ b/tests/phpunit/tests/class-test-functions.php
@@ -267,6 +267,10 @@ class Test_Functions extends \WP_UnitTestCase {
 
 		$this->assertSame( 1, grapheme_length( $family ) );
 		$this->assertSame( 3, grapheme_length( 'abc' ) );
+
+		// Other multi-code-point clusters Bluesky also counts as one.
+		$this->assertSame( 1, grapheme_length( "\u{1F44D}\u{1F3FB}" ) ); // Thumbs-up + skin tone.
+		$this->assertSame( 1, grapheme_length( "\u{1F1FA}\u{1F1F8}" ) ); // Flag: US.
 	}
 
 	/**

--- a/tests/phpunit/tests/transformer/class-test-post.php
+++ b/tests/phpunit/tests/transformer/class-test-post.php
@@ -107,6 +107,30 @@ class Test_Post extends WP_UnitTestCase {
 	}
 
 	/**
+	 * When the composed title + excerpt + permalink overflows 300 characters,
+	 * the link-card text is truncated to fit and still ends with the full
+	 * permalink. Exercises `build_text()`'s overflow/reservation branch.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_long_form_link_card_text_truncates_within_limit() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => \str_repeat( 'word ', 80 ), // ~400 chars, overflows on its own.
+				'post_content' => '',
+				'post_excerpt' => '',
+			)
+		);
+
+		$record    = ( new Post( $post ) )->transform();
+		$permalink = \get_permalink( $post );
+
+		// ASCII body, so code points and graphemes coincide.
+		$this->assertLessThanOrEqual( 300, \mb_strlen( $record['text'] ) );
+		$this->assertStringEndsWith( $permalink, $record['text'] );
+	}
+
+	/**
 	 * An untitled post is short-form: body becomes the text, no embed.
 	 *
 	 * @covers ::transform

--- a/tests/phpunit/tests/transformer/class-test-post.php
+++ b/tests/phpunit/tests/transformer/class-test-post.php
@@ -292,6 +292,89 @@ class Test_Post extends WP_UnitTestCase {
 	}
 
 	/**
+	 * An emoji-heavy short-form body whose code-point count exceeds 300 but
+	 * whose grapheme count stays under it is published whole — Bluesky's cap
+	 * is 300 graphemes, so a ZWJ family emoji counts as one, not five.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_short_form_keeps_emoji_body_within_grapheme_limit() {
+		if ( ! \function_exists( 'grapheme_strlen' ) ) {
+			$this->markTestSkipped( 'intl extension required for grapheme counting.' );
+		}
+
+		// 70 family emoji: 70 graphemes, but 350 code points.
+		$family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
+		$post   = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => '',
+				'post_content' => \str_repeat( $family, 70 ),
+			)
+		);
+
+		$record = ( new Post( $post ) )->transform();
+
+		// Whole body survives: 70 graphemes, no ellipsis, no cluster split.
+		$this->assertSame( 70, \grapheme_strlen( $record['text'] ) );
+		$this->assertStringNotContainsString( '...', $record['text'] );
+	}
+
+	/**
+	 * An inline link preceded by enough emoji to push the code-point count
+	 * past 300 — but not the grapheme count — keeps its facet. Counting code
+	 * points here would truncate the body and drop the link.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_short_form_keeps_link_facet_after_emoji_overflow() {
+		if ( ! \function_exists( 'grapheme_strlen' ) ) {
+			$this->markTestSkipped( 'intl extension required for grapheme counting.' );
+		}
+
+		// 70 family emoji (350 code points / 70 graphemes), then a link.
+		$family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
+		$post   = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => '',
+				'post_content' => \str_repeat( $family, 70 ) . ' Read <a href="https://example.com/page">the source</a>.',
+			)
+		);
+
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertLessThanOrEqual( 300, \grapheme_strlen( $record['text'] ) );
+		$this->assertContains( 'https://example.com/page', $this->facet_link_uris( $record ), 'The link must survive emoji overflow.' );
+		$this->assertFacetsWithinText( $record );
+	}
+
+	/**
+	 * The pre-publish projection counts graphemes, so its "X / 300" matches
+	 * the number Bluesky's own composer shows — a family emoji is one, not
+	 * five code points.
+	 *
+	 * @covers ::project
+	 */
+	public function test_project_counts_emoji_body_as_graphemes() {
+		if ( ! \function_exists( 'grapheme_strlen' ) ) {
+			$this->markTestSkipped( 'intl extension required for grapheme counting.' );
+		}
+
+		// 50 family emoji: 50 graphemes, 250 code points.
+		$family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
+		$post   = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => '',
+				'post_content' => \str_repeat( $family, 50 ),
+			)
+		);
+
+		$projection = ( new Post( $post ) )->project();
+
+		$this->assertSame( 50, $projection['records'][0]['characters'] );
+		$this->assertFalse( $projection['records'][0]['over_limit'] );
+	}
+
+	/**
 	 * An `href`-like attribute on another key (e.g. `data-href`) is not
 	 * treated as the link target, so non-link markup never becomes a facet.
 	 *

--- a/tests/phpunit/tests/transformer/class-test-post.php
+++ b/tests/phpunit/tests/transformer/class-test-post.php
@@ -972,6 +972,26 @@ class Test_Post extends WP_UnitTestCase {
 		$this->assertNotSame( '', $cut );
 	}
 
+	/**
+	 * The hard-cap path measures in graphemes: an unbroken run of ZWJ family
+	 * emoji past the budget is clamped to whole clusters plus an ellipsis,
+	 * never split into mojibake.
+	 */
+	public function test_truncate_to_budget_hard_cap_counts_graphemes() {
+		if ( ! \function_exists( 'grapheme_strlen' ) ) {
+			$this->markTestSkipped( 'intl extension required for grapheme counting.' );
+		}
+
+		// A single unbroken token (no spaces): 50 family emoji, 250 code points.
+		$family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
+		$cut    = $this->truncate( \str_repeat( $family, 50 ), 10, true );
+
+		// 9 family clusters + the ellipsis: 10 graphemes, no split cluster.
+		$this->assertSame( 10, \grapheme_strlen( $cut ) );
+		$this->assertSame( '…', \mb_substr( $cut, -1 ) );
+		$this->assertSame( \str_repeat( $family, 9 ) . '…', $cut );
+	}
+
 	/*
 	 * -----------------------------------------------------------------
 	 * build_long_form_records() — strategy branches.
@@ -1581,6 +1601,40 @@ class Test_Post extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'embed', $records[0] );
 		$this->assertSame( 'app.bsky.embed.external', $records[0]['embed']['$type'] );
 		$this->assertSame( \get_permalink( $post ), $records[0]['embed']['external']['uri'] );
+	}
+
+	/**
+	 * An emoji-only body within the 280-grapheme hook budget — but well over
+	 * it in code points — still collapses to a single record. The hook is the
+	 * whole body, so the redundancy gate, which measures in graphemes, fires
+	 * just as it does for an equivalent ASCII body.
+	 *
+	 * @covers ::build_long_form_records
+	 */
+	public function test_build_long_form_records_teaser_thread_emoji_body_collapses_to_single_record() {
+		if ( ! \function_exists( 'grapheme_strlen' ) ) {
+			$this->markTestSkipped( 'intl extension required for grapheme counting.' );
+		}
+
+		// 200 family emoji: 200 graphemes (under the 280 hook budget) but
+		// 1,000 code points (over it). Counting code points here would read
+		// the hook as a truncated prefix and ship a needless 2-entry thread.
+		$family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
+		$post   = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'Titled',
+				'post_content' => \str_repeat( $family, 200 ),
+				'post_excerpt' => '',
+			)
+		);
+
+		\add_filter( 'atmosphere_long_form_composition', fn() => 'teaser-thread' );
+
+		$records = ( new Post( $post ) )->build_long_form_records();
+
+		$this->assertCount( 1, $records );
+		$this->assertSame( 200, \grapheme_strlen( $records[0]['text'] ) );
+		$this->assertSame( 'app.bsky.embed.external', $records[0]['embed']['$type'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #140

## Proposed changes:

The short-form publish path measured Bluesky's 300-character cap with `mb_strlen` (Unicode **code points**), but Bluesky measures it in **graphemes** (its `app.bsky.feed.post` lexicon declares `maxGraphemes: 300`, and its composer counts the same way). A multi-code-point cluster — a ZWJ family emoji 👨‍👩‍👧‍👦, a skin-tone modifier, a flag — counted as several characters instead of one, so the plugin:

* trimmed emoji-heavy posts earlier than Bluesky would have, and
* showed a pre-publish character count that disagreed with the number Bluesky's own composer shows for the same text.

This was never a *rejected-post* bug (graphemes ≤ code points, so the old count was conservative) — it over-counted, over-truncated, and surfaced a misleading "X / 300".

This PR makes the whole short-form path count graphemes the way Bluesky does:

* New `grapheme_length()` helper (graphemes, with an `mb_strlen` fallback when `intl` is missing or the string is invalid UTF-8 — that direction never under-counts).
* `truncate_text()` rewritten to cut on grapheme boundaries (word-break + ellipsis preserved), so a cluster is never split into mojibake.
* Every **300-cap** measurement in the Post transformer switched to graphemes: the pre-publish counter (`project()`), the short/long classification gate, `build_text`, `truncate_to_budget`, the link-card guards, `build_truncate_link_text`, and the teaser-thread collapse gate that mirrors the 280-grapheme hook budget.
* The facet byte-offset survival logic is intentionally left in bytes — it operates on the truncated output and stays correct.

The `>= 10` "is there enough prose" substance floors are deliberately left as code points: they're fuzzy heuristics, not the 300-cap, and aren't coupled to the truncation unit.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Create a titleless post whose body is ~70 ZWJ family emoji (`👨‍👩‍👧` repeated) — over 300 code points but only ~70 graphemes.
2. Open the Bluesky pre-publish panel: the count reads ~70 / 300 (not ~350 / 300) and is not flagged over-limit.
3. Publish (or inspect the transform): the full emoji body is shared, not truncated mid-way.
4. Add an inline link after a long emoji run that pushes code points past 300 but keeps graphemes under it — the link survives as a facet instead of being dropped.
5. `npm run env-test` and `composer lint` both pass.

### Changelog entry

A `patch` / `Fixed` entry is committed on the branch (`.github/changelog/fix-grapheme-truncation`).
