### PR TITLE
Surface quoted posts when importing Bluesky replies as comments

### DIFF
--- a/.github/changelog/fix-comment-quote-embed
+++ b/.github/changelog/fix-comment-quote-embed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Bluesky replies that quote another post now keep a link to the quoted post when imported as comments, instead of dropping it.

--- a/includes/class-reaction-sync.php
+++ b/includes/class-reaction-sync.php
@@ -566,10 +566,6 @@ class Reaction_Sync {
 
 		$text = $record['text'] ?? '';
 
-		if ( '' === $text ) {
-			return false;
-		}
-
 		/*
 		 * Bluesky stores `text` as the display string — long URLs are
 		 * truncated to e.g. `bsky.app/profile/jere...` and the real
@@ -583,6 +579,28 @@ class Reaction_Sync {
 		 */
 		$facets = $record['facets'] ?? array();
 		$text   = Facet::apply( $text, \is_array( $facets ) ? $facets : array() );
+
+		/*
+		 * A reply that quotes another post carries the quoted post's
+		 * AT-URI in `embed` (app.bsky.embed.record), not in `text`.
+		 * Surface it as a linked blockquote so the quote isn't dropped on
+		 * import; append after the reply text, mirroring how Bluesky
+		 * renders the quote card below the reply.
+		 */
+		$quote = self::build_quote_html( $record );
+
+		if ( '' !== $quote ) {
+			$text = '' === $text ? $quote : $text . "\n\n" . $quote;
+		}
+
+		/*
+		 * Drop replies that carry neither text nor a resolvable quote —
+		 * the gate is here, after both are resolved, so a quote-only
+		 * reply (empty `text`, populated `embed`) still imports.
+		 */
+		if ( '' === $text ) {
+			return false;
+		}
 
 		/**
 		 * Filters whether a reply should be synced as a WordPress comment.
@@ -895,6 +913,117 @@ class Reaction_Sync {
 		}
 
 		return \esc_url_raw( 'https://bsky.app/profile/' . \rawurlencode( $handle ) . '/post/' . $rkey );
+	}
+
+	/**
+	 * Build a blockquote linking to a reply's quoted post, if any.
+	 *
+	 * Bluesky quote-posts attach the quoted record to the reply's `embed`
+	 * (`app.bsky.embed.record`, or `recordWithMedia` when the quote also
+	 * carries media), pointing at the quoted post's AT-URI — the reply's
+	 * `text` says nothing about it. Without this, the quote is dropped on
+	 * import.
+	 *
+	 * Returns an HTML fragment safe to pass through the caller's
+	 * `wp_kses_post()` gate, or '' when there's no quoted `app.bsky.feed.post`
+	 * to link to. The quoted post's own text is intentionally not resolved:
+	 * it usually lives in another actor's repo, which would require a
+	 * separate network round-trip per quote — a link to the quote is enough
+	 * to stop the drop.
+	 *
+	 * @param array $record The reply record (notification record or own value).
+	 * @return string Blockquote HTML, or '' when there's no linkable quote.
+	 */
+	private static function build_quote_html( array $record ): string {
+		$embed = $record['embed'] ?? null;
+
+		if ( ! \is_array( $embed ) ) {
+			return '';
+		}
+
+		$uri = self::quoted_post_uri( $embed );
+		$url = '' === $uri ? '' : self::quoted_post_web_url( $uri );
+
+		if ( '' === $url ) {
+			return '';
+		}
+
+		$href = \esc_url( $url );
+
+		if ( '' === $href ) {
+			return '';
+		}
+
+		return '<blockquote class="atmosphere-bsky-quote"><p><a href="' . $href . '">'
+			. \esc_html__( 'Quoted post on Bluesky', 'atmosphere' )
+			. '</a></p></blockquote>';
+	}
+
+	/**
+	 * Read the quoted post's AT-URI out of a reply's `embed`.
+	 *
+	 * Handles `app.bsky.embed.record` (URI at `record.uri`) and
+	 * `app.bsky.embed.recordWithMedia` (one level deeper at
+	 * `record.record.uri`), along with their hydrated `#view` forms, which
+	 * share the same paths. Every level is `is_array()`-guarded because the
+	 * embed is untrusted PDS JSON; an unrecognised or malformed shape
+	 * returns '' rather than fataling the cron sync.
+	 *
+	 * @param array $embed The record's `embed` value.
+	 * @return string The quoted post's AT-URI, or '' when absent/malformed.
+	 */
+	private static function quoted_post_uri( array $embed ): string {
+		$type = $embed['$type'] ?? '';
+
+		if ( ! \is_string( $type ) || ! \str_starts_with( $type, 'app.bsky.embed.record' ) ) {
+			return '';
+		}
+
+		$record = $embed['record'] ?? null;
+
+		if ( ! \is_array( $record ) ) {
+			return '';
+		}
+
+		// recordWithMedia nests the quoted record one level deeper.
+		if ( ! isset( $record['uri'] ) && \is_array( $record['record'] ?? null ) ) {
+			$record = $record['record'];
+		}
+
+		$uri = $record['uri'] ?? '';
+
+		return \is_string( $uri ) ? $uri : '';
+	}
+
+	/**
+	 * Convert a quoted post's AT-URI to its bsky.app web URL.
+	 *
+	 * Builds the DID form (`bsky.app/profile/<did>/post/<rkey>`), which
+	 * resolves without a handle lookup. Only `app.bsky.feed.post` records
+	 * have a bsky.app post page, so any other collection — or a malformed
+	 * URI — returns ''.
+	 *
+	 * @param string $at_uri Quoted post AT-URI.
+	 * @return string The bsky.app URL, or '' when not a linkable post.
+	 */
+	private static function quoted_post_web_url( string $at_uri ): string {
+		if ( ! \str_starts_with( $at_uri, 'at://' ) ) {
+			return '';
+		}
+
+		$parts = \explode( '/', \substr( $at_uri, \strlen( 'at://' ) ) );
+
+		if ( 3 !== \count( $parts ) ) {
+			return '';
+		}
+
+		list( $repo, $collection, $rkey ) = $parts;
+
+		if ( 'app.bsky.feed.post' !== $collection || '' === $repo || '' === $rkey ) {
+			return '';
+		}
+
+		return 'https://bsky.app/profile/' . $repo . '/post/' . $rkey;
 	}
 
 	/**

--- a/includes/class-reaction-sync.php
+++ b/includes/class-reaction-sync.php
@@ -1014,34 +1014,39 @@ class Reaction_Sync {
 	}
 
 	/**
-	 * Convert a quoted post's AT-URI to its bsky.app web URL.
+	 * Convert a quoted post's AT-URI to its appview web URL.
 	 *
-	 * Builds the DID form (`bsky.app/profile/<did>/post/<rkey>`), which
-	 * resolves without a handle lookup. Only `app.bsky.feed.post` records
-	 * have a bsky.app post page, so any other collection — or a malformed
-	 * URI — returns ''.
+	 * Builds the DID form (`profile/<did>/post/<rkey>`), which resolves
+	 * without a handle lookup. The host defaults to `bsky.app` and is
+	 * filterable via `atmosphere_appview_host`. Only `app.bsky.feed.post`
+	 * records have an appview post page, so any other collection — or a
+	 * malformed URI — returns ''.
 	 *
 	 * @param string $at_uri Quoted post AT-URI.
-	 * @return string The bsky.app URL, or '' when not a linkable post.
+	 * @return string The appview URL, or '' when not a linkable post.
 	 */
 	private static function quoted_post_web_url( string $at_uri ): string {
-		if ( ! \str_starts_with( $at_uri, 'at://' ) ) {
+		$parts = parse_at_uri( $at_uri );
+
+		if ( false === $parts ) {
 			return '';
 		}
 
-		$parts = \explode( '/', \substr( $at_uri, \strlen( 'at://' ) ) );
-
-		if ( 3 !== \count( $parts ) ) {
+		if ( 'app.bsky.feed.post' !== $parts['collection'] || '' === $parts['did'] || '' === $parts['rkey'] ) {
 			return '';
 		}
 
-		list( $repo, $collection, $rkey ) = $parts;
-
-		if ( 'app.bsky.feed.post' !== $collection || '' === $repo || '' === $rkey ) {
-			return '';
-		}
-
-		return 'https://bsky.app/profile/' . $repo . '/post/' . $rkey;
+		// The DID is passed raw, matching the other profile/<did>/post/<rkey>
+		// builders (Atmosphere::* and Facet); its colons are valid path chars
+		// the appview expects unencoded. Handles, by contrast, are rawurlencode()d.
+		return appview_url(
+			'profile/' . $parts['did'] . '/post/' . $parts['rkey'],
+			array(
+				'type' => 'post',
+				'did'  => $parts['did'],
+				'rkey' => $parts['rkey'],
+			)
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-reaction-sync.php
+++ b/tests/phpunit/tests/class-test-reaction-sync.php
@@ -249,6 +249,334 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A reply that quotes another post carries the quoted post's AT-URI in
+	 * the record's `embed` (app.bsky.embed.record), not in `text`. The
+	 * imported comment must surface it as a linked blockquote pointing at
+	 * the quoted post's bsky.app page. Regression test for issue #133.
+	 */
+	public function test_process_reply_appends_quote_post_embed() {
+		$post_id  = self::factory()->post->create();
+		$post_uri = 'at://did:plc:me/app.bsky.feed.post/mypost';
+
+		\update_post_meta( $post_id, BskyPost::META_URI, $post_uri );
+
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'process_reply' );
+
+		$notification = array(
+			'uri'    => 'at://did:plc:replier/app.bsky.feed.post/quotereply',
+			'cid'    => 'bafyreiquote',
+			'record' => array(
+				'text'      => 'Look at this!',
+				'createdAt' => '2026-06-20T12:00:00.000Z',
+				'embed'     => array(
+					'$type'  => 'app.bsky.embed.record',
+					'record' => array(
+						'cid' => 'bafyreifz7yief4dwg7wgyotql3zkknx4nolwcl2ukio6jdld4ejn7wclfm',
+						'uri' => 'at://did:plc:quoted/app.bsky.feed.post/3mnzu7nvcss2e',
+					),
+				),
+				'reply'     => array(
+					'parent' => array( 'uri' => $post_uri ),
+					'root'   => array( 'uri' => $post_uri ),
+				),
+			),
+			'author' => array(
+				'did'    => 'did:plc:replier',
+				'handle' => 'replier.bsky.social',
+			),
+		);
+
+		$comment_id = $method->invoke( null, $notification );
+
+		$this->assertIsInt( $comment_id );
+
+		$comment = \get_comment( $comment_id );
+
+		// The original reply text survives.
+		$this->assertStringContainsString( 'Look at this!', $comment->comment_content );
+		// A blockquote links to the quoted post on bsky.app (DID form).
+		$this->assertStringContainsString( '<blockquote', $comment->comment_content );
+		$this->assertStringContainsString(
+			'href="https://bsky.app/profile/did:plc:quoted/post/3mnzu7nvcss2e"',
+			$comment->comment_content
+		);
+	}
+
+	/**
+	 * A quote that also carries media uses app.bsky.embed.recordWithMedia,
+	 * which nests the quoted record one level deeper. The quoted post must
+	 * still be surfaced. Regression test for issue #133.
+	 */
+	public function test_process_reply_appends_quote_from_record_with_media() {
+		$post_id  = self::factory()->post->create();
+		$post_uri = 'at://did:plc:me/app.bsky.feed.post/mypost';
+
+		\update_post_meta( $post_id, BskyPost::META_URI, $post_uri );
+
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'process_reply' );
+
+		$notification = array(
+			'uri'    => 'at://did:plc:replier/app.bsky.feed.post/quotemedia',
+			'cid'    => 'bafyreiquotemedia',
+			'record' => array(
+				'text'      => 'Quote with an image.',
+				'createdAt' => '2026-06-20T12:00:00.000Z',
+				'embed'     => array(
+					'$type'  => 'app.bsky.embed.recordWithMedia',
+					'record' => array(
+						'$type'  => 'app.bsky.embed.record',
+						'record' => array(
+							'cid' => 'bafyreinested',
+							'uri' => 'at://did:plc:quoted/app.bsky.feed.post/withmedia',
+						),
+					),
+					'media'  => array(
+						'$type'  => 'app.bsky.embed.images',
+						'images' => array(),
+					),
+				),
+				'reply'     => array(
+					'parent' => array( 'uri' => $post_uri ),
+					'root'   => array( 'uri' => $post_uri ),
+				),
+			),
+			'author' => array(
+				'did'    => 'did:plc:replier',
+				'handle' => 'replier.bsky.social',
+			),
+		);
+
+		$comment_id = $method->invoke( null, $notification );
+
+		$this->assertIsInt( $comment_id );
+
+		$comment = \get_comment( $comment_id );
+
+		$this->assertStringContainsString( 'Quote with an image.', $comment->comment_content );
+		$this->assertStringContainsString(
+			'href="https://bsky.app/profile/did:plc:quoted/post/withmedia"',
+			$comment->comment_content
+		);
+	}
+
+	/**
+	 * A reply that is *only* a quote (empty text) must still import as a
+	 * comment carrying the quote blockquote, rather than being dropped by
+	 * the empty-text gate. Regression test for issue #133.
+	 */
+	public function test_process_reply_imports_quote_only_reply() {
+		$post_id  = self::factory()->post->create();
+		$post_uri = 'at://did:plc:me/app.bsky.feed.post/mypost';
+
+		\update_post_meta( $post_id, BskyPost::META_URI, $post_uri );
+
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'process_reply' );
+
+		$notification = array(
+			'uri'    => 'at://did:plc:replier/app.bsky.feed.post/quoteonly',
+			'cid'    => 'bafyreiquoteonly',
+			'record' => array(
+				'text'      => '',
+				'createdAt' => '2026-06-20T12:00:00.000Z',
+				'embed'     => array(
+					'$type'  => 'app.bsky.embed.record',
+					'record' => array(
+						'uri' => 'at://did:plc:quoted/app.bsky.feed.post/onlyquote',
+					),
+				),
+				'reply'     => array(
+					'parent' => array( 'uri' => $post_uri ),
+					'root'   => array( 'uri' => $post_uri ),
+				),
+			),
+			'author' => array(
+				'did'    => 'did:plc:replier',
+				'handle' => 'replier.bsky.social',
+			),
+		);
+
+		$comment_id = $method->invoke( null, $notification );
+
+		$this->assertIsInt( $comment_id );
+
+		$comment = \get_comment( $comment_id );
+
+		$this->assertStringContainsString(
+			'href="https://bsky.app/profile/did:plc:quoted/post/onlyquote"',
+			$comment->comment_content
+		);
+	}
+
+	/**
+	 * Only quoted `app.bsky.feed.post` records get a bsky.app post link;
+	 * a quoted record of another collection (e.g. a feed generator or
+	 * list) has no post page, so no blockquote is added — but the reply
+	 * text still imports normally.
+	 */
+	public function test_process_reply_ignores_non_post_quote_embed() {
+		$post_id  = self::factory()->post->create();
+		$post_uri = 'at://did:plc:me/app.bsky.feed.post/mypost';
+
+		\update_post_meta( $post_id, BskyPost::META_URI, $post_uri );
+
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'process_reply' );
+
+		$notification = array(
+			'uri'    => 'at://did:plc:replier/app.bsky.feed.post/quotelist',
+			'cid'    => 'bafyreiquotelist',
+			'record' => array(
+				'text'      => 'Quoting a list.',
+				'createdAt' => '2026-06-20T12:00:00.000Z',
+				'embed'     => array(
+					'$type'  => 'app.bsky.embed.record',
+					'record' => array(
+						'uri' => 'at://did:plc:quoted/app.bsky.graph.list/somelist',
+					),
+				),
+				'reply'     => array(
+					'parent' => array( 'uri' => $post_uri ),
+					'root'   => array( 'uri' => $post_uri ),
+				),
+			),
+			'author' => array(
+				'did'    => 'did:plc:replier',
+				'handle' => 'replier.bsky.social',
+			),
+		);
+
+		$comment_id = $method->invoke( null, $notification );
+
+		$this->assertIsInt( $comment_id );
+
+		$comment = \get_comment( $comment_id );
+
+		$this->assertSame( 'Quoting a list.', $comment->comment_content );
+		$this->assertStringNotContainsString( '<blockquote', $comment->comment_content );
+	}
+
+	/**
+	 * The hydrated `app.bsky.embed.record#view` shape (returned by feed /
+	 * thread views) carries the quoted post's URI at the same `record.uri`
+	 * path as the raw record form, and the `$type` prefix match must accept
+	 * it. Locks in the documented `#view` support.
+	 */
+	public function test_process_reply_appends_quote_from_record_view() {
+		$post_id  = self::factory()->post->create();
+		$post_uri = 'at://did:plc:me/app.bsky.feed.post/mypost';
+
+		\update_post_meta( $post_id, BskyPost::META_URI, $post_uri );
+
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'process_reply' );
+
+		$notification = array(
+			'uri'    => 'at://did:plc:replier/app.bsky.feed.post/quoteview',
+			'cid'    => 'bafyreiquoteview',
+			'record' => array(
+				'text'      => 'Quoting from a view.',
+				'createdAt' => '2026-06-20T12:00:00.000Z',
+				'embed'     => array(
+					'$type'  => 'app.bsky.embed.record#view',
+					'record' => array(
+						'$type' => 'app.bsky.embed.record#viewRecord',
+						'uri'   => 'at://did:plc:quoted/app.bsky.feed.post/viewquote',
+					),
+				),
+				'reply'     => array(
+					'parent' => array( 'uri' => $post_uri ),
+					'root'   => array( 'uri' => $post_uri ),
+				),
+			),
+			'author' => array(
+				'did'    => 'did:plc:replier',
+				'handle' => 'replier.bsky.social',
+			),
+		);
+
+		$comment_id = $method->invoke( null, $notification );
+
+		$this->assertIsInt( $comment_id );
+
+		$comment = \get_comment( $comment_id );
+
+		$this->assertStringContainsString(
+			'href="https://bsky.app/profile/did:plc:quoted/post/viewquote"',
+			$comment->comment_content
+		);
+	}
+
+	/**
+	 * A malformed `embed` value (untrusted PDS JSON) must not fatal the
+	 * cron sync; the reply still imports as a plain comment without a
+	 * blockquote. Covers a scalar embed and a record whose `uri` is the
+	 * wrong type — pinning the `is_array`/`is_string` guards.
+	 *
+	 * @dataProvider data_malformed_embeds
+	 * @param mixed $embed Malformed embed value.
+	 */
+	public function test_process_reply_tolerates_malformed_embed( $embed ) {
+		$post_id  = self::factory()->post->create();
+		$post_uri = 'at://did:plc:me/app.bsky.feed.post/mypost';
+
+		\update_post_meta( $post_id, BskyPost::META_URI, $post_uri );
+
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'process_reply' );
+
+		$notification = array(
+			'uri'    => 'at://did:plc:replier/app.bsky.feed.post/badembed-' . \uniqid(),
+			'cid'    => 'bafyreibadembed',
+			'record' => array(
+				'text'      => 'Plain reply with a broken embed.',
+				'createdAt' => '2026-06-20T12:00:00.000Z',
+				'embed'     => $embed,
+				'reply'     => array(
+					'parent' => array( 'uri' => $post_uri ),
+					'root'   => array( 'uri' => $post_uri ),
+				),
+			),
+			'author' => array(
+				'did'    => 'did:plc:replier',
+				'handle' => 'replier.bsky.social',
+			),
+		);
+
+		$comment_id = $method->invoke( null, $notification );
+
+		$this->assertIsInt( $comment_id );
+		$comment = \get_comment( $comment_id );
+		$this->assertSame( 'Plain reply with a broken embed.', $comment->comment_content );
+		$this->assertStringNotContainsString( '<blockquote', $comment->comment_content );
+	}
+
+	/**
+	 * Data provider for malformed `embed` shapes.
+	 *
+	 * @return array<string, array{0: mixed}>
+	 */
+	public function data_malformed_embeds(): array {
+		return array(
+			'scalar embed'       => array( 'not-an-array' ),
+			'non-array record'   => array(
+				array(
+					'$type'  => 'app.bsky.embed.record',
+					'record' => 'nope',
+				),
+			),
+			'non-string uri'     => array(
+				array(
+					'$type'  => 'app.bsky.embed.record',
+					'record' => array( 'uri' => array() ),
+				),
+			),
+			'unknown embed type' => array(
+				array(
+					'$type'  => 'app.bsky.embed.images',
+					'images' => array(),
+				),
+			),
+		);
+	}
+
+	/**
 	 * A reply whose record carries a malformed `facets` value (untrusted
 	 * PDS JSON) must still import as a plain comment rather than fataling
 	 * the cron sync with a TypeError. Regression test for PR #134.

--- a/tests/phpunit/tests/class-test-reaction-sync.php
+++ b/tests/phpunit/tests/class-test-reaction-sync.php
@@ -505,6 +505,61 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The quote link is built through `appview_url()`, so a site that swaps
+	 * its appview host via `atmosphere_appview_host` gets the quote link
+	 * pointed at that host too — it must not be the lone hardcoded `bsky.app`.
+	 */
+	public function test_process_reply_quote_honors_appview_host_filter() {
+		$post_id  = self::factory()->post->create();
+		$post_uri = 'at://did:plc:me/app.bsky.feed.post/mypost';
+
+		\update_post_meta( $post_id, BskyPost::META_URI, $post_uri );
+
+		$filter = static fn() => 'deer.social';
+		\add_filter( 'atmosphere_appview_host', $filter );
+
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'process_reply' );
+
+		$notification = array(
+			'uri'    => 'at://did:plc:replier/app.bsky.feed.post/quotefiltered',
+			'cid'    => 'bafyreiquotefiltered',
+			'record' => array(
+				'text'      => 'Quoting on a custom appview.',
+				'createdAt' => '2026-06-20T12:00:00.000Z',
+				'embed'     => array(
+					'$type'  => 'app.bsky.embed.record',
+					'record' => array(
+						'cid' => 'bafyreifiltered',
+						'uri' => 'at://did:plc:quoted/app.bsky.feed.post/filteredpost',
+					),
+				),
+				'reply'     => array(
+					'parent' => array( 'uri' => $post_uri ),
+					'root'   => array( 'uri' => $post_uri ),
+				),
+			),
+			'author' => array(
+				'did'    => 'did:plc:replier',
+				'handle' => 'replier.bsky.social',
+			),
+		);
+
+		$comment_id = $method->invoke( null, $notification );
+
+		\remove_filter( 'atmosphere_appview_host', $filter );
+
+		$this->assertIsInt( $comment_id );
+
+		$comment = \get_comment( $comment_id );
+
+		$this->assertStringContainsString(
+			'href="https://deer.social/profile/did:plc:quoted/post/filteredpost"',
+			$comment->comment_content
+		);
+		$this->assertStringNotContainsString( 'bsky.app', $comment->comment_content );
+	}
+
+	/**
 	 * A malformed `embed` value (untrusted PDS JSON) must not fatal the
 	 * cron sync; the reply still imports as a plain comment without a
 	 * blockquote. Covers a scalar embed and a record whose `uri` is the


### PR DESCRIPTION
Fixes #133

## Proposed changes:

* A Bluesky reply that quotes another post carries the quoted post's AT-URI in the reply record's `embed` (`app.bsky.embed.record`, or `recordWithMedia` when the quote also carries media), not in `text` — so `Reaction_Sync` was silently dropping the quote on import.
* This detects the quote embed in the same inbound pass that resolves facets and appends a `<blockquote>` linking to the quoted post's `bsky.app` page, built from the AT-URI's DID so no handle lookup is needed; only `app.bsky.feed.post` quotes get a link, and every nested shape is `is_array()`-guarded against malformed PDS JSON.
* The empty-text gate now runs *after* the quote is resolved, so a quote-only reply (empty `text`, populated `embed`) imports instead of being dropped.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Connect the plugin to a Bluesky account and publish a post.
* From Bluesky, reply to that post and use the "quote post" action to quote another Bluesky post (with or without text in the reply itself).
* Run the reaction sync (`wp atmosphere sync-reactions`, or wait for the scheduled run) and open the imported comment.
* **Before:** the quoted post is dropped entirely. **After:** the comment shows the reply text followed by a blockquote linking to the quoted post on Bluesky. A reply that is *only* a quote (no text) now imports too.

### Changelog entry

A changelog entry is already committed on this branch (`.github/changelog/fix-comment-quote-embed`), so no auto-entry is needed.

-   [ ] Automatically create a changelog entry from the details below.