### PR TITLE
Make the Bluesky appview host filterable

### DIFF
--- a/.github/changelog/add-filterable-appview-host
+++ b/.github/changelog/add-filterable-appview-host
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a filter so links to Bluesky can point at an alternative AT Protocol appview.

--- a/.github/changelog/add-filterable-appview-host
+++ b/.github/changelog/add-filterable-appview-host
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add a filter so links to Bluesky can point at an alternative AT Protocol appview.
+Add filters so links to Bluesky can point at an alternative AT Protocol appview, including ones hosted on a subdomain or subpath.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,8 @@ Text domain: always `'atmosphere'`.
 
 **MUST** use `use` imports for cross-namespace references — no inline `\Namespace\Class`.
 
+**MUST** build any front-end-displayed Bluesky/appview web link (`profile`, `post`, `hashtag`, `mention`) through `Atmosphere\appview_url( $path, $context )` in `includes/functions.php` — never hardcode `https://bsky.app/...`. The helper centralizes the host and makes it filterable (`atmosphere_appview_host` / `atmosphere_appview_url`). Keep escaping at the call site (`\esc_url()` for HTML, `\esc_url_raw()` for storage); the helper returns an unescaped URL on purpose. This applies to display links only, not to AT Protocol records being published.
+
 ## Autoloading
 
 Uses the custom `Atmosphere\Autoloader` in `includes/class-autoloader.php`, which respects WordPress filename conventions (`class-foo.php`, lowercase, hyphenated). `composer.json` declares an empty `autoload` block — Composer is only used for dev tooling (PHPUnit, PHPCS, Changelogger). Helper functions in `includes/functions.php` are loaded via a direct `require_once` from `atmosphere.php`.

--- a/docs/developer-docs.md
+++ b/docs/developer-docs.md
@@ -49,7 +49,7 @@ When adding a new public hook, mark its `@since` tag as `unreleased` — the rel
 
 ### Pointing Bluesky links at another appview
 
-Rendered links to Bluesky (profiles, hashtags, mentions, posts) default to the `bsky.app` web appview. The `atmosphere_appview_host` filter swaps that host for any AT Protocol appview. Callbacks receive three arguments and must return a bare host (no scheme, no trailing slash):
+Rendered links to Bluesky (profiles, hashtags, mentions, posts) default to the `bsky.app` web appview. The `atmosphere_appview_host` filter swaps that host for any AT Protocol appview. A callback must return a bare host (no scheme, no trailing slash). The filter passes up to three arguments; as with any WordPress filter, register with `$accepted_args = 3` if your callback needs `$path` and `$context`:
 
 - `$host` — the default host, `'bsky.app'`.
 - `$path` — the path being built, e.g. `profile/<did>` or `hashtag/<tag>`.
@@ -58,6 +58,16 @@ Rendered links to Bluesky (profiles, hashtags, mentions, posts) default to the `
 ```php
 // Point Bluesky web links at an alternative appview.
 add_filter( 'atmosphere_appview_host', fn() => 'deer.social' );
