### PR TITLE
Fix standard.site document strong refs

### DIFF
--- a/.github/changelog/fix-standard-site-strong-ref-cids
+++ b/.github/changelog/fix-standard-site-strong-ref-cids
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Kept standard.site document references in Bluesky posts pointing at the current document record and made discovery URLs resolve more consistently.

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -162,8 +162,8 @@ class Atmosphere {
 
 		// Well-known endpoints.
 		\add_action( 'init', array( $this, 'register_wellknown_rewrite' ) );
-		\add_action( 'template_redirect', array( $this, 'serve_wellknown_atproto_did' ) );
-		\add_action( 'template_redirect', array( $this, 'serve_wellknown_publication' ) );
+		\add_action( 'template_redirect', array( $this, 'serve_wellknown_atproto_did' ), 0 );
+		\add_action( 'template_redirect', array( $this, 'serve_wellknown_publication' ), 0 );
 
 		// Register the built-in content parsers.
 		self::register_default_content_parsers();
@@ -423,8 +423,8 @@ class Atmosphere {
 	 * @var array<string, string>
 	 */
 	private const WELLKNOWN_REWRITE_PATTERNS = array(
-		'^\.well-known/atproto-did$'                 => 'index.php?atmosphere_wellknown=atproto-did',
-		'^\.well-known/site\.standard\.publication$' => 'index.php?atmosphere_wellknown=publication',
+		'^\.well-known/atproto-did/?$'                 => 'index.php?atmosphere_wellknown=atproto-did',
+		'^\.well-known/site\.standard\.publication/?$' => 'index.php?atmosphere_wellknown=publication',
 	);
 
 	/**

--- a/includes/class-publisher.php
+++ b/includes/class-publisher.php
@@ -150,6 +150,8 @@ class Publisher {
 					)
 				);
 			} else {
+				$bsky_transformer->set_document_strong_ref( null );
+
 				/*
 				 * Encoder hit a record shape it could not handle.
 				 * Surfacing the post error here would abort an
@@ -349,10 +351,7 @@ class Publisher {
 			)
 		);
 
-		$doc_ref_result = self::update_document_bsky_ref( $post, $doc_transformer );
-		if ( \is_wp_error( $doc_ref_result ) ) {
-			return $doc_ref_result;
-		}
+		\delete_post_meta( $post->ID, Post::META_DOC_REF_PENDING );
 
 		return $result;
 	}
@@ -449,19 +448,7 @@ class Publisher {
 		self::store_document_meta( $post->ID, $root_result, $doc_transformer );
 		self::mirror_thread_records_meta( $post->ID, $thread_records );
 
-		// Best-effort: a doc-ref update failure must not abort thread
-		// publishing after the root + document are already created.
-		// Bailing here leaves META_THREAD_RECORDS at length=1, and a
-		// subsequent edit treats that as a shape change and rewrites
-		// the (already-published) root — invalidating likes/reposts/
-		// external replies pointing at it. Persist the gap to
-		// META_DOC_REF_PENDING so operators (and any admin/Site Health
-		// surface) can see it; the next edit retries the doc-ref via
-		// update_*'s normal call to update_document_bsky_ref.
-		$doc_ref_result = self::update_document_bsky_ref( $post, $doc_transformer );
-		if ( \is_wp_error( $doc_ref_result ) ) {
-			self::record_doc_ref_pending( $post->ID, $doc_ref_result );
-		}
+		\delete_post_meta( $post->ID, Post::META_DOC_REF_PENDING );
 
 		$aggregated_results = $root_result['results'] ?? array();
 
@@ -785,6 +772,41 @@ class Publisher {
 
 		$bsky_transformer = new Post( $post );
 		$doc_transformer  = new Document( $post );
+		$is_short         = $bsky_transformer->is_short_form_post();
+		$doc_record       = null;
+
+		/*
+		 * Updates have the same strong-ref requirement as initial
+		 * publishes: build the document record once, compute the CID from
+		 * that exact payload, inject it before composing the Bluesky record,
+		 * then write the same document payload in the applyWrites batch.
+		 * Reading Document::META_CID here would use the previous document
+		 * version, and the updated document write would immediately make the
+		 * Bluesky associatedRef stale.
+		 */
+		if ( ! $is_short ) {
+			$doc_record = $doc_transformer->transform();
+			$doc_cid    = CID::from_record( $doc_record );
+
+			if ( ! \is_wp_error( $doc_cid ) ) {
+				$bsky_transformer->set_document_strong_ref(
+					array(
+						'uri' => build_at_uri( get_did(), 'site.standard.document', $doc_transformer->get_rkey() ),
+						'cid' => $doc_cid,
+					)
+				);
+			} else {
+				$bsky_transformer->set_document_strong_ref( null );
+
+				debug_log(
+					\sprintf(
+						'post %d: document CID precompute failed during update (%s) — updating without document associatedRef',
+						$post->ID,
+						$doc_cid->get_error_code()
+					)
+				);
+			}
+		}
 
 		// Pass the stored count to `build_long_form_records()` so the
 		// transformer can preserve the existing thread shape on update
@@ -793,7 +815,7 @@ class Publisher {
 		// — that path would re-mint the root URI and orphan external
 		// engagement on the original. New posts (no stored records) get
 		// the optimised shape; live posts keep theirs forever.
-		$new_records = $bsky_transformer->is_short_form_post()
+		$new_records = $is_short
 			? array( $bsky_transformer->transform() )
 			: $bsky_transformer->build_long_form_records( \count( $stored ) );
 
@@ -811,7 +833,8 @@ class Publisher {
 					$new_records[0],
 					$bsky_transformer,
 					$doc_transformer,
-					$doc_tid
+					$doc_tid,
+					$doc_record
 				);
 			}
 
@@ -820,7 +843,8 @@ class Publisher {
 				$stored,
 				$new_records,
 				$doc_transformer,
-				$doc_tid
+				$doc_tid,
+				$doc_record
 			);
 		}
 
@@ -833,12 +857,17 @@ class Publisher {
 	 * update path. Extended only to refresh `META_THREAD_RECORDS` with the
 	 * post-update CID.
 	 *
-	 * @param \WP_Post $post             WordPress post.
-	 * @param array    $stored_root      The single stored {uri, cid, tid} triple.
-	 * @param array    $new_bsky_record  Freshly composed bsky record.
-	 * @param Post     $bsky_transformer Bsky transformer instance.
-	 * @param Document $doc_transformer  Document transformer instance.
-	 * @param string   $doc_tid          Document record TID.
+	 * @param \WP_Post   $post             WordPress post.
+	 * @param array      $stored_root      The single stored {uri, cid, tid} triple.
+	 * @param array      $new_bsky_record  Freshly composed bsky record.
+	 * @param Post       $bsky_transformer Bsky transformer instance.
+	 * @param Document   $doc_transformer  Document transformer instance.
+	 * @param string     $doc_tid          Document record TID.
+	 * @param array|null $doc_record     Pre-computed document record from
+	 *                                   `update_post()`. Reused as the write
+	 *                                   payload so the injected document
+	 *                                   strongRef points at the updated
+	 *                                   document record's CID.
 	 * @return array|\WP_Error
 	 */
 	private static function update_single(
@@ -847,10 +876,15 @@ class Publisher {
 		array $new_bsky_record,
 		Post $bsky_transformer,
 		Document $doc_transformer,
-		string $doc_tid
+		string $doc_tid,
+		?array $doc_record = null
 	): array|\WP_Error {
 		if ( empty( $new_bsky_record['createdAt'] ) ) {
 			$new_bsky_record['createdAt'] = to_iso8601( $post->post_date_gmt );
+		}
+
+		if ( null === $doc_record ) {
+			$doc_record = $doc_transformer->transform();
 		}
 
 		$writes = array(
@@ -864,7 +898,7 @@ class Publisher {
 				'$type'      => 'com.atproto.repo.applyWrites#update',
 				'collection' => 'site.standard.document',
 				'rkey'       => $doc_tid,
-				'value'      => $doc_transformer->transform(),
+				'value'      => $doc_record,
 			),
 		);
 
@@ -887,10 +921,7 @@ class Publisher {
 			)
 		);
 
-		$doc_ref_result = self::update_document_bsky_ref( $post, $doc_transformer );
-		if ( \is_wp_error( $doc_ref_result ) ) {
-			return $doc_ref_result;
-		}
+		\delete_post_meta( $post->ID, Post::META_DOC_REF_PENDING );
 
 		return self::reconcile_post_after_write( $post, $result );
 	}
@@ -909,11 +940,16 @@ class Publisher {
 	 * After the write, `META_THREAD_RECORDS` is refreshed with the new
 	 * CIDs from the response so future updates chain from current CIDs.
 	 *
-	 * @param \WP_Post $post            WordPress post.
-	 * @param array[]  $stored          Current {uri, cid, tid} triples in order.
-	 * @param array[]  $new_records     Freshly composed bsky records, same count.
-	 * @param Document $doc_transformer Document transformer.
-	 * @param string   $doc_tid         Document record TID.
+	 * @param \WP_Post   $post            WordPress post.
+	 * @param array[]    $stored          Current {uri, cid, tid} triples in order.
+	 * @param array[]    $new_records     Freshly composed bsky records, same count.
+	 * @param Document   $doc_transformer Document transformer.
+	 * @param string     $doc_tid         Document record TID.
+	 * @param array|null $doc_record    Pre-computed document record from
+	 *                                  `update_post()`. Reused as the write
+	 *                                  payload so the injected document
+	 *                                  strongRef points at the updated
+	 *                                  document record's CID.
 	 * @return array|\WP_Error
 	 */
 	private static function update_thread_in_place(
@@ -921,12 +957,17 @@ class Publisher {
 		array $stored,
 		array $new_records,
 		Document $doc_transformer,
-		string $doc_tid
+		string $doc_tid,
+		?array $doc_record = null
 	): array|\WP_Error {
 		$root       = $stored[0];
 		$created_at = to_iso8601( $post->post_date_gmt );
 		$writes     = array();
 		$bsky_count = \count( $new_records );
+
+		if ( null === $doc_record ) {
+			$doc_record = $doc_transformer->transform();
+		}
 
 		foreach ( $new_records as $i => $record ) {
 			if ( empty( $record['createdAt'] ) ) {
@@ -958,7 +999,7 @@ class Publisher {
 			'$type'      => 'com.atproto.repo.applyWrites#update',
 			'collection' => 'site.standard.document',
 			'rkey'       => $doc_tid,
-			'value'      => $doc_transformer->transform(),
+			'value'      => $doc_record,
 		);
 
 		$result = API::apply_writes( $writes );
@@ -988,10 +1029,7 @@ class Publisher {
 			\update_post_meta( $post->ID, Document::META_CID, $doc_entry['cid'] );
 		}
 
-		$doc_ref_result = self::update_document_bsky_ref( $post, $doc_transformer );
-		if ( \is_wp_error( $doc_ref_result ) ) {
-			return $doc_ref_result;
-		}
+		\delete_post_meta( $post->ID, Post::META_DOC_REF_PENDING );
 
 		return self::reconcile_post_after_write( $post, $result );
 	}
@@ -1795,92 +1833,6 @@ class Publisher {
 		}
 
 		return true;
-	}
-
-	/**
-	 * Update the document record with the bsky root strong reference.
-	 *
-	 * After the initial applyWrites, the bsky root's CID is known, so
-	 * we re-transform the document (which picks up the ref via its
-	 * own read of `Post::META_URI` / `META_CID`) and persist via
-	 * `putRecord`. Called once per publish — the doc always references
-	 * the thread root, regardless of thread length.
-	 *
-	 * @param \WP_Post $post            WordPress post.
-	 * @param Document $doc_transformer Document transformer.
-	 * @return array|\WP_Error|null
-	 */
-	private static function update_document_bsky_ref( \WP_Post $post, Document $doc_transformer ): array|\WP_Error|null {
-		$bsky_uri = \get_post_meta( $post->ID, Post::META_URI, true );
-		$bsky_cid = \get_post_meta( $post->ID, Post::META_CID, true );
-
-		if ( ! $bsky_uri || ! $bsky_cid ) {
-			return null;
-		}
-
-		// `transform()` reads Post::META_URI / META_CID fresh from post
-		// meta on every call, so the existing transformer picks up the
-		// values just persisted by mirror_thread_records_meta() above —
-		// no need for a new instance.
-		$record = $doc_transformer->transform();
-
-		$result = API::post(
-			'/xrpc/com.atproto.repo.putRecord',
-			array(
-				'repo'       => get_did(),
-				'collection' => 'site.standard.document',
-				'rkey'       => $doc_transformer->get_rkey(),
-				'record'     => $record,
-			)
-		);
-
-		// Clear any previous deferred-failure marker on success so
-		// subsequent edits stop reporting the post as pending.
-		if ( ! \is_wp_error( $result ) ) {
-			\delete_post_meta( $post->ID, Post::META_DOC_REF_PENDING );
-		}
-
-		return $result;
-	}
-
-	/**
-	 * Persist a deferred `update_document_bsky_ref` failure.
-	 *
-	 * Called from `publish_thread()` when the follow-up `putRecord`
-	 * fails after the bsky thread root and document records have
-	 * already been created. The publish itself is treated as a success
-	 * (replies still ship; rewriting the root on the next edit would
-	 * be the worse failure mode), but the gap is recorded here so
-	 * operators / admin surfaces can see that the document's
-	 * `bskyPostRef` is stale and that the post should be re-saved to
-	 * trigger a retry.
-	 *
-	 * Cleared by a subsequent successful `update_document_bsky_ref`.
-	 *
-	 * TODO: surface in admin / Site Health alongside META_ORPHAN_RECORDS
-	 * (issue 44).
-	 *
-	 * @param int       $post_id WordPress post ID.
-	 * @param \WP_Error $error   The doc-ref failure to record.
-	 */
-	private static function record_doc_ref_pending( int $post_id, \WP_Error $error ): void {
-		\update_post_meta(
-			$post_id,
-			Post::META_DOC_REF_PENDING,
-			array(
-				'stamp'   => \gmdate( 'Y-m-d\TH:i:s.000\Z' ),
-				'code'    => $error->get_error_code(),
-				'message' => $error->get_error_message(),
-			)
-		);
-
-		debug_log(
-			\sprintf(
-				'post %d: doc-ref update failed during thread publish (%s); continuing with replies',
-				$post_id,
-				$error->get_error_code()
-			)
-		);
 	}
 
 	/**

--- a/includes/transformer/class-document.php
+++ b/includes/transformer/class-document.php
@@ -3,8 +3,7 @@
  * Transforms a WordPress post into a site.standard.document record.
  *
  * Documents carry full structured metadata: title, path, description,
- * cover image, plain-text content, tags, and a cross-reference to
- * the corresponding Bluesky post.
+ * cover image, plain-text content, and tags.
  *
  * @package Atmosphere
  */
@@ -127,16 +126,6 @@ class Document extends Base {
 			$tags = $this->collect_tags( $this->object );
 			if ( ! empty( $tags ) ) {
 				$record['tags'] = $tags;
-			}
-
-			// Bluesky cross-reference (populated after initial publish).
-			$bsky_uri = \get_post_meta( $this->object->ID, Post::META_URI, true );
-			$bsky_cid = \get_post_meta( $this->object->ID, Post::META_CID, true );
-			if ( $bsky_uri && $bsky_cid ) {
-				$record['bskyPostRef'] = array(
-					'uri' => $bsky_uri,
-					'cid' => $bsky_cid,
-				);
 			}
 
 			// Updated timestamp.

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -105,19 +105,13 @@ class Post extends Base {
 	public const META_ORPHAN_RECORDS = '_atmosphere_bsky_orphan_records';
 
 	/**
-	 * Tracks a deferred `update_document_bsky_ref` failure.
+	 * Legacy post meta key for deferred document back-reference failures.
 	 *
-	 * Set by Publisher when the doc-ref `putRecord` fails after the
-	 * thread root + document have already been written, so the bsky
-	 * post(s) and the document are both live on the PDS but the
-	 * document's `bskyPostRef` is missing or stale. The publish itself
-	 * is treated as successful (replies still ship; rewriting the root
-	 * on the next edit would be worse) and this meta records the gap so
-	 * an operator or admin/Site Health surface can spot it.
-	 *
-	 * Cleared the next time `update_document_bsky_ref` succeeds for the
-	 * post (typical recovery path: any subsequent edit retries the
-	 * follow-up putRecord). Value: `[ stamp, code, message ]`.
+	 * Kept so cleanup paths remove markers left by older versions that
+	 * attempted a follow-up document `putRecord` after publishing the
+	 * Bluesky post. New writes no longer set this marker because the
+	 * document record is now the stable target of the Bluesky
+	 * `associatedRefs` strong reference.
 	 *
 	 * @var string
 	 */
@@ -167,14 +161,25 @@ class Post extends Base {
 	 * `source` / `associatedProfiles` enrichment).
 	 *
 	 * Null on a fresh transformer; reset whenever a fresh Post object
-	 * is constructed. Subsequent publishes of the same post
-	 * (`update_post()` flow) do not inject — by then
-	 * `Document::META_URI` / `Document::META_CID` are populated and
-	 * {@see self::build_embed()} reads the ref from meta instead.
+	 * is constructed. When no ref is injected and meta fallback is
+	 * enabled, {@see self::build_embed()} reads from `Document::META_*`.
 	 *
 	 * @var array{$type: string, uri: string, cid: string}|null
 	 */
 	private ?array $document_strong_ref = null;
+
+	/**
+	 * Whether the embed builder may fall back to the stored document ref.
+	 *
+	 * The Publisher disables this after it attempted to compute the
+	 * current document CID but failed. In that case `Document::META_CID`
+	 * points at the previous document version, while the same batch is
+	 * about to write a new document record, so advertising the meta ref
+	 * would preserve the stale-CID bug this guard exists to avoid.
+	 *
+	 * @var bool
+	 */
+	private bool $document_meta_strong_ref_enabled = true;
 
 	/**
 	 * Memoized short-form verdict for this post.
@@ -344,11 +349,20 @@ class Post extends Base {
 	 * See {@see self::$document_strong_ref} for the why. Passing an
 	 * empty array or a malformed shape (missing `uri` / `cid`) clears
 	 * the injection and the embed builder falls back to reading from
-	 * `Document::META_*`.
+	 * `Document::META_*`. Passing null clears the injection and
+	 * suppresses that fallback for this transformer instance.
 	 *
-	 * @param array $ref StrongRef to advertise (keys: optional `$type`, required `uri` and `cid`).
+	 * @param array|null $ref StrongRef to advertise (keys: optional `$type`, required `uri` and `cid`).
 	 */
-	public function set_document_strong_ref( array $ref ): void {
+	public function set_document_strong_ref( ?array $ref ): void {
+		if ( null === $ref ) {
+			$this->document_strong_ref              = null;
+			$this->document_meta_strong_ref_enabled = false;
+			return;
+		}
+
+		$this->document_meta_strong_ref_enabled = true;
+
 		if ( empty( $ref['uri'] ) || empty( $ref['cid'] ) ) {
 			$this->document_strong_ref = null;
 			return;
@@ -904,17 +918,15 @@ class Post extends Base {
 		 * record has been written.
 		 *
 		 * Document ref has two sources:
-		 *   - On the *initial* publish, the Publisher precomputes the
-		 *     document's CID locally via DAG-CBOR and injects via
-		 *     `set_document_strong_ref()`. Without this, the document
-		 *     ref could only be added after the atomic write returned
-		 *     — and Bluesky's AppView ignores subsequent
-		 *     `applyWrites#update` for the purposes of indexing
-		 *     `source` / `associatedProfiles` enrichment.
-		 *   - On an *update* publish, the injection is absent but
-		 *     `Document::META_*` are already populated by the
-		 *     previous publish's `store_document_meta()`, so reading
-		 *     from meta produces an equivalent ref.
+		 *   - The Publisher precomputes the document's CID locally via
+		 *     DAG-CBOR and injects via `set_document_strong_ref()`.
+		 *     Without this, the document ref could only be added after
+		 *     the atomic write returned — and Bluesky's AppView ignores
+		 *     subsequent `applyWrites#update` for the purposes of
+		 *     indexing `source` / `associatedProfiles` enrichment.
+		 *   - Read-only or legacy paths may omit injection and fall back
+		 *     to `Document::META_*`, which represents the last document
+		 *     record known to have been written.
 		 *
 		 * The injection wins if both sources are present — it
 		 * reflects what the Publisher is *about* to write, the meta
@@ -929,7 +941,7 @@ class Post extends Base {
 
 		if ( null !== $this->document_strong_ref ) {
 			$associated_refs[] = $this->document_strong_ref;
-		} else {
+		} elseif ( $this->document_meta_strong_ref_enabled ) {
 			$doc_uri = (string) \get_post_meta( $this->object->ID, Document::META_URI, true );
 			$doc_cid = (string) \get_post_meta( $this->object->ID, Document::META_CID, true );
 			if ( '' !== $doc_uri && '' !== $doc_cid ) {

--- a/tests/phpunit/tests/class-test-publisher.php
+++ b/tests/phpunit/tests/class-test-publisher.php
@@ -3,7 +3,7 @@
  * Tests for the Publisher class.
  *
  * Verifies publish, update, and delete flows including the
- * URI-based existence check and bsky cross-reference refresh.
+ * URI-based existence check and standard.site document strong refs.
  *
  * @package Atmosphere
  * @group atmosphere
@@ -13,6 +13,7 @@
 namespace Atmosphere\Tests;
 
 use WP_UnitTestCase;
+use Atmosphere\CID;
 use Atmosphere\Publisher;
 use Atmosphere\Reaction_Sync;
 use Atmosphere\OAuth\DPoP;
@@ -44,8 +45,6 @@ class Test_Publisher extends WP_UnitTestCase {
 			)
 		);
 		\update_option( 'atmosphere_did', 'did:plc:test123' );
-
-		\add_filter( 'pre_http_request', array( $this, 'mock_document_ref_update' ), 10, 3 );
 	}
 
 	/**
@@ -60,38 +59,10 @@ class Test_Publisher extends WP_UnitTestCase {
 		\remove_all_filters( 'atmosphere_long_form_composition' );
 		\remove_all_filters( 'atmosphere_teaser_thread_posts' );
 		\remove_all_filters( 'atmosphere_transform_bsky_post' );
+		\remove_all_filters( 'atmosphere_transform_document' );
 		\remove_all_filters( 'atmosphere_is_short_form_post' );
-		\remove_filter( 'pre_http_request', array( $this, 'mock_document_ref_update' ), 10 );
 
 		parent::tear_down();
-	}
-
-	/**
-	 * Mock follow-up document putRecord calls.
-	 *
-	 * @param false|array|\WP_Error $response Preemptive HTTP response.
-	 * @param array                 $args     Request args.
-	 * @param string                $url      Request URL.
-	 * @return false|array|\WP_Error
-	 */
-	public function mock_document_ref_update( $response, array $args, string $url ) {
-		if ( false !== $response ) {
-			return $response;
-		}
-
-		if ( false === \strpos( $url, 'com.atproto.repo.putRecord' ) ) {
-			return $response;
-		}
-
-		return array(
-			'response' => array( 'code' => 200 ),
-			'body'     => \wp_json_encode(
-				array(
-					'uri' => 'at://did:plc:test123/site.standard.document/doc-ref',
-					'cid' => 'bafyreibdocref',
-				)
-			),
-		);
 	}
 
 	/**
@@ -1155,6 +1126,22 @@ class Test_Publisher extends WP_UnitTestCase {
 		$this->assertSame( 'app.bsky.feed.post', $writes[0]['collection'] );
 		$this->assertSame( 'com.atproto.repo.applyWrites#create', $writes[1]['$type'] );
 		$this->assertSame( 'site.standard.document', $writes[1]['collection'] );
+		$this->assertArrayNotHasKey( 'bskyPostRef', $writes[1]['value'] );
+
+		$doc_cid = CID::from_record( $writes[1]['value'] );
+		$this->assertNotWPError( $doc_cid );
+
+		$refs    = $writes[0]['value']['embed']['external']['associatedRefs'] ?? array();
+		$doc_ref = null;
+		foreach ( $refs as $ref ) {
+			if ( false !== \strpos( $ref['uri'] ?? '', '/site.standard.document/' ) ) {
+				$doc_ref = $ref;
+				break;
+			}
+		}
+
+		$this->assertIsArray( $doc_ref );
+		$this->assertSame( $doc_cid, $doc_ref['cid'] );
 
 		$thread_records = \get_post_meta( $post->ID, Post::META_THREAD_RECORDS, true );
 		$this->assertIsArray( $thread_records );
@@ -1312,116 +1299,11 @@ class Test_Publisher extends WP_UnitTestCase {
 	}
 
 	/**
-	 * If the follow-up document update fails after the initial applyWrites,
-	 * publish returns the error while preserving meta for a retry.
+	 * A successful publish clears the legacy `META_DOC_REF_PENDING`
+	 * marker left by versions that tried to update the document after
+	 * publishing the Bluesky record.
 	 */
-	public function test_publish_surfaces_document_ref_update_failure() {
-		$post = self::factory()->post->create_and_get(
-			array(
-				'post_title'   => 'A Long-Form Post',
-				'post_content' => 'Body content.',
-			)
-		);
-
-		$put_record_failure = static function ( $response, $args, $url ) {
-			if ( false !== \strpos( $url, 'com.atproto.repo.putRecord' ) ) {
-				return new \WP_Error( 'atmosphere_doc_ref_failed', 'Document ref update failed.' );
-			}
-			return $response;
-		};
-
-		\add_filter( 'pre_http_request', $put_record_failure, 5, 3 );
-
-		try {
-			$this->fail_call_indexes = array();
-			$this->register_capture( $post->ID );
-
-			$result = Publisher::publish( $post );
-
-			$this->assertWPError( $result );
-			$this->assertSame( 'atmosphere_doc_ref_failed', $result->get_error_code() );
-
-			$thread_records = \get_post_meta( $post->ID, Post::META_THREAD_RECORDS, true );
-			$this->assertIsArray( $thread_records );
-			$this->assertCount( 1, $thread_records );
-			$this->assertNotEmpty( \get_post_meta( $post->ID, Document::META_URI, true ) );
-		} finally {
-			\remove_filter( 'pre_http_request', $put_record_failure, 5 );
-		}
-	}
-
-	/**
-	 * In a thread publish, a failure on the doc-ref `putRecord` between
-	 * step 1 (root + doc) and step 2+ (replies) must not abort the thread
-	 * — otherwise META_THREAD_RECORDS sticks at length=1 and the next
-	 * edit triggers a rewrite that replaces the already-published root
-	 * URI/TID, invalidating likes/reposts/external replies.
-	 *
-	 * Best-effort: log the doc-ref failure, then continue writing replies.
-	 */
-	public function test_publish_thread_continues_when_doc_ref_update_fails() {
-		$post = self::factory()->post->create_and_get(
-			array(
-				'post_title'   => 'A Long-Form Post',
-				'post_excerpt' => 'A curated excerpt long enough to compose a hook from.',
-				// Empty body: hook comes from the excerpt and there is no
-				// body chunk, so the default shape is [hook, cta] and the
-				// protocol assertions below expect a single reply write.
-				'post_content' => '',
-			)
-		);
-
-		\add_filter( 'atmosphere_long_form_composition', fn() => 'teaser-thread' );
-
-		$put_record_failure = static function ( $response, $args, $url ) {
-			if ( false !== \strpos( $url, 'com.atproto.repo.putRecord' ) ) {
-				return new \WP_Error( 'atmosphere_doc_ref_failed', 'Document ref update failed.' );
-			}
-			return $response;
-		};
-
-		\add_filter( 'pre_http_request', $put_record_failure, 5, 3 );
-
-		try {
-			$this->fail_call_indexes = array();
-			$this->register_capture( $post->ID );
-
-			$result = Publisher::publish( $post );
-
-			// Doc-ref failure is swallowed — overall publish succeeds.
-			$this->assertIsArray( $result );
-			$this->assertArrayHasKey( 'results', $result );
-
-			// Both root + reply applyWrites batches went through (call 1 = root+doc, call 2 = reply).
-			$this->assertCount( 2, $this->captured_calls );
-
-			$thread_records = \get_post_meta( $post->ID, Post::META_THREAD_RECORDS, true );
-			$this->assertIsArray( $thread_records );
-			$this->assertCount( 2, $thread_records );
-			foreach ( $thread_records as $record ) {
-				$this->assertNotEmpty( $record['uri'] );
-				$this->assertNotEmpty( $record['cid'] );
-			}
-
-			// Pending-doc-ref marker is persisted so admin / Site Health
-			// can surface the gap; logs are not the only signal.
-			$pending = \get_post_meta( $post->ID, Post::META_DOC_REF_PENDING, true );
-			$this->assertIsArray( $pending );
-			$this->assertSame( 'atmosphere_doc_ref_failed', $pending['code'] );
-			$this->assertNotEmpty( $pending['stamp'] );
-			$this->assertNotEmpty( $pending['message'] );
-		} finally {
-			\remove_filter( 'pre_http_request', $put_record_failure, 5 );
-		}
-	}
-
-	/**
-	 * A successful `update_document_bsky_ref` clears any prior
-	 * `META_DOC_REF_PENDING` marker — typical recovery path is the user
-	 * re-saves the post (any `Publisher::update*` flow ends at
-	 * `update_document_bsky_ref`).
-	 */
-	public function test_publish_clears_doc_ref_pending_on_successful_doc_ref() {
+	public function test_publish_clears_legacy_doc_ref_pending_marker() {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_title'   => 'A Long-Form Post',
@@ -1606,6 +1488,7 @@ class Test_Publisher extends WP_UnitTestCase {
 		\update_post_meta( $post->ID, Post::META_CID, 'bafyreibstored' );
 		\update_post_meta( $post->ID, Document::META_URI, 'at://did:plc:test123/site.standard.document/doc-rkey-1' );
 		\update_post_meta( $post->ID, Document::META_TID, 'doc-rkey-1' );
+		\update_post_meta( $post->ID, Document::META_CID, 'bafyreibstaledoc' );
 
 		$this->fail_call_indexes = array();
 		$this->register_capture( $post->ID );
@@ -1621,6 +1504,75 @@ class Test_Publisher extends WP_UnitTestCase {
 		$this->assertSame( 'stored-rkey-1', $writes[0]['rkey'] );
 		$this->assertSame( 'com.atproto.repo.applyWrites#update', $writes[1]['$type'] );
 		$this->assertSame( 'doc-rkey-1', $writes[1]['rkey'] );
+		$this->assertArrayNotHasKey( 'bskyPostRef', $writes[1]['value'] );
+
+		$doc_cid = CID::from_record( $writes[1]['value'] );
+		$this->assertNotWPError( $doc_cid );
+
+		$refs    = $writes[0]['value']['embed']['external']['associatedRefs'] ?? array();
+		$doc_ref = null;
+		foreach ( $refs as $ref ) {
+			if ( false !== \strpos( $ref['uri'] ?? '', '/site.standard.document/' ) ) {
+				$doc_ref = $ref;
+				break;
+			}
+		}
+
+		$this->assertIsArray( $doc_ref );
+		$this->assertSame( $doc_cid, $doc_ref['cid'] );
+		$this->assertNotSame( 'bafyreibstaledoc', $doc_ref['cid'] );
+	}
+
+	/**
+	 * If the current document payload cannot be locally encoded, update
+	 * must not fall back to advertising the previous document CID.
+	 */
+	public function test_update_suppresses_document_ref_when_doc_cid_precompute_fails() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'A Long-Form Post',
+				'post_content' => 'Body.',
+				'post_excerpt' => 'Teaser excerpt.',
+			)
+		);
+
+		$root_uri = 'at://did:plc:test123/app.bsky.feed.post/stored-rkey-1';
+		\update_post_meta(
+			$post->ID,
+			Post::META_THREAD_RECORDS,
+			array(
+				array(
+					'uri' => $root_uri,
+					'cid' => 'bafyreibstored',
+					'tid' => 'stored-rkey-1',
+				),
+			)
+		);
+		\update_post_meta( $post->ID, Post::META_URI, $root_uri );
+		\update_post_meta( $post->ID, Post::META_TID, 'stored-rkey-1' );
+		\update_post_meta( $post->ID, Post::META_CID, 'bafyreibstored' );
+		\update_post_meta( $post->ID, Document::META_URI, 'at://did:plc:test123/site.standard.document/doc-rkey-1' );
+		\update_post_meta( $post->ID, Document::META_TID, 'doc-rkey-1' );
+		\update_post_meta( $post->ID, Document::META_CID, 'bafyreibstaledoc' );
+
+		\add_filter(
+			'atmosphere_transform_document',
+			static function ( array $record ): array {
+				$record['unsupported'] = new \stdClass();
+				return $record;
+			}
+		);
+
+		$this->fail_call_indexes = array();
+		$this->register_capture( $post->ID );
+
+		$result = Publisher::update( $post );
+
+		$this->assertIsArray( $result );
+
+		$writes = $this->captured_calls[0]['writes'];
+		$this->assertArrayHasKey( 'unsupported', $writes[1]['value'] );
+		$this->assertArrayNotHasKey( 'associatedRefs', $writes[0]['value']['embed']['external'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-wellknown-rewrite.php
+++ b/tests/phpunit/tests/class-test-wellknown-rewrite.php
@@ -38,8 +38,8 @@ class Test_Wellknown_Rewrite extends WP_UnitTestCase {
 	 * @var array<string, string>
 	 */
 	private const WELLKNOWN_PATTERNS = array(
-		'^\.well-known/atproto-did$'                 => 'index.php?atmosphere_wellknown=atproto-did',
-		'^\.well-known/site\.standard\.publication$' => 'index.php?atmosphere_wellknown=publication',
+		'^\.well-known/atproto-did/?$'                 => 'index.php?atmosphere_wellknown=atproto-did',
+		'^\.well-known/site\.standard\.publication/?$' => 'index.php?atmosphere_wellknown=publication',
 	);
 
 	/**
@@ -141,9 +141,9 @@ class Test_Wellknown_Rewrite extends WP_UnitTestCase {
 	 */
 	public function test_no_flush_when_both_patterns_present(): void {
 		$original = array(
-			'^\.well-known/atproto-did$'                 => 'index.php?atmosphere_wellknown=atproto-did',
-			'^\.well-known/site\.standard\.publication$' => 'index.php?atmosphere_wellknown=publication',
-			'some/other/rule'                            => 'index.php?other=1',
+			'^\.well-known/atproto-did/?$'                 => 'index.php?atmosphere_wellknown=atproto-did',
+			'^\.well-known/site\.standard\.publication/?$' => 'index.php?atmosphere_wellknown=publication',
+			'some/other/rule'                              => 'index.php?other=1',
 		);
 		\update_option( 'rewrite_rules', $original );
 
@@ -174,8 +174,25 @@ class Test_Wellknown_Rewrite extends WP_UnitTestCase {
 		\update_option(
 			'rewrite_rules',
 			array(
+				'^\.well-known/atproto-did/?$' => 'index.php?atmosphere_wellknown=atproto-did',
+				'some/other/rule'              => 'index.php?other=1',
+			)
+		);
+
+		Atmosphere::maybe_flush_wellknown_rewrites();
+
+		$this->assertWellknownPatternsResolved( \get_option( 'rewrite_rules' ) );
+	}
+
+	/**
+	 * Flushes when a site still has the older exact-match rules.
+	 */
+	public function test_flushes_when_legacy_exact_patterns_are_present(): void {
+		\update_option(
+			'rewrite_rules',
+			array(
 				'^\.well-known/atproto-did$' => 'index.php?atmosphere_wellknown=atproto-did',
-				'some/other/rule'            => 'index.php?other=1',
+				'^\.well-known/site\.standard\.publication$' => 'index.php?atmosphere_wellknown=publication',
 			)
 		);
 

--- a/tests/phpunit/tests/cli/class-test-backfill-command-invoke.php
+++ b/tests/phpunit/tests/cli/class-test-backfill-command-invoke.php
@@ -50,7 +50,6 @@ class Test_Backfill_Command_Invoke extends \WP_UnitTestCase {
 		\update_option( 'atmosphere_did', 'did:plc:test123' );
 
 		\add_filter( 'atmosphere_syncable_post_types', array( $this, 'force_post_support' ) );
-		\add_filter( 'pre_http_request', array( $this, 'mock_put_record' ), 10, 3 );
 	}
 
 	/**
@@ -62,7 +61,6 @@ class Test_Backfill_Command_Invoke extends \WP_UnitTestCase {
 
 		\remove_all_filters( 'atmosphere_pre_apply_writes' );
 		\remove_filter( 'atmosphere_syncable_post_types', array( $this, 'force_post_support' ) );
-		\remove_filter( 'pre_http_request', array( $this, 'mock_put_record' ), 10 );
 
 		parent::tear_down();
 	}
@@ -74,34 +72,6 @@ class Test_Backfill_Command_Invoke extends \WP_UnitTestCase {
 	 */
 	public function force_post_support(): array {
 		return array( 'post' );
-	}
-
-	/**
-	 * Mock the document-ref `putRecord` follow-up call.
-	 *
-	 * @param false|array|\WP_Error $response Preemptive HTTP response.
-	 * @param array                 $args     Request args.
-	 * @param string                $url      Request URL.
-	 * @return false|array|\WP_Error
-	 */
-	public function mock_put_record( $response, array $args, string $url ) {
-		if ( false !== $response ) {
-			return $response;
-		}
-
-		if ( false === \strpos( $url, 'com.atproto.repo.putRecord' ) ) {
-			return $response;
-		}
-
-		return array(
-			'response' => array( 'code' => 200 ),
-			'body'     => \wp_json_encode(
-				array(
-					'uri' => 'at://did:plc:test123/site.standard.document/doc-ref',
-					'cid' => 'bafyreibdocref',
-				)
-			),
-		);
 	}
 
 	/**

--- a/tests/phpunit/tests/transformer/class-test-document.php
+++ b/tests/phpunit/tests/transformer/class-test-document.php
@@ -194,6 +194,26 @@ class Test_Document extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Public document records do not include a Bluesky back-reference.
+	 */
+	public function test_document_omits_bsky_post_ref() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_status'  => 'publish',
+				'post_title'   => 'Public post',
+				'post_content' => 'Public body.',
+			)
+		);
+
+		\update_post_meta( $post->ID, Post::META_URI, 'at://did:plc:test/app.bsky.feed.post/public' );
+		\update_post_meta( $post->ID, Post::META_CID, 'bafypublic' );
+
+		$record = ( new Document( $post ) )->transform();
+
+		$this->assertArrayNotHasKey( 'bskyPostRef', $record );
+	}
+
+	/**
 	 * Password-protected posts must not expose protected fields through
 	 * document records, even when the transformer is called directly.
 	 */

--- a/tests/phpunit/tests/transformer/class-test-post.php
+++ b/tests/phpunit/tests/transformer/class-test-post.php
@@ -3939,6 +3939,40 @@ class Test_Post extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Passing null explicitly suppresses the document-meta fallback.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_long_form_embed_can_suppress_document_meta_fallback() {
+		\update_option( 'atmosphere_identity', array( 'did' => 'did:plc:test123' ), false );
+		\update_option( Publication::OPTION_TID, '3kpub00000000', false );
+		\update_option( Publication::OPTION_CID, 'bafyreipublication0000000000000000000000000000000000000000000', false );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'A Titled Post',
+				'post_content' => 'Long-form blog body.',
+			)
+		);
+
+		\update_post_meta( $post->ID, Document::META_URI, 'at://did:plc:test123/site.standard.document/stale' );
+		\update_post_meta( $post->ID, Document::META_CID, 'bafyreistalestalestalestalestalestalestalestalestalestalestale' );
+
+		$transformer = new Post( $post );
+		$transformer->set_document_strong_ref( null );
+
+		$record = $transformer->transform();
+
+		$refs = $record['embed']['external']['associatedRefs'];
+		$this->assertCount( 1, $refs );
+		$this->assertSame( 'at://did:plc:test123/site.standard.publication/3kpub00000000', $refs[0]['uri'] );
+
+		\delete_option( 'atmosphere_identity' );
+		\delete_option( Publication::OPTION_TID );
+		\delete_option( Publication::OPTION_CID );
+	}
+
+	/**
 	 * Short-form posts (`app.bsky.embed.images`, or no embed) never
 	 * carry `associatedRefs` — that field is defined only on
 	 * `app.bsky.embed.external#external`. Even with both publication


### PR DESCRIPTION
## Proposed changes:
* Stop mutating `site.standard.document` after publishing the Bluesky record, because that changes the document CID and leaves Bluesky `associatedRefs` pointing at an older document version.
* Compute the document CID from the exact document payload written in the same `applyWrites` batch for both initial publish and updates.
* Suppress stale document-meta fallback if local document CID precompute fails.
* Serve well-known standard.site/AT Protocol discovery endpoints before canonical redirects and accept optional trailing slashes.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
* Run `composer lint`.
* Run `npm run env-test`.
* Publish or update a long-form post and inspect the captured/appview record: the Bluesky post's `embed.external.associatedRefs` document CID should match the `site.standard.document` record written in the same publish/update.
* Request `/.well-known/site.standard.publication` and `/.well-known/site.standard.publication/`; both should resolve to the publication AT-URI without relying on a canonical redirect.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
