### PR TITLE
Warn when auto-publish is on but no post types are selected

### DIFF
--- a/.github/changelog/add-warn-no-post-types-selected
+++ b/.github/changelog/add-warn-no-post-types-selected
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+The settings page now warns you when auto-publishing is on but no post types are selected, so nothing would be published. The post types list also sits directly under the auto-publish setting to make their connection clearer.

--- a/.github/changelog/add-warn-no-post-types-selected
+++ b/.github/changelog/add-warn-no-post-types-selected
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-The settings page now warns you when auto-publishing is on but no post types are selected, so nothing would be published. The post types list also sits directly under the auto-publish setting to make their connection clearer.
+The settings page now warns you when auto-publishing is on but no post types are selected, so nothing would be published.

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -285,8 +285,8 @@ class Admin {
 	 *
 	 * Auto-publish defaults on and the Post types list is easy to miss, so
 	 * a user can end up "publishing" with everything unticked and nothing
-	 * eligible to send (issue #173). Registered as a settings error so it
-	 * surfaces at the top of the page via `options-head.php`.
+	 * eligible to send. Registered as a settings error so it surfaces at
+	 * the top of the page via `options-head.php`.
 	 *
 	 * Gated on `has_identity()` to match the publishing section's own
 	 * visibility, and on the effective `get_supported_post_types()` list so

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -283,23 +283,14 @@ class Admin {
 	/**
 	 * Warn when auto-publish is on but no post type will ever publish.
 	 *
-	 * Auto-publish defaults on while the Post types list is easy to miss
-	 * further down the page, so a user can leave the screen "publishing"
-	 * with every post type unticked and nothing eligible to send — a
-	 * silent dead end (see issue #173). Registering the warning as a
-	 * settings error surfaces it at the top of the Settings page through
-	 * `options-head.php`'s `settings_errors()` call, alongside the usual
-	 * "Settings saved." notice.
+	 * Auto-publish defaults on and the Post types list is easy to miss, so
+	 * a user can end up "publishing" with everything unticked and nothing
+	 * eligible to send (issue #173). Registered as a settings error so it
+	 * surfaces at the top of the page via `options-head.php`.
 	 *
-	 * Hooked on `load-settings_page_atmosphere`, which fires before
-	 * `admin-header.php` renders the settings errors, so the notice lands
-	 * on the same pageview. Gated on `has_identity()` to match the
-	 * publishing section's own visibility: when no identity is on file the
-	 * Post types field is not on screen, so a warning about it would
-	 * dangle. The effective list from `get_supported_post_types()` (not
-	 * the raw option) is the right signal — a native
-	 * `add_post_type_support()` opt-in keeps publishing alive even with an
-	 * empty option, and that is not a misconfiguration to warn about.
+	 * Gated on `has_identity()` to match the publishing section's own
+	 * visibility, and on the effective `get_supported_post_types()` list so
+	 * a native `add_post_type_support()` opt-in does not trip a false alarm.
 	 */
 	public static function maybe_warn_missing_post_types(): void {
 		if ( ! \current_user_can( 'manage_options' ) ) {

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -14,6 +14,8 @@ use Atmosphere\Handle;
 use Atmosphere\OAuth\Client;
 use Atmosphere\Publisher;
 use function Atmosphere\get_connection;
+use function Atmosphere\get_supported_post_types;
+use function Atmosphere\has_identity;
 use function Atmosphere\needs_reauth;
 
 /**
@@ -38,6 +40,7 @@ class Admin {
 		\add_action( 'admin_init', array( self::class, 'maybe_set_domain_handle' ) );
 		\add_action( 'admin_enqueue_scripts', array( self::class, 'enqueue_assets' ) );
 		\add_action( 'admin_notices', array( self::class, 'maybe_render_reauth_notice' ) );
+		\add_action( 'load-settings_page_atmosphere', array( self::class, 'maybe_warn_missing_post_types' ) );
 
 		\add_action( 'admin_post_atmosphere_disconnect', array( self::class, 'handle_disconnect' ) );
 	}
@@ -275,5 +278,51 @@ class Admin {
 			</p>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Warn when auto-publish is on but no post type will ever publish.
+	 *
+	 * Auto-publish defaults on while the Post types list is easy to miss
+	 * further down the page, so a user can leave the screen "publishing"
+	 * with every post type unticked and nothing eligible to send — a
+	 * silent dead end (see issue #173). Registering the warning as a
+	 * settings error surfaces it at the top of the Settings page through
+	 * `options-head.php`'s `settings_errors()` call, alongside the usual
+	 * "Settings saved." notice.
+	 *
+	 * Hooked on `load-settings_page_atmosphere`, which fires before
+	 * `admin-header.php` renders the settings errors, so the notice lands
+	 * on the same pageview. Gated on `has_identity()` to match the
+	 * publishing section's own visibility: when no identity is on file the
+	 * Post types field is not on screen, so a warning about it would
+	 * dangle. The effective list from `get_supported_post_types()` (not
+	 * the raw option) is the right signal — a native
+	 * `add_post_type_support()` opt-in keeps publishing alive even with an
+	 * empty option, and that is not a misconfiguration to warn about.
+	 */
+	public static function maybe_warn_missing_post_types(): void {
+		if ( ! \current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		if ( ! has_identity() ) {
+			return;
+		}
+
+		if ( '1' !== \get_option( 'atmosphere_auto_publish', '1' ) ) {
+			return;
+		}
+
+		if ( ! empty( get_supported_post_types() ) ) {
+			return;
+		}
+
+		\add_settings_error(
+			'atmosphere',
+			'no_post_types',
+			\__( 'Auto-publish is on, but no post types are selected — nothing will be published. Select one or more post types under “Post types” below to start publishing.', 'atmosphere' ),
+			'warning'
+		);
 	}
 }

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -312,7 +312,7 @@ class Admin {
 		\add_settings_error(
 			'atmosphere',
 			'no_post_types',
-			\__( 'Auto-publish is on, but no post types are selected — nothing will be published. Select one or more post types under “Post types” below to start publishing.', 'atmosphere' ),
+			\__( 'Auto-publish is on, but no post types are selected, so nothing will be published. Select one or more post types under “Post types” below to start publishing.', 'atmosphere' ),
 			'warning'
 		);
 	}

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -90,24 +90,18 @@ class Settings_Fields {
 			'atmosphere_publishing'
 		);
 
-		/*
-		 * Sits directly under Auto-publish on purpose: the two settings
-		 * gate each other (auto-publish does nothing with no post types
-		 * selected), so keeping them adjacent makes that dependency hard
-		 * to miss. See issue #173.
-		 */
 		\add_settings_field(
-			'atmosphere_support_post_types',
-			\__( 'Post types', 'atmosphere' ),
-			array( self::class, 'render_support_post_types_field' ),
+			'atmosphere_long_form_composition',
+			\__( 'Long-form posts', 'atmosphere' ),
+			array( self::class, 'render_long_form_composition_field' ),
 			'atmosphere',
 			'atmosphere_publishing'
 		);
 
 		\add_settings_field(
-			'atmosphere_long_form_composition',
-			\__( 'Long-form posts', 'atmosphere' ),
-			array( self::class, 'render_long_form_composition_field' ),
+			'atmosphere_support_post_types',
+			\__( 'Post types', 'atmosphere' ),
+			array( self::class, 'render_support_post_types_field' ),
 			'atmosphere',
 			'atmosphere_publishing'
 		);

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -90,18 +90,24 @@ class Settings_Fields {
 			'atmosphere_publishing'
 		);
 
+		/*
+		 * Sits directly under Auto-publish on purpose: the two settings
+		 * gate each other (auto-publish does nothing with no post types
+		 * selected), so keeping them adjacent makes that dependency hard
+		 * to miss. See issue #173.
+		 */
 		\add_settings_field(
-			'atmosphere_long_form_composition',
-			\__( 'Long-form posts', 'atmosphere' ),
-			array( self::class, 'render_long_form_composition_field' ),
+			'atmosphere_support_post_types',
+			\__( 'Post types', 'atmosphere' ),
+			array( self::class, 'render_support_post_types_field' ),
 			'atmosphere',
 			'atmosphere_publishing'
 		);
 
 		\add_settings_field(
-			'atmosphere_support_post_types',
-			\__( 'Post types', 'atmosphere' ),
-			array( self::class, 'render_support_post_types_field' ),
+			'atmosphere_long_form_composition',
+			\__( 'Long-form posts', 'atmosphere' ),
+			array( self::class, 'render_long_form_composition_field' ),
 			'atmosphere',
 			'atmosphere_publishing'
 		);

--- a/tests/phpunit/tests/wp-admin/class-test-missing-post-types-notice.php
+++ b/tests/phpunit/tests/wp-admin/class-test-missing-post-types-notice.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Tests for `Admin::maybe_warn_missing_post_types()`.
+ *
+ * Auto-publish defaults on, so a user who unticks every Post types
+ * checkbox ends up with publishing "enabled" yet nothing eligible to
+ * publish — a silent dead end (see issue #173). The settings page must
+ * surface a warning in that state and stay quiet otherwise.
+ *
+ * The warning is registered as a settings error so WordPress renders it
+ * at the top of the Settings page via `options-head.php`'s
+ * `settings_errors()` call. These tests invoke the registration method
+ * directly and inspect `get_settings_errors()`.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group wp-admin
+ */
+
+namespace Atmosphere\Tests\WP_Admin;
+
+use Atmosphere\WP_Admin\Admin;
+use WP_UnitTestCase;
+
+/**
+ * Missing-post-types warning tests.
+ */
+class Test_Missing_Post_Types_Notice extends WP_UnitTestCase {
+
+	/**
+	 * Start each test with a clean settings-error queue.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		global $wp_settings_errors;
+		$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	}
+
+	/**
+	 * Reset request state, options, and the settings-error queue.
+	 */
+	public function tear_down(): void {
+		\wp_set_current_user( 0 );
+		\delete_option( 'atmosphere_identity' );
+		\delete_option( 'atmosphere_auto_publish' );
+		\delete_option( 'atmosphere_support_post_types' );
+		global $wp_settings_errors;
+		$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Become an administrator (grants `manage_options`).
+	 */
+	private function become_admin(): void {
+		$admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		\wp_set_current_user( $admin );
+	}
+
+	/**
+	 * Seed the identity row so the publishing section (and its Post
+	 * types field) is considered on screen.
+	 */
+	private function seed_identity(): void {
+		\update_option(
+			'atmosphere_identity',
+			array(
+				'did'          => 'did:plc:test',
+				'handle'       => 'example.com',
+				'pds_endpoint' => 'https://pds.example.com',
+			),
+			true
+		);
+	}
+
+	/**
+	 * Run the registration and return the codes of any settings errors
+	 * registered under the `atmosphere` slug.
+	 *
+	 * @return string[]
+	 */
+	private function registered_codes(): array {
+		Admin::maybe_warn_missing_post_types();
+
+		return \array_column(
+			\array_filter(
+				\get_settings_errors(),
+				static fn ( $error ) => 'atmosphere' === $error['setting']
+			),
+			'code'
+		);
+	}
+
+	/**
+	 * Auto-publish on with no post types selected: the warning must fire.
+	 */
+	public function test_warns_when_auto_publish_on_and_no_post_types(): void {
+		$this->become_admin();
+		$this->seed_identity();
+		\update_option( 'atmosphere_auto_publish', '1' );
+		\update_option( 'atmosphere_support_post_types', array() );
+
+		$this->assertContains( 'no_post_types', $this->registered_codes() );
+	}
+
+	/**
+	 * At least one post type selected: no warning, even with auto-publish on.
+	 */
+	public function test_no_warning_when_post_types_selected(): void {
+		$this->become_admin();
+		$this->seed_identity();
+		\update_option( 'atmosphere_auto_publish', '1' );
+		\update_option( 'atmosphere_support_post_types', array( 'post' ) );
+
+		$this->assertNotContains( 'no_post_types', $this->registered_codes() );
+	}
+
+	/**
+	 * Auto-publish off: an empty post-type list is harmless, so stay quiet.
+	 */
+	public function test_no_warning_when_auto_publish_disabled(): void {
+		$this->become_admin();
+		$this->seed_identity();
+		\update_option( 'atmosphere_auto_publish', '' );
+		\update_option( 'atmosphere_support_post_types', array() );
+
+		$this->assertNotContains( 'no_post_types', $this->registered_codes() );
+	}
+
+	/**
+	 * No identity on file: the Post types field is not on screen, so the
+	 * warning would dangle. It must not fire.
+	 */
+	public function test_no_warning_without_identity(): void {
+		$this->become_admin();
+		// No identity row.
+		\update_option( 'atmosphere_auto_publish', '1' );
+		\update_option( 'atmosphere_support_post_types', array() );
+
+		$this->assertNotContains( 'no_post_types', $this->registered_codes() );
+	}
+
+	/**
+	 * A native `add_post_type_support()` opt-in keeps the effective list
+	 * non-empty even when the option is empty, so nothing is actually
+	 * blocked: stay quiet.
+	 */
+	public function test_no_warning_when_post_type_enabled_via_native_support(): void {
+		$this->become_admin();
+		$this->seed_identity();
+		\update_option( 'atmosphere_auto_publish', '1' );
+		\update_option( 'atmosphere_support_post_types', array() );
+		\add_post_type_support( 'page', 'atmosphere' );
+
+		$codes = $this->registered_codes();
+
+		\remove_post_type_support( 'page', 'atmosphere' );
+
+		$this->assertNotContains( 'no_post_types', $codes );
+	}
+
+	/**
+	 * Fresh install: neither option is stored, so both fall back to their
+	 * registered defaults — auto-publish on, post types `['post']`. The
+	 * default list is non-empty, so the most common path stays quiet.
+	 */
+	public function test_no_warning_on_fresh_install_defaults(): void {
+		$this->become_admin();
+		$this->seed_identity();
+		// No atmosphere_auto_publish or atmosphere_support_post_types rows.
+
+		$this->assertNotContains( 'no_post_types', $this->registered_codes() );
+	}
+
+	/**
+	 * Capability gate: a user without `manage_options` gets no warning.
+	 */
+	public function test_no_warning_without_manage_options_cap(): void {
+		$this->seed_identity();
+		\update_option( 'atmosphere_auto_publish', '1' );
+		\update_option( 'atmosphere_support_post_types', array() );
+
+		$this->assertNotContains( 'no_post_types', $this->registered_codes() );
+	}
+}

--- a/tests/phpunit/tests/wp-admin/class-test-missing-post-types-notice.php
+++ b/tests/phpunit/tests/wp-admin/class-test-missing-post-types-notice.php
@@ -4,7 +4,7 @@
  *
  * Auto-publish defaults on, so a user who unticks every Post types
  * checkbox ends up with publishing "enabled" yet nothing eligible to
- * publish — a silent dead end (see issue #173). The settings page must
+ * publish, a silent dead end (see issue #173). The settings page must
  * surface a warning in that state and stay quiet otherwise.
  *
  * The warning is registered as a settings error so WordPress renders it
@@ -162,7 +162,7 @@ class Test_Missing_Post_Types_Notice extends WP_UnitTestCase {
 
 	/**
 	 * Fresh install: neither option is stored, so both fall back to their
-	 * registered defaults — auto-publish on, post types `['post']`. The
+	 * registered defaults: auto-publish on, post types `['post']`. The
 	 * default list is non-empty, so the most common path stays quiet.
 	 */
 	public function test_no_warning_on_fresh_install_defaults(): void {


### PR DESCRIPTION
Fixes #173

## Proposed changes:

Auto-publish defaults **on**, but the "Post types" checkboxes sit a couple of fields down the settings page, far enough that a user can finish setting up while leaving every type unticked. The result is a silent dead end: publishing looks enabled, yet nothing is ever eligible to send, with no feedback explaining why. The reporter nearly filed a "nothing publishes" bug over exactly this.

This PR adds a warning for that state. When an identity is connected, auto-publish is on, but no post type will publish, the settings page shows a warning at the top (in the same spot as "Settings saved."): *"Auto-publish is on, but no post types are selected, so nothing will be published. Select one or more post types under 'Post types' below to start publishing."* It's a warning rather than a hard error, since the configuration isn't strictly invalid, it just does nothing.

<img width="1370" height="271" alt="image" src="https://github.com/user-attachments/assets/1078804a-3dd1-435f-b9a2-00f9b7c3acf9" />

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Connect the plugin to an AT Protocol identity (or seed one: `wp option update atmosphere_identity --format=json '{"did":"did:plc:test","handle":"example.com","pds_endpoint":"https://pds.example.com"}'`).
2. Go to **Settings → ATmosphere**.
3. Under **Publishing**, make sure **Auto-publish** is checked, then untick **every** box under **Post types** and click **Save Changes**.
4. **Expected:** a warning appears at the top of the page: *"Auto-publish is on, but no post types are selected, so nothing will be published…"*
5. Tick at least one post type and save again. **Expected:** the warning is gone (replaced by "Settings saved.").
6. Untick all post types but also uncheck **Auto-publish**, save. **Expected:** no warning (an empty list is harmless when auto-publish is off).

### Changelog entry

A changelog entry (`.github/changelog/add-warn-no-post-types-selected`) is already included in this branch, so the automation below is left unchecked.