+
+// Route by context: send profiles elsewhere, keep hashtags on bsky.app.
+add_filter(
+	'atmosphere_appview_host',
+	function ( $host, $path, $context ) {
+		return 'hashtag' === ( $context['type'] ?? '' ) ? $host : 'deer.social';
+	},
+	10,
+	3
+);
 ```
 
 Of note: links rendered on the fly (facet mentions, hashtags, and the "View on Bluesky" link) pick up the filter on every render, so changing it updates them immediately. The author and source links stored on synced reaction comments are resolved once at sync time, so they keep whichever host was in effect when the comment was synced.

--- a/docs/developer-docs.md
+++ b/docs/developer-docs.md
@@ -40,11 +40,25 @@ ATmosphere exposes a small set of filters and actions for plugins to extend beha
 | `atmosphere_should_sync_reply` | filter | Customise which inbound Bluesky replies become WordPress comments. |
 | `atmosphere_transform_bsky_post` | filter | Mutate the Bluesky post record before write. |
 | `atmosphere_transform_document` | filter | Mutate the document record before write. |
+| `atmosphere_appview_host` | filter | Point Bluesky web links at an alternative AT Protocol appview. |
 | `atmosphere_publish_post_result` | action | React to a post-publish outcome (success or `WP_Error`). |
 | `atmosphere_publish_comment_result` | action | React to a comment-publish outcome. |
 | `atmosphere_reaction_synced` | action | React when a Bluesky reaction is stored as a WordPress comment. |
 
 When adding a new public hook, mark its `@since` tag as `unreleased` — the release script rewrites it (see [Release Process → Marking Unreleased Code](release-process.md#marking-unreleased-code)).
+
+### Pointing Bluesky links at another appview
+
+Rendered links to Bluesky (profiles, hashtags, mentions, posts) default to the `bsky.app` web appview. The `atmosphere_appview_host` filter swaps that host for any AT Protocol appview. Callbacks receive three arguments and must return a bare host (no scheme, no trailing slash):
+
+- `$host` — the default host, `'bsky.app'`.
+- `$path` — the path being built, e.g. `profile/<did>` or `hashtag/<tag>`.
+- `$context` — array with the available parts: `type`, `did`, `handle`, `rkey`, `tag`.
+
+```php
+// Point Bluesky web links at an alternative appview.
+add_filter( 'atmosphere_appview_host', fn() => 'deer.social' );
+```
 
 ## Extending Content Formats
 

--- a/docs/developer-docs.md
+++ b/docs/developer-docs.md
@@ -40,7 +40,8 @@ ATmosphere exposes a small set of filters and actions for plugins to extend beha
 | `atmosphere_should_sync_reply` | filter | Customise which inbound Bluesky replies become WordPress comments. |
 | `atmosphere_transform_bsky_post` | filter | Mutate the Bluesky post record before write. |
 | `atmosphere_transform_document` | filter | Mutate the document record before write. |
-| `atmosphere_appview_host` | filter | Point Bluesky web links at an alternative AT Protocol appview. |
+| `atmosphere_appview_host` | filter | Point Bluesky web links at an alternative AT Protocol appview (host or subpath). |
+| `atmosphere_appview_url` | filter | Rewrite the whole assembled appview link, including its route. |
 | `atmosphere_publish_post_result` | action | React to a post-publish outcome (success or `WP_Error`). |
 | `atmosphere_publish_comment_result` | action | React to a comment-publish outcome. |
 | `atmosphere_reaction_synced` | action | React when a Bluesky reaction is stored as a WordPress comment. |
@@ -49,15 +50,25 @@ When adding a new public hook, mark its `@since` tag as `unreleased` — the rel
 
 ### Pointing Bluesky links at another appview
 
-Rendered links to Bluesky (profiles, hashtags, mentions, posts) default to the `bsky.app` web appview. The `atmosphere_appview_host` filter swaps that host for any AT Protocol appview. A callback must return a bare host (no scheme, no trailing slash). The filter passes up to three arguments; as with any WordPress filter, register with `$accepted_args = 3` if your callback needs `$path` and `$context`:
+Rendered links to Bluesky (profiles, hashtags, mentions, posts) default to the `bsky.app` web appview. Two filters let you redirect them, depending on how much you need to change.
 
-- `$host` — the default host, `'bsky.app'`.
+Both filters pass up to three arguments. As with any WordPress filter, register with `$accepted_args = 3` if your callback needs `$path` and `$context`:
+
 - `$path` — the path being built, e.g. `profile/<did>` or `hashtag/<tag>`.
-- `$context` — array with the available parts: `type`, `did`, `handle`, `rkey`, `tag`.
+- `$context` — array with the available parts: `type` (one of `profile`, `post`, `mention`, `hashtag`), `did`, `handle`, `rkey`, `tag`.
+
+#### `atmosphere_appview_host` — swap the host (or subpath)
+
+Use this when the alternative appview mirrors bsky.app's routes (`/profile/...`, `/hashtag/...`) and you only need to change where they live. The first argument is the default host, `'bsky.app'`.
+
+The returned value can be a bare host, a host on a subdomain, or a host with a path prefix, with or without a scheme or trailing slash — it's normalized before use, so an appview hosted on a subpath works cleanly:
 
 ```php
-// Point Bluesky web links at an alternative appview.
+// Bare host.
 add_filter( 'atmosphere_appview_host', fn() => 'deer.social' );
