### PR TITLE
Harden AT Protocol HTTP redirects

### DIFF
--- a/.github/changelog/harden-atproto-http-redirects
+++ b/.github/changelog/harden-atproto-http-redirects
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AT Protocol OAuth and API requests now stay on their original endpoints instead of following redirects.

--- a/.github/changelog/harden-atproto-http-redirects
+++ b/.github/changelog/harden-atproto-http-redirects
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-AT Protocol OAuth and API requests now stay on their original endpoints instead of following redirects.
+Hardened the security of connections to your Bluesky account.

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -78,16 +78,18 @@ class API {
 		}
 
 		$defaults = array(
-			'method'  => $method,
-			'headers' => array(
+			'method'      => $method,
+			'headers'     => array(
 				'Authorization' => 'DPoP ' . $access_token,
 				'Content-Type'  => $content_type,
 				'DPoP'          => $dpop_proof,
 			),
-			'timeout' => 30,
+			'timeout'     => 30,
+			'redirection' => 0,
 		);
 
-		$args = \wp_parse_args( $args, $defaults );
+		$args                = \wp_parse_args( $args, $defaults );
+		$args['redirection'] = 0;
 
 		if ( ! empty( $args['body'] ) && \is_array( $args['body'] ) ) {
 			$args['body'] = \wp_json_encode( $args['body'] );
@@ -194,7 +196,7 @@ class API {
 			return self::request( $method, $endpoint, $original_args, null, true );
 		}
 
-		if ( $status >= 400 ) {
+		if ( 2 !== \intdiv( (int) $status, 100 ) ) {
 			$msg = $body['message'] ?? ( $body['error'] ?? \__( 'PDS request failed.', 'atmosphere' ) );
 			return new \WP_Error( 'atmosphere_pds', $msg, array( 'status' => $status ) );
 		}

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -196,7 +196,7 @@ class API {
 			return self::request( $method, $endpoint, $original_args, null, true );
 		}
 
-		if ( 2 !== \intdiv( (int) $status, 100 ) ) {
+		if ( ! is_success_status( $status ) ) {
 			$msg = $body['message'] ?? ( $body['error'] ?? \__( 'PDS request failed.', 'atmosphere' ) );
 			return new \WP_Error( 'atmosphere_pds', $msg, array( 'status' => $status ) );
 		}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -650,3 +650,23 @@ function debug_log( string $message ): void {
 	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 	\error_log( '[atmosphere] ' . $message );
 }
+
+/**
+ * Whether an HTTP status code is in the Success (2xx) class.
+ *
+ * "Success" is the IANA registry name for the 2xx range
+ * ({@link https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml}).
+ * AT Protocol OAuth and PDS requests disable redirects, so any non-2xx
+ * status (including a 3xx the server would have redirected) is treated
+ * as a failure. Centralizes that check for the OAuth and API callers.
+ *
+ * @since unreleased
+ *
+ * @param mixed $status HTTP status code (int, or '' when the request failed).
+ * @return bool True for 200-299, false otherwise.
+ */
+function is_success_status( $status ): bool {
+	$status = (int) $status;
+
+	return $status >= 200 && $status < 300;
+}

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -16,6 +16,7 @@ use Atmosphere\Atmosphere;
 use function Atmosphere\clear_scheduled_hooks;
 use function Atmosphere\debug_log;
 use function Atmosphere\get_connection;
+use function Atmosphere\is_success_status;
 
 /**
  * OAuth client that manages the authorization lifecycle.
@@ -341,9 +342,9 @@ class Client {
 			}
 		}
 
-		if ( 2 !== \intdiv( (int) $status, 100 ) || empty( $data['request_uri'] ) ) {
+		if ( ! is_success_status( $status ) || empty( $data['request_uri'] ) ) {
 			$msg = $data['error_description'] ?? ( $data['error'] ?? \__( 'PAR request failed.', 'atmosphere' ) );
-			return new \WP_Error( 'atmosphere_par', $msg );
+			return new \WP_Error( 'atmosphere_par', $msg, array( 'status' => $status ) );
 		}
 
 		$params = array(
@@ -506,9 +507,9 @@ class Client {
 			}
 		}
 
-		if ( 2 !== \intdiv( (int) $status, 100 ) || empty( $data['access_token'] ) ) {
+		if ( ! is_success_status( $status ) || empty( $data['access_token'] ) ) {
 			$msg = $data['error_description'] ?? ( $data['error'] ?? \__( 'Token exchange failed.', 'atmosphere' ) );
-			return new \WP_Error( 'atmosphere_token', $msg );
+			return new \WP_Error( 'atmosphere_token', $msg, array( 'status' => $status ) );
 		}
 
 		/*
@@ -787,7 +788,7 @@ class Client {
 			}
 		}
 
-		if ( 2 !== \intdiv( (int) $status, 100 ) || empty( $data['access_token'] ) ) {
+		if ( ! is_success_status( $status ) || empty( $data['access_token'] ) ) {
 			$msg = $data['error_description'] ?? ( $data['error'] ?? \__( 'Token refresh failed.', 'atmosphere' ) );
 
 			/*
@@ -835,7 +836,7 @@ class Client {
 				}
 			}
 
-			return new \WP_Error( 'atmosphere_refresh', $msg );
+			return new \WP_Error( 'atmosphere_refresh', $msg, array( 'status' => $status ) );
 		}
 
 		/*
@@ -1454,7 +1455,7 @@ class Client {
 		 * indicates a misconfigured client or a server outage; either
 		 * way disconnect proceeds.
 		 */
-		if ( 2 !== \intdiv( (int) $status, 100 ) ) {
+		if ( ! is_success_status( $status ) ) {
 			debug_log(
 				\sprintf(
 					'refresh-token revocation returned status %d',

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -275,12 +275,13 @@ class Client {
 		$response = \wp_safe_remote_post(
 			$par_url,
 			array(
-				'headers' => array(
+				'headers'     => array(
 					'Content-Type' => 'application/x-www-form-urlencoded',
 					'DPoP'         => $dpop_proof,
 				),
-				'body'    => $body,
-				'timeout' => 15,
+				'body'        => $body,
+				'timeout'     => 15,
+				'redirection' => 0,
 			)
 		);
 
@@ -314,12 +315,13 @@ class Client {
 			$response = \wp_safe_remote_post(
 				$par_url,
 				array(
-					'headers' => array(
+					'headers'     => array(
 						'Content-Type' => 'application/x-www-form-urlencoded',
 						'DPoP'         => $dpop_proof,
 					),
-					'body'    => $body,
-					'timeout' => 15,
+					'body'        => $body,
+					'timeout'     => 15,
+					'redirection' => 0,
 				)
 			);
 
@@ -339,7 +341,7 @@ class Client {
 			}
 		}
 
-		if ( $status >= 400 || empty( $data['request_uri'] ) ) {
+		if ( 2 !== \intdiv( (int) $status, 100 ) || empty( $data['request_uri'] ) ) {
 			$msg = $data['error_description'] ?? ( $data['error'] ?? \__( 'PAR request failed.', 'atmosphere' ) );
 			return new \WP_Error( 'atmosphere_par', $msg );
 		}
@@ -433,12 +435,13 @@ class Client {
 		$response = \wp_safe_remote_post(
 			$token_endpoint,
 			array(
-				'headers' => array(
+				'headers'     => array(
 					'Content-Type' => 'application/x-www-form-urlencoded',
 					'DPoP'         => $dpop_proof,
 				),
-				'body'    => $token_body,
-				'timeout' => 15,
+				'body'        => $token_body,
+				'timeout'     => 15,
+				'redirection' => 0,
 			)
 		);
 
@@ -470,12 +473,13 @@ class Client {
 			$response = \wp_safe_remote_post(
 				$token_endpoint,
 				array(
-					'headers' => array(
+					'headers'     => array(
 						'Content-Type' => 'application/x-www-form-urlencoded',
 						'DPoP'         => $dpop_proof,
 					),
-					'body'    => $token_body,
-					'timeout' => 15,
+					'body'        => $token_body,
+					'timeout'     => 15,
+					'redirection' => 0,
 				)
 			);
 
@@ -502,7 +506,7 @@ class Client {
 			}
 		}
 
-		if ( $status >= 400 || empty( $data['access_token'] ) ) {
+		if ( 2 !== \intdiv( (int) $status, 100 ) || empty( $data['access_token'] ) ) {
 			$msg = $data['error_description'] ?? ( $data['error'] ?? \__( 'Token exchange failed.', 'atmosphere' ) );
 			return new \WP_Error( 'atmosphere_token', $msg );
 		}
@@ -712,12 +716,13 @@ class Client {
 		$response = \wp_safe_remote_post(
 			$token_endpoint,
 			array(
-				'headers' => array(
+				'headers'     => array(
 					'Content-Type' => 'application/x-www-form-urlencoded',
 					'DPoP'         => $dpop_proof,
 				),
-				'body'    => $body,
-				'timeout' => 15,
+				'body'        => $body,
+				'timeout'     => 15,
+				'redirection' => 0,
 			)
 		);
 
@@ -749,12 +754,13 @@ class Client {
 			$response = \wp_safe_remote_post(
 				$token_endpoint,
 				array(
-					'headers' => array(
+					'headers'     => array(
 						'Content-Type' => 'application/x-www-form-urlencoded',
 						'DPoP'         => $dpop_proof,
 					),
-					'body'    => $body,
-					'timeout' => 15,
+					'body'        => $body,
+					'timeout'     => 15,
+					'redirection' => 0,
 				)
 			);
 
@@ -781,7 +787,7 @@ class Client {
 			}
 		}
 
-		if ( $status >= 400 || empty( $data['access_token'] ) ) {
+		if ( 2 !== \intdiv( (int) $status, 100 ) || empty( $data['access_token'] ) ) {
 			$msg = $data['error_description'] ?? ( $data['error'] ?? \__( 'Token refresh failed.', 'atmosphere' ) );
 
 			/*
@@ -1371,12 +1377,13 @@ class Client {
 		$response = \wp_safe_remote_post(
 			$revocation_endpoint,
 			array(
-				'headers' => array(
+				'headers'     => array(
 					'Content-Type' => 'application/x-www-form-urlencoded',
 					'DPoP'         => $dpop_proof,
 				),
-				'body'    => $body,
-				'timeout' => 10,
+				'body'        => $body,
+				'timeout'     => 10,
+				'redirection' => 0,
 			)
 		);
 
@@ -1413,12 +1420,13 @@ class Client {
 			$response = \wp_safe_remote_post(
 				$revocation_endpoint,
 				array(
-					'headers' => array(
+					'headers'     => array(
 						'Content-Type' => 'application/x-www-form-urlencoded',
 						'DPoP'         => $dpop_proof,
 					),
-					'body'    => $body,
-					'timeout' => 10,
+					'body'        => $body,
+					'timeout'     => 10,
+					'redirection' => 0,
 				)
 			);
 
@@ -1446,7 +1454,7 @@ class Client {
 		 * indicates a misconfigured client or a server outage; either
 		 * way disconnect proceeds.
 		 */
-		if ( $status >= 400 ) {
+		if ( 2 !== \intdiv( (int) $status, 100 ) ) {
 			debug_log(
 				\sprintf(
 					'refresh-token revocation returned status %d',

--- a/tests/phpunit/tests/class-test-api.php
+++ b/tests/phpunit/tests/class-test-api.php
@@ -132,6 +132,56 @@ class Test_API extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * PDS API requests must not follow redirects.
+	 */
+	public function test_request_disables_redirection() {
+		$captured_args = null;
+
+		\add_filter(
+			'pre_http_request',
+			static function ( $response, $args, $url ) use ( &$captured_args ) {
+				if ( false !== \strpos( $url, '/xrpc/' ) ) {
+					$captured_args = $args;
+					return array(
+						'response' => array( 'code' => 200 ),
+						'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+						'body'     => (string) \wp_json_encode( array( 'ok' => true ) ),
+					);
+				}
+
+				return $response;
+			},
+			10,
+			3
+		);
+
+		$result = API::get( '/xrpc/com.atproto.repo.getRecord' );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 0, $captured_args['redirection'] ?? null );
+	}
+
+	/**
+	 * Redirect responses are surfaced as failed PDS requests.
+	 */
+	public function test_request_rejects_redirect_response() {
+		$this->stub_http(
+			function () {
+				$this->fail( 'Token endpoint should not be called for a PDS redirect response.' );
+			},
+			function () {
+				return $this->http_response( 307, array() );
+			}
+		);
+
+		$result = API::get( '/xrpc/com.atproto.repo.getRecord' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'atmosphere_pds', $result->get_error_code() );
+		$this->assertSame( 307, $result->get_error_data()['status'] ?? null );
+	}
+
+	/**
 	 * When the PDS rejects the access token with a 401 `InvalidToken`,
 	 * `API::request()` must call `Client::refresh()` exactly once and
 	 * replay the request with the rotated token.

--- a/tests/phpunit/tests/oauth/class-test-client-authorize.php
+++ b/tests/phpunit/tests/oauth/class-test-client-authorize.php
@@ -15,6 +15,7 @@ namespace Atmosphere\Tests\OAuth;
 
 use WP_UnitTestCase;
 use Atmosphere\OAuth\Client;
+use Atmosphere\OAuth\DPoP;
 use Atmosphere\OAuth\Encryption;
 
 /**
@@ -30,6 +31,8 @@ class Test_Client_Authorize extends WP_UnitTestCase {
 		\delete_transient( 'atmosphere_oauth_state' );
 		\delete_transient( 'atmosphere_oauth_verifier' );
 		\delete_transient( 'atmosphere_oauth_resolved' );
+		\delete_option( 'atmosphere_connection' );
+		\delete_option( 'atmosphere_identity' );
 		\remove_all_filters( 'pre_http_request' );
 
 		parent::tear_down();
@@ -259,6 +262,143 @@ class Test_Client_Authorize extends WP_UnitTestCase {
 		$this->assertIsArray( $jwk );
 		$this->assertArrayHasKey( 'd', $jwk );
 		$this->assertArrayHasKey( 'kty', $jwk );
+	}
+
+	/**
+	 * PAR requests must not follow redirects.
+	 */
+	public function test_authorize_par_request_disables_redirection() {
+		$captured_args = null;
+
+		\add_filter(
+			'pre_http_request',
+			static function ( $response, $args, $url ) use ( &$captured_args ) {
+				if ( false !== \strpos( $url, '/.well-known/atproto-did' ) ) {
+					return array(
+						'response' => array( 'code' => 200 ),
+						'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+						'body'     => 'did:plc:test',
+					);
+				}
+
+				if ( false !== \strpos( $url, 'plc.directory/did:plc:test' ) ) {
+					return array(
+						'response' => array( 'code' => 200 ),
+						'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+						'body'     => (string) \wp_json_encode(
+							array(
+								'id'      => 'did:plc:test',
+								'service' => array(
+									array(
+										'id'              => '#atproto_pds',
+										'type'            => 'AtprotoPersonalDataServer',
+										'serviceEndpoint' => 'https://pds.example.com',
+									),
+								),
+							)
+						),
+					);
+				}
+
+				if ( false !== \strpos( $url, 'oauth-protected-resource' ) ) {
+					return array(
+						'response' => array( 'code' => 200 ),
+						'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+						'body'     => (string) \wp_json_encode(
+							array( 'authorization_servers' => array( 'https://auth.example.com' ) )
+						),
+					);
+				}
+
+				if ( false !== \strpos( $url, 'oauth-authorization-server' ) ) {
+					return array(
+						'response' => array( 'code' => 200 ),
+						'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+						'body'     => (string) \wp_json_encode(
+							array(
+								'token_endpoint'         => 'https://auth.example.com/oauth/token',
+								'authorization_endpoint' => 'https://auth.example.com/oauth/authorize',
+								'pushed_authorization_request_endpoint' => 'https://auth.example.com/oauth/par',
+							)
+						),
+					);
+				}
+
+				if ( false !== \strpos( $url, 'oauth/par' ) ) {
+					$captured_args = $args;
+					return array(
+						'response' => array( 'code' => 200 ),
+						'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+						'body'     => (string) \wp_json_encode( array( 'request_uri' => 'urn:ietf:params:oauth:request_uri:test' ) ),
+					);
+				}
+
+				return $response;
+			},
+			10,
+			3
+		);
+
+		$result = Client::authorize( 'alice.atmosphere-test.io' );
+
+		$this->assertIsString( $result );
+		$this->assertStringStartsWith( 'https://auth.example.com/oauth/authorize?', $result );
+		$this->assertSame( 0, $captured_args['redirection'] ?? null );
+	}
+
+	/**
+	 * Authorization-code token exchange requests must not follow redirects.
+	 */
+	public function test_handle_callback_token_request_disables_redirection() {
+		$jwk = DPoP::generate_key();
+
+		\set_transient( 'atmosphere_oauth_state', 'state-abc', HOUR_IN_SECONDS );
+		\set_transient( 'atmosphere_oauth_verifier', 'verifier-xyz', HOUR_IN_SECONDS );
+		\set_transient( 'atmosphere_oauth_dpop_jwk', Encryption::encrypt( (string) \wp_json_encode( $jwk ) ), HOUR_IN_SECONDS );
+		\set_transient(
+			'atmosphere_oauth_resolved',
+			array(
+				'did'          => 'did:plc:test',
+				'pds_endpoint' => 'https://pds.example.com',
+				'auth_server'  => array(
+					'token_endpoint' => 'https://auth.example.com/oauth/token',
+					'issuer_url'     => 'https://auth.example.com',
+				),
+				'handle'       => 'alice.example.com',
+			),
+			HOUR_IN_SECONDS
+		);
+
+		$captured_args = null;
+
+		\add_filter(
+			'pre_http_request',
+			static function ( $response, $args, $url ) use ( &$captured_args ) {
+				if ( false !== \strpos( $url, 'oauth/token' ) ) {
+					$captured_args = $args;
+					return array(
+						'response' => array( 'code' => 200 ),
+						'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+						'body'     => (string) \wp_json_encode(
+							array(
+								'access_token'  => 'access-token',
+								'refresh_token' => 'refresh-token',
+								'expires_in'    => 3600,
+							)
+						),
+					);
+				}
+
+				return $response;
+			},
+			10,
+			3
+		);
+
+		$result = Client::handle_callback( 'code-123', 'state-abc' );
+
+		$this->assertTrue( $result );
+		$this->assertSame( 0, $captured_args['redirection'] ?? null );
 	}
 
 	/**

--- a/tests/phpunit/tests/oauth/class-test-client-refresh.php
+++ b/tests/phpunit/tests/oauth/class-test-client-refresh.php
@@ -136,6 +136,77 @@ class Test_Client_Refresh extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Refresh requests must not follow redirects.
+	 */
+	public function test_refresh_request_disables_redirection() {
+		$captured_args = null;
+
+		\add_filter(
+			'pre_http_request',
+			static function ( $response, $args, $url ) use ( &$captured_args ) {
+				if ( false !== \strpos( $url, 'oauth/token' ) ) {
+					$captured_args = $args;
+					return array(
+						'response' => array( 'code' => 200 ),
+						'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+						'body'     => (string) \wp_json_encode(
+							array(
+								'access_token'  => 'new-access-token',
+								'refresh_token' => 'new-refresh-token',
+								'expires_in'    => 3600,
+							)
+						),
+					);
+				}
+
+				return $response;
+			},
+			10,
+			3
+		);
+
+		$result = Client::refresh();
+
+		$this->assertTrue( $result );
+		$this->assertSame( 0, $captured_args['redirection'] ?? null );
+	}
+
+	/**
+	 * Refresh-token revocation requests must not follow redirects.
+	 */
+	public function test_revoke_refresh_token_request_disables_redirection() {
+		$captured_args = null;
+		$dpop_jwk      = DPoP::generate_key();
+
+		\add_filter(
+			'pre_http_request',
+			static function ( $response, $args, $url ) use ( &$captured_args ) {
+				if ( false !== \strpos( $url, 'oauth/revoke' ) ) {
+					$captured_args = $args;
+					return array(
+						'response' => array( 'code' => 200 ),
+						'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+						'body'     => '{}',
+					);
+				}
+
+				return $response;
+			},
+			10,
+			3
+		);
+
+		Client::revoke_refresh_token(
+			Encryption::encrypt( 'refresh-token' ),
+			Encryption::encrypt( (string) \wp_json_encode( $dpop_jwk ) ),
+			'https://auth.example.com/oauth/revoke',
+			'https://auth.example.com'
+		);
+
+		$this->assertSame( 0, $captured_args['redirection'] ?? null );
+	}
+
+	/**
 	 * Test that invalid_grant marks the connection for reauth without
 	 * deleting it, and preserves the identity option for the public
 	 * verification headers.


### PR DESCRIPTION
Fixes #

## Proposed changes:
* Disable redirects for AT Protocol OAuth PAR, token exchange, refresh, and revocation requests.
* Disable redirects for authenticated PDS API requests, including caller-provided request arguments.
* Treat non-2xx PDS and OAuth responses as failures now that redirects are not followed.
* Add regression tests for redirect handling across OAuth and PDS request paths.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
* Run `composer lint`.
* Run `npm run env-test`.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

A changelog entry is included in `.github/changelog/harden-atproto-http-redirects`.