+
+// Appview living on a subpath: yields https://something.social/atblue/profile/<did>.
+add_filter( 'atmosphere_appview_host', fn() => 'something.social/atblue' );
 
 // Route by context: send profiles elsewhere, keep hashtags on bsky.app.
 add_filter(
@@ -70,7 +81,26 @@ add_filter(
 );
 ```
 
-Of note: links rendered on the fly (facet mentions, hashtags, and the "View on Bluesky" link) pick up the filter on every render, so changing it updates them immediately. The author and source links stored on synced reaction comments are resolved once at sync time, so they keep whichever host was in effect when the comment was synced.
+#### `atmosphere_appview_url` — rewrite the whole link
+
+Use this when the appview's routes differ from bsky.app's — for example `/account/<did>` instead of `/profile/<did>`, or a custom hashtag route. The first argument is the fully assembled URL (after the host filter has run); rebuild it from `$context` and return a complete URL:
+
+```php
+// Custom profile route: /account/<did> instead of /profile/<did>.
+add_filter(
+	'atmosphere_appview_url',
+	function ( $url, $path, $context ) {
+		if ( 'mention' === ( $context['type'] ?? '' ) || 'profile' === ( $context['type'] ?? '' ) ) {
+			return 'https://my.appview/account/' . ( $context['did'] ?? $context['handle'] ?? '' );
+		}
+		return $url;
+	},
+	10,
+	3
+);
+```
+
+Of note: links rendered on the fly (facet mentions, hashtags, and the "View on Bluesky" link) pick up the filters on every render, so changing them updates immediately. The author and source links stored on synced reaction comments are resolved once at sync time, so they keep whichever host was in effect when the comment was synced.
 
 ## Extending Content Formats
 

--- a/docs/developer-docs.md
+++ b/docs/developer-docs.md
@@ -60,6 +60,8 @@ Rendered links to Bluesky (profiles, hashtags, mentions, posts) default to the `
 add_filter( 'atmosphere_appview_host', fn() => 'deer.social' );
 ```
 
+Of note: links rendered on the fly (facet mentions, hashtags, and the "View on Bluesky" link) pick up the filter on every render, so changing it updates them immediately. The author and source links stored on synced reaction comments are resolved once at sync time, so they keep whichever host was in effect when the comment was synced.
+
 ## Extending Content Formats
 
 The `site.standard.document` record's `content` field is a singular open union of typed content objects (see [`docs/content-formats.md`](content-formats.md)). ATmosphere ships built-in parsers for HTML, Markpub, Leaflet, and pckt formats, and integrations can register additional parsers.

--- a/docs/php-coding-standards.md
+++ b/docs/php-coding-standards.md
@@ -223,6 +223,7 @@ use function Atmosphere\is_connected;
 \apply_filters( 'atmosphere_backfill_query_chunk_size',   500 );
 \apply_filters( 'atmosphere_oauth_redirect_uri',          $uri );
 \apply_filters( 'atmosphere_client_metadata',             $metadata );
+\apply_filters( 'atmosphere_appview_host',                'bsky.app', $path, $context ); // Bare host for appview web links; $context keys: type|did|handle|rkey|tag.
 ```
 
 **Actions:**

--- a/docs/php-coding-standards.md
+++ b/docs/php-coding-standards.md
@@ -223,7 +223,8 @@ use function Atmosphere\is_connected;
 \apply_filters( 'atmosphere_backfill_query_chunk_size',   500 );
 \apply_filters( 'atmosphere_oauth_redirect_uri',          $uri );
 \apply_filters( 'atmosphere_client_metadata',             $metadata );
-\apply_filters( 'atmosphere_appview_host',                'bsky.app', $path, $context ); // Bare host for appview web links; $context keys: type|did|handle|rkey|tag.
+\apply_filters( 'atmosphere_appview_host',                'bsky.app', $path, $context ); // Host/subpath for appview web links; normalized; $context keys: type|did|handle|rkey|tag.
+\apply_filters( 'atmosphere_appview_url',                 $url, $path, $context );        // Whole assembled appview link; rewrite the route from $context.
 ```
 
 **Actions:**

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -1434,11 +1434,12 @@ class Atmosphere {
 	}
 
 	/**
-	 * Build the bsky.app web URL for one of our own post AT-URIs.
+	 * Build the appview web URL for one of our own post AT-URIs.
 	 *
 	 * `at://<did>/app.bsky.feed.post/<rkey>` →
-	 * `https://bsky.app/profile/<did>/post/<rkey>`. bsky.app resolves the
-	 * DID form, so no handle lookup is needed.
+	 * `https://<appview-host>/profile/<did>/post/<rkey>`. The appview resolves
+	 * the DID form, so no handle lookup is needed. The host defaults to
+	 * `bsky.app` and is filterable via `atmosphere_appview_host`.
 	 *
 	 * @param string $uri AT-URI from `Post::META_URI`.
 	 * @return string Web URL, or '' when the URI shape is unexpected.

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -1448,7 +1448,16 @@ class Atmosphere {
 			return '';
 		}
 
-		return \esc_url_raw( 'https://bsky.app/profile/' . $matches['did'] . '/post/' . $matches['rkey'] );
+		return \esc_url_raw(
+			appview_url(
+				'profile/' . $matches['did'] . '/post/' . $matches['rkey'],
+				array(
+					'type' => 'post',
+					'did'  => $matches['did'],
+					'rkey' => $matches['rkey'],
+				)
+			)
+		);
 	}
 
 	/**

--- a/includes/class-reaction-sync.php
+++ b/includes/class-reaction-sync.php
@@ -725,7 +725,15 @@ class Reaction_Sync {
 			'comment_post_ID'      => $post_id,
 			'comment_parent'       => $comment_parent,
 			'comment_author'       => $author_name,
-			'comment_author_url'   => \esc_url_raw( 'https://bsky.app/profile/' . \rawurlencode( $author_handle ) ),
+			'comment_author_url'   => \esc_url_raw(
+				appview_url(
+					'profile/' . \rawurlencode( $author_handle ),
+					array(
+						'type'   => 'profile',
+						'handle' => $author_handle,
+					)
+				)
+			),
 			'comment_author_email' => '',
 			'comment_author_IP'    => '',
 			'comment_content'      => \wp_kses_post( $content ),
@@ -894,7 +902,16 @@ class Reaction_Sync {
 			return '';
 		}
 
-		return \esc_url_raw( 'https://bsky.app/profile/' . \rawurlencode( $handle ) . '/post/' . $rkey );
+		return \esc_url_raw(
+			appview_url(
+				'profile/' . \rawurlencode( $handle ) . '/post/' . $rkey,
+				array(
+					'type'   => 'post',
+					'handle' => $handle,
+					'rkey'   => $rkey,
+				)
+			)
+		);
 	}
 
 	/**

--- a/includes/class-reaction-sync.php
+++ b/includes/class-reaction-sync.php
@@ -881,10 +881,11 @@ class Reaction_Sync {
 	}
 
 	/**
-	 * Build the https://bsky.app/... web URL for a given AT-URI + handle.
+	 * Build the appview web URL for a given AT-URI + handle.
 	 *
-	 * Only app.bsky.feed.post records have a corresponding bsky.app
-	 * web page; like and repost rkeys don't, so those return ''.
+	 * Only app.bsky.feed.post records have a corresponding appview web
+	 * page; like and repost rkeys don't, so those return ''. The host
+	 * defaults to `bsky.app` and is filterable via `atmosphere_appview_host`.
 	 *
 	 * @param string $at_uri AT-URI.
 	 * @param string $handle Bluesky handle.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -46,6 +46,37 @@ function build_at_uri( string $did, string $collection, string $rkey ): string {
 }
 
 /**
+ * Build a web URL pointing at an AT Protocol appview.
+ *
+ * Returns an UNESCAPED URL. Callers MUST escape at the point of use
+ * (\esc_url() for HTML output, \esc_url_raw() for storage/redirects), as
+ * late as possible and in the right context.
+ *
+ * @param string $path    Path after the host, with no leading slash, e.g.
+ *                        'profile/<did>/post/<rkey>' or 'hashtag/<tag>'.
+ *                        Callers are responsible for encoding path segments.
+ * @param array  $context Optional parts the caller has on hand. Recognised
+ *                        keys: 'type' (profile|post|mention|hashtag), 'did',
+ *                        'handle', 'rkey', 'tag'.
+ * @return string Unescaped URL, e.g. 'https://bsky.app/profile/<did>'.
+ */
+function appview_url( string $path, array $context = array() ): string {
+	/**
+	 * Filters the host used for AT Protocol appview web links.
+	 *
+	 * Return a bare host with no scheme or trailing slash (e.g. 'deer.social').
+	 * Defaults to 'bsky.app', the Bluesky appview.
+	 *
+	 * @param string $host    Default appview host ('bsky.app').
+	 * @param string $path    Path being built, e.g. 'profile/<did>'.
+	 * @param array  $context Available parts: type, did, handle, rkey, tag.
+	 */
+	$host = \apply_filters( 'atmosphere_appview_host', 'bsky.app', $path, $context );
+
+	return 'https://' . $host . '/' . $path;
+}
+
+/**
  * Decode entities, strip HTML, normalise whitespace.
  *
  * @param string $text Raw text.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -103,9 +103,17 @@ function appview_url( string $path, array $context = array() ): string {
  * Normalize a filtered appview base into a clean 'scheme://host[:port][/prefix]'.
  *
  * Accepts a bare host, a host with a path prefix, with or without a scheme or
- * trailing slash, and rebuilds it without empty or doubled segments. The scheme
- * is clamped to http/https, and an unparseable or hostless value falls back to
- * the default 'https://bsky.app'.
+ * trailing slash, and rebuilds it without empty or doubled segments. The host is
+ * lower-cased and the scheme is clamped to http/https. An empty value falls back
+ * to 'https://bsky.app' silently; a non-empty value that yields no host falls
+ * back too, but flags `_doing_it_wrong` since the callback returned something
+ * unusable.
+ *
+ * These URLs are display links — rendered for users to click, or stored as
+ * comment author/source links — and are always escaped at the call site. They
+ * are never fetched server-side, so there is no SSRF surface, and IP-literal or
+ * localhost hosts are intentionally allowed for self-hosted appviews. The value
+ * comes from a site-owner filter callback, not from external request input.
  *
  * @param string $base Filtered base value, e.g. 'something.social/atblue/'.
  * @return string Clean base with no trailing slash, e.g. 'https://something.social/atblue'.
@@ -113,15 +121,25 @@ function appview_url( string $path, array $context = array() ): string {
 function appview_base_url( string $base ): string {
 	$base = \trim( $base );
 
+	// An empty value just means "use the default appview" — nothing to flag.
+	if ( '' === $base ) {
+		return 'https://bsky.app';
+	}
+
 	// Ensure a scheme so wp_parse_url splits the host from any path prefix.
 	if ( ! \preg_match( '#^[a-z][a-z0-9+.-]*://#i', $base ) ) {
 		$base = 'https://' . \ltrim( $base, '/' );
 	}
 
 	$parts = \wp_parse_url( $base );
-	$host  = \is_array( $parts ) ? ( $parts['host'] ?? '' ) : '';
+	$host  = \is_array( $parts ) ? \strtolower( $parts['host'] ?? '' ) : '';
 
 	if ( '' === $host ) {
+		\_doing_it_wrong(
+			__FUNCTION__,
+			\esc_html__( 'atmosphere_appview_host must return a host (optionally with a scheme and path prefix); falling back to bsky.app.', 'atmosphere' ),
+			'unreleased'
+		);
 		return 'https://bsky.app';
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -67,6 +67,8 @@ function appview_url( string $path, array $context = array() ): string {
 	 * Return a bare host with no scheme or trailing slash (e.g. 'deer.social').
 	 * Defaults to 'bsky.app', the Bluesky appview.
 	 *
+	 * @since unreleased
+	 *
 	 * @param string $host    Default appview host ('bsky.app').
 	 * @param string $path    Path being built, e.g. 'profile/<did>'.
 	 * @param array  $context Available parts: type, did, handle, rkey, tag.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -62,10 +62,15 @@ function build_at_uri( string $did, string $collection, string $rkey ): string {
  */
 function appview_url( string $path, array $context = array() ): string {
 	/**
-	 * Filters the host used for AT Protocol appview web links.
+	 * Filters the base of AT Protocol appview web links.
 	 *
-	 * Return a bare host with no scheme or trailing slash (e.g. 'deer.social').
-	 * Defaults to 'bsky.app', the Bluesky appview.
+	 * The base is everything before the path: scheme, host, and an optional
+	 * path prefix. The returned value may be a bare host ('deer.social'), a
+	 * host with a path prefix ('something.social/atblue'), and may include a
+	 * scheme and/or trailing slash — it is normalized before use, so appviews
+	 * hosted on a subdomain or a subpath work cleanly. Defaults to 'bsky.app',
+	 * the Bluesky appview. To rewrite the path itself (e.g. a custom route),
+	 * use the {@see 'atmosphere_appview_url'} filter instead.
 	 *
 	 * @since unreleased
 	 *
@@ -73,9 +78,62 @@ function appview_url( string $path, array $context = array() ): string {
 	 * @param string $path    Path being built, e.g. 'profile/<did>'.
 	 * @param array  $context Available parts: type, did, handle, rkey, tag.
 	 */
-	$host = \apply_filters( 'atmosphere_appview_host', 'bsky.app', $path, $context );
+	$base = \apply_filters( 'atmosphere_appview_host', 'bsky.app', $path, $context );
 
-	return 'https://' . $host . '/' . $path;
+	$url = appview_base_url( $base ) . '/' . \ltrim( $path, '/' );
+
+	/**
+	 * Filters the fully assembled AT Protocol appview web URL.
+	 *
+	 * Use this to rewrite the entire URL — including the route, e.g.
+	 * '/account/<did>' instead of '/profile/<did>', or a custom hashtag
+	 * route — by rebuilding it from the parts in $context. Return a complete
+	 * URL; it is escaped by the caller, not here.
+	 *
+	 * @since unreleased
+	 *
+	 * @param string $url     Assembled URL, e.g. 'https://bsky.app/profile/<did>'.
+	 * @param string $path    Path that was appended, e.g. 'profile/<did>'.
+	 * @param array  $context Available parts: type, did, handle, rkey, tag.
+	 */
+	return \apply_filters( 'atmosphere_appview_url', $url, $path, $context );
+}
+
+/**
+ * Normalize a filtered appview base into a clean 'scheme://host[:port][/prefix]'.
+ *
+ * Accepts a bare host, a host with a path prefix, with or without a scheme or
+ * trailing slash, and rebuilds it without empty or doubled segments. The scheme
+ * is clamped to http/https, and an unparseable or hostless value falls back to
+ * the default 'https://bsky.app'.
+ *
+ * @param string $base Filtered base value, e.g. 'something.social/atblue/'.
+ * @return string Clean base with no trailing slash, e.g. 'https://something.social/atblue'.
+ */
+function appview_base_url( string $base ): string {
+	$base = \trim( $base );
+
+	// Ensure a scheme so wp_parse_url splits the host from any path prefix.
+	if ( ! \preg_match( '#^[a-z][a-z0-9+.-]*://#i', $base ) ) {
+		$base = 'https://' . \ltrim( $base, '/' );
+	}
+
+	$parts = \wp_parse_url( $base );
+	$host  = \is_array( $parts ) ? ( $parts['host'] ?? '' ) : '';
+
+	if ( '' === $host ) {
+		return 'https://bsky.app';
+	}
+
+	$scheme = \strtolower( $parts['scheme'] ?? 'https' );
+	if ( 'http' !== $scheme && 'https' !== $scheme ) {
+		$scheme = 'https';
+	}
+
+	$port   = isset( $parts['port'] ) ? ':' . $parts['port'] : '';
+	$prefix = \trim( $parts['path'] ?? '', '/' );
+
+	return $scheme . '://' . $host . $port . ( '' !== $prefix ? '/' . $prefix : '' );
 }
 
 /**

--- a/includes/transformer/class-facet.php
+++ b/includes/transformer/class-facet.php
@@ -199,8 +199,8 @@ class Facet {
 			case 'app.bsky.richtext.facet#mention':
 				/*
 				 * The mention facet only carries the DID, so link by DID.
-				 * bsky.app/profile/{did} resolves the same as the handle
-				 * form used elsewhere in Reaction_Sync.
+				 * The appview's /profile/{did} resolves the same as the
+				 * handle form used elsewhere in Reaction_Sync.
 				 */
 				$did  = $feature['did'] ?? '';
 				$href = '' === $did

--- a/includes/transformer/class-facet.php
+++ b/includes/transformer/class-facet.php
@@ -13,6 +13,7 @@ namespace Atmosphere\Transformer;
 \defined( 'ABSPATH' ) || exit;
 
 use function Atmosphere\get_connection;
+use function Atmosphere\appview_url;
 
 /**
  * Extracts facets from plain text.
@@ -202,12 +203,32 @@ class Facet {
 				 * form used elsewhere in Reaction_Sync.
 				 */
 				$did  = $feature['did'] ?? '';
-				$href = '' === $did ? '' : \esc_url( 'https://bsky.app/profile/' . $did );
+				$href = '' === $did
+					? ''
+					: \esc_url(
+						appview_url(
+							'profile/' . $did,
+							array(
+								'type' => 'mention',
+								'did'  => $did,
+							)
+						)
+					);
 				break;
 
 			case 'app.bsky.richtext.facet#tag':
 				$tag  = $feature['tag'] ?? '';
-				$href = '' === $tag ? '' : \esc_url( 'https://bsky.app/hashtag/' . \rawurlencode( $tag ) );
+				$href = '' === $tag
+					? ''
+					: \esc_url(
+						appview_url(
+							'hashtag/' . \rawurlencode( $tag ),
+							array(
+								'type' => 'hashtag',
+								'tag'  => $tag,
+							)
+						)
+					);
 				break;
 
 			default:

--- a/tests/phpunit/tests/class-test-functions.php
+++ b/tests/phpunit/tests/class-test-functions.php
@@ -595,16 +595,42 @@ class Test_Functions extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * A non-http(s) scheme is clamped to https.
+	 * A non-http(s) scheme is clamped to https — including a javascript:
+	 * scheme, which must never survive into the link host.
 	 */
 	public function test_appview_url_clamps_unsupported_scheme() {
-		$callback = static function () {
+		$ftp = static function () {
 			return 'ftp://example.test';
+		};
+		\add_filter( 'atmosphere_appview_host', $ftp );
+		$this->assertSame(
+			'https://example.test/profile/did:plc:abc123',
+			appview_url( 'profile/did:plc:abc123' )
+		);
+		\remove_filter( 'atmosphere_appview_host', $ftp );
+
+		$js = static function () {
+			return 'javascript://evil.test';
+		};
+		\add_filter( 'atmosphere_appview_host', $js );
+		$url = appview_url( 'profile/did:plc:abc123' );
+		\remove_filter( 'atmosphere_appview_host', $js );
+
+		$this->assertSame( 'https://evil.test/profile/did:plc:abc123', $url );
+		$this->assertStringNotContainsString( 'javascript', $url );
+	}
+
+	/**
+	 * The host is lower-cased so a mixed-case filter return is normalized.
+	 */
+	public function test_appview_url_lowercases_host() {
+		$callback = static function () {
+			return 'Deer.Social/AtBlue';
 		};
 		\add_filter( 'atmosphere_appview_host', $callback );
 
 		$this->assertSame(
-			'https://example.test/profile/did:plc:abc123',
+			'https://deer.social/AtBlue/profile/did:plc:abc123',
 			appview_url( 'profile/did:plc:abc123' )
 		);
 
@@ -612,11 +638,34 @@ class Test_Functions extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * An empty or hostless filtered value falls back to the default appview.
+	 * An empty filtered value falls back to the default appview silently
+	 * (no _doing_it_wrong — an empty return just means "use the default").
 	 */
 	public function test_appview_url_falls_back_on_empty_host() {
+		foreach ( array( '   ', '' ) as $empty ) {
+			$callback = static function () use ( $empty ) {
+				return $empty;
+			};
+			\add_filter( 'atmosphere_appview_host', $callback );
+
+			$this->assertSame(
+				'https://bsky.app/profile/did:plc:abc123',
+				appview_url( 'profile/did:plc:abc123' )
+			);
+
+			\remove_filter( 'atmosphere_appview_host', $callback );
+		}
+	}
+
+	/**
+	 * A non-empty but unparseable filtered value falls back to the default
+	 * appview and flags _doing_it_wrong (the callback returned garbage).
+	 */
+	public function test_appview_url_warns_on_malformed_host() {
+		$this->setExpectedIncorrectUsage( 'Atmosphere\appview_base_url' );
+
 		$callback = static function () {
-			return '   ';
+			return 'https://:80';
 		};
 		\add_filter( 'atmosphere_appview_host', $callback );
 

--- a/tests/phpunit/tests/class-test-functions.php
+++ b/tests/phpunit/tests/class-test-functions.php
@@ -9,6 +9,7 @@ namespace Atmosphere\Tests;
 
 use function Atmosphere\parse_at_uri;
 use function Atmosphere\build_at_uri;
+use function Atmosphere\appview_url;
 use function Atmosphere\sanitize_text;
 use function Atmosphere\truncate_text;
 use function Atmosphere\truncate_graphemes;
@@ -433,5 +434,94 @@ class Test_Functions extends \WP_UnitTestCase {
 		$this->assertSame( 1, \substr_count( $contents, '[atmosphere] first line' ) );
 		$this->assertStringNotContainsString( "first line\n", $contents );
 		$this->assertStringNotContainsString( "first line\r", $contents );
+	}
+
+	/**
+	 * Default host yields a bsky.app URL.
+	 */
+	public function test_appview_url_default_host() {
+		$this->assertSame(
+			'https://bsky.app/profile/did:plc:abc123',
+			appview_url( 'profile/did:plc:abc123' )
+		);
+	}
+
+	/**
+	 * A filter can override the appview host.
+	 */
+	public function test_appview_url_filter_overrides_host() {
+		$callback = static function () {
+			return 'deer.social';
+		};
+		\add_filter( 'atmosphere_appview_host', $callback );
+
+		$this->assertSame(
+			'https://deer.social/profile/did:plc:abc123',
+			appview_url( 'profile/did:plc:abc123' )
+		);
+
+		\remove_filter( 'atmosphere_appview_host', $callback );
+	}
+
+	/**
+	 * The filter receives the path and context arguments.
+	 */
+	public function test_appview_url_filter_receives_path_and_context() {
+		$seen     = array();
+		$callback = static function ( $host, $path, $context ) use ( &$seen ) {
+			$seen = array(
+				'host'    => $host,
+				'path'    => $path,
+				'context' => $context,
+			);
+			return $host;
+		};
+		\add_filter( 'atmosphere_appview_host', $callback, 10, 3 );
+
+		appview_url(
+			'profile/did:plc:abc123/post/3kabc',
+			array(
+				'type' => 'post',
+				'did'  => 'did:plc:abc123',
+				'rkey' => '3kabc',
+			)
+		);
+
+		\remove_filter( 'atmosphere_appview_host', $callback, 10 );
+
+		$this->assertSame( 'bsky.app', $seen['host'] );
+		$this->assertSame( 'profile/did:plc:abc123/post/3kabc', $seen['path'] );
+		$this->assertSame( 'post', $seen['context']['type'] );
+		$this->assertSame( 'did:plc:abc123', $seen['context']['did'] );
+		$this->assertSame( '3kabc', $seen['context']['rkey'] );
+	}
+
+	/**
+	 * A callback can vary the host by context type.
+	 */
+	public function test_appview_url_host_varies_by_context_type() {
+		$callback = static function ( $host, $path, $context ) {
+			return 'hashtag' === ( $context['type'] ?? '' ) ? 'bsky.app' : 'deer.social';
+		};
+		\add_filter( 'atmosphere_appview_host', $callback, 10, 3 );
+
+		$profile = appview_url( 'profile/did:plc:abc123', array( 'type' => 'profile' ) );
+		$hashtag = appview_url( 'hashtag/WordPress', array( 'type' => 'hashtag' ) );
+
+		\remove_filter( 'atmosphere_appview_host', $callback, 10 );
+
+		$this->assertSame( 'https://deer.social/profile/did:plc:abc123', $profile );
+		$this->assertSame( 'https://bsky.app/hashtag/WordPress', $hashtag );
+	}
+
+	/**
+	 * The helper returns an unescaped URL (callers own escaping).
+	 */
+	public function test_appview_url_returns_unescaped() {
+		// An ampersand in the path is returned verbatim, not entity-encoded.
+		$this->assertSame(
+			'https://bsky.app/profile/a&b',
+			appview_url( 'profile/a&b' )
+		);
 	}
 }

--- a/tests/phpunit/tests/class-test-functions.php
+++ b/tests/phpunit/tests/class-test-functions.php
@@ -524,4 +524,166 @@ class Test_Functions extends \WP_UnitTestCase {
 			appview_url( 'profile/a&b' )
 		);
 	}
+
+	/**
+	 * A filtered host can include a path prefix (appview on a subpath).
+	 */
+	public function test_appview_url_host_with_path_prefix() {
+		$callback = static function () {
+			return 'something.social/atblue';
+		};
+		\add_filter( 'atmosphere_appview_host', $callback );
+
+		$this->assertSame(
+			'https://something.social/atblue/profile/did:plc:abc123',
+			appview_url( 'profile/did:plc:abc123' )
+		);
+
+		\remove_filter( 'atmosphere_appview_host', $callback );
+	}
+
+	/**
+	 * A filtered host is normalized: a scheme and trailing slash are cleaned
+	 * up so the join never produces doubled or empty segments.
+	 */
+	public function test_appview_url_host_is_normalized() {
+		$callback = static function () {
+			return 'https://sub.deer.social/atblue/';
+		};
+		\add_filter( 'atmosphere_appview_host', $callback );
+
+		$this->assertSame(
+			'https://sub.deer.social/atblue/hashtag/WordPress',
+			appview_url( 'hashtag/WordPress' )
+		);
+
+		\remove_filter( 'atmosphere_appview_host', $callback );
+	}
+
+	/**
+	 * A bare host with a trailing slash does not produce a double slash.
+	 */
+	public function test_appview_url_host_trailing_slash() {
+		$callback = static function () {
+			return 'deer.social/';
+		};
+		\add_filter( 'atmosphere_appview_host', $callback );
+
+		$this->assertSame(
+			'https://deer.social/profile/did:plc:abc123',
+			appview_url( 'profile/did:plc:abc123' )
+		);
+
+		\remove_filter( 'atmosphere_appview_host', $callback );
+	}
+
+	/**
+	 * An http scheme and port are preserved (e.g. for local testing).
+	 */
+	public function test_appview_url_preserves_http_and_port() {
+		$callback = static function () {
+			return 'http://localhost:3000';
+		};
+		\add_filter( 'atmosphere_appview_host', $callback );
+
+		$this->assertSame(
+			'http://localhost:3000/profile/did:plc:abc123',
+			appview_url( 'profile/did:plc:abc123' )
+		);
+
+		\remove_filter( 'atmosphere_appview_host', $callback );
+	}
+
+	/**
+	 * A non-http(s) scheme is clamped to https.
+	 */
+	public function test_appview_url_clamps_unsupported_scheme() {
+		$callback = static function () {
+			return 'ftp://example.test';
+		};
+		\add_filter( 'atmosphere_appview_host', $callback );
+
+		$this->assertSame(
+			'https://example.test/profile/did:plc:abc123',
+			appview_url( 'profile/did:plc:abc123' )
+		);
+
+		\remove_filter( 'atmosphere_appview_host', $callback );
+	}
+
+	/**
+	 * An empty or hostless filtered value falls back to the default appview.
+	 */
+	public function test_appview_url_falls_back_on_empty_host() {
+		$callback = static function () {
+			return '   ';
+		};
+		\add_filter( 'atmosphere_appview_host', $callback );
+
+		$this->assertSame(
+			'https://bsky.app/profile/did:plc:abc123',
+			appview_url( 'profile/did:plc:abc123' )
+		);
+
+		\remove_filter( 'atmosphere_appview_host', $callback );
+	}
+
+	/**
+	 * The atmosphere_appview_url filter can rewrite the whole URL, including
+	 * the route, from the context (e.g. /account/ instead of /profile/).
+	 */
+	public function test_appview_url_full_url_filter_rewrites_route() {
+		$callback = static function ( $url, $path, $context ) {
+			if ( 'mention' === ( $context['type'] ?? '' ) ) {
+				return 'https://bsky.app/account/' . $context['did'];
+			}
+			return $url;
+		};
+		\add_filter( 'atmosphere_appview_url', $callback, 10, 3 );
+
+		$this->assertSame(
+			'https://bsky.app/account/did:plc:abc123',
+			appview_url(
+				'profile/did:plc:abc123',
+				array(
+					'type' => 'mention',
+					'did'  => 'did:plc:abc123',
+				)
+			)
+		);
+
+		\remove_filter( 'atmosphere_appview_url', $callback, 10 );
+	}
+
+	/**
+	 * The atmosphere_appview_url filter receives the assembled URL, the path,
+	 * and the context.
+	 */
+	public function test_appview_url_full_url_filter_receives_args() {
+		$seen     = array();
+		$callback = static function ( $url, $path, $context ) use ( &$seen ) {
+			$seen = array(
+				'url'     => $url,
+				'path'    => $path,
+				'context' => $context,
+			);
+			return $url;
+		};
+		\add_filter( 'atmosphere_appview_url', $callback, 10, 3 );
+
+		appview_url(
+			'hashtag/WordPress',
+			array(
+				'type' => 'hashtag',
+				'tag'  => 'WordPress',
+			)
+		);
+
+		\remove_filter( 'atmosphere_appview_url', $callback, 10 );
+
+		$this->assertSame( 'https://bsky.app/hashtag/WordPress', $seen['url'] );
+		$this->assertSame( 'hashtag/WordPress', $seen['path'] );
+		$this->assertSame( 'hashtag', $seen['context']['type'] );
+		$this->assertSame( 'WordPress', $seen['context']['tag'] );
+	}
 }

--- a/tests/phpunit/tests/transformer/class-test-facet.php
+++ b/tests/phpunit/tests/transformer/class-test-facet.php
@@ -449,4 +449,37 @@ class Test_Facet extends WP_UnitTestCase {
 
 		$this->assertSame( $text, Facet::apply( $text, $facets ) );
 	}
+
+	/**
+	 * The atmosphere_appview_host filter changes rendered facet links.
+	 */
+	public function test_apply_honours_appview_host_filter() {
+		$callback = static function () {
+			return 'deer.social';
+		};
+		\add_filter( 'atmosphere_appview_host', $callback );
+
+		$text   = 'Love #WordPress here';
+		$facets = array(
+			array(
+				'index'    => array(
+					'byteStart' => 5,
+					'byteEnd'   => 15,
+				),
+				'features' => array(
+					array(
+						'$type' => 'app.bsky.richtext.facet#tag',
+						'tag'   => 'WordPress',
+					),
+				),
+			),
+		);
+
+		$result = Facet::apply( $text, $facets );
+
+		\remove_filter( 'atmosphere_appview_host', $callback );
+
+		$this->assertStringContainsString( 'https://deer.social/hashtag/WordPress', $result );
+		$this->assertStringNotContainsString( 'bsky.app', $result );
+	}
 }


### PR DESCRIPTION
Fixes #158

## Proposed changes:

We build Bluesky web links (`https://bsky.app/profile/...`, `/hashtag/...`) in five places across the plugin, with the `bsky.app` host hardcoded in each. This pulls that construction into a single helper and adds filtering so people can point readers at an alternative AT Protocol appview (deer.social, a self-hosted one, etc.).

* New helper `Atmosphere\appview_url( string $path, array $context = array() )` owns the `https://` scheme and the host, and runs it through the filters below.
* **`atmosphere_appview_host`** (default `bsky.app`) swaps the host. It accepts a bare host, a subdomain, or a host with a path prefix (`something.social/atblue`), with or without a scheme or trailing slash — the value is normalized with `wp_parse_url` (host lower-cased, scheme clamped to http/https, no doubled/empty segments), so appviews on a subpath work cleanly. A malformed return falls back to `bsky.app` (and flags `_doing_it_wrong`).
* **`atmosphere_appview_url`** wraps the fully assembled URL, so a callback can rewrite the whole route — e.g. `/account/<did>` instead of `/profile/<did>`, or a custom hashtag route — using the parts in `$context` (`type`, `did`, `handle`, `rkey`, `tag`).
* All five call sites go through the helper and keep escaping at the point of use (`esc_url_raw` for stored/meta values, `esc_url` for HTML). The helper returns an unescaped string on purpose, so escaping stays as late as possible.

These are all display-side links, so nothing here touches the records we publish to the network. It only changes where we point people when they click through. :)

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Unit tests for the helper (default host, filter override, subpath/subdomain bases, scheme preserve/clamp, port, trailing-slash and malformed-host handling, both filters' argument passing, and a full-URL route rewrite) plus an end-to-end test that runs the real Facet render path through the filter.

## Testing instructions:

* With no filter, confirm Bluesky links still point at `bsky.app` — open a synced post's "View on Bluesky" link, and check rendered reaction/comment links and facet mentions/hashtags. Nothing should change.
* Swap the host with a snippet (plugin or theme `functions.php`):
  ```php
  add_filter( 'atmosphere_appview_host', fn() => 'something.social/atblue' );
  ```
  Render a post with facet mentions/hashtags and confirm links become `https://something.social/atblue/...`.
* Rewrite a route with the URL filter:
  ```php
  add_filter( 'atmosphere_appview_url', function ( $url, $path, $context ) {
      return 'mention' === ( $context['type'] ?? '' )
          ? 'https://my.appview/account/' . $context['did']
          : $url;
  }, 10, 3 );
  ```
* Of note: links rendered on the fly pick up the filters immediately, while author/source links already stored on synced reaction comments keep the host they were synced with. Documented in `docs/developer-docs.md`.

### Changelog entry

Changelog entry already added manually on the branch (`.github/changelog/add-filterable-appview-host`), so no need to auto-generate one here.
