### PR TITLE
Add retry with backoff for failed publish and update cron workers

### DIFF
--- a/.agents/skills/code-style/SKILL.md
+++ b/.agents/skills/code-style/SKILL.md
@@ -60,7 +60,7 @@ Always reserve the rkey via meta in `get_rkey()` — that meta key is the marker
 
 **Content / composition:** `atmosphere_content_parser` (deprecated; use `Content_Parser\Registry::register()`), `atmosphere_document_content`, `atmosphere_long_form_composition`, `atmosphere_teaser_thread_posts`.
 
-**Gating:** `atmosphere_syncable_post_types`, `atmosphere_should_publish_comment`, `atmosphere_should_sync_reply`, `atmosphere_backfill_query_chunk_size`, `atmosphere_oauth_redirect_uri`, `atmosphere_client_metadata`.
+**Gating:** `atmosphere_syncable_post_types`, `atmosphere_should_publish_comment`, `atmosphere_should_sync_reply`, `atmosphere_backfill_query_chunk_size`, `atmosphere_oauth_redirect_uri`, `atmosphere_client_metadata`, `atmosphere_publish_retry_delays` (backoff ladder for failed publish/update cron workers; length = retry budget; empty array disables retries).
 
 **Actions:** `atmosphere_publishing`, `atmosphere_publish_post_result`, `atmosphere_publish_comment_result`, `atmosphere_update_skipped_unsynced_post`, `atmosphere_long_form_strategy_downgraded`, `atmosphere_reaction_synced`. `atmosphere_publishing` receives the current `WP_Post` and is not a request-wide guard.
 

--- a/.github/changelog/add-publish-retry-backoff
+++ b/.github/changelog/add-publish-retry-backoff
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Failed attempts to share a post to Bluesky are now retried automatically for about twenty minutes, so a brief network or server hiccup no longer means the post silently never appears.

--- a/.github/changelog/fix-unschedule-all-cron-events
+++ b/.github/changelog/fix-unschedule-all-cron-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Disconnecting or deactivating now reliably removes all pending background tasks, so a task queued under a previous connection can no longer run against a newly connected account.

--- a/docs/php-coding-standards.md
+++ b/docs/php-coding-standards.md
@@ -227,6 +227,7 @@ use function Atmosphere\is_connected;
 \apply_filters( 'atmosphere_should_publish_comment',      $bool, $comment );
 \apply_filters( 'atmosphere_should_sync_reply',           $bool, $notification, $post_id );
 \apply_filters( 'atmosphere_backfill_query_chunk_size',   500 );
+\apply_filters( 'atmosphere_publish_retry_delays',        array( 60, 300, 900 ) ); // Backoff ladder for failed publish/update cron workers; length = retry budget; empty array disables retries.
 \apply_filters( 'atmosphere_oauth_redirect_uri',          $uri );
 \apply_filters( 'atmosphere_client_metadata',             $metadata );
 \apply_filters( 'atmosphere_appview_host',                'bsky.app', $path, $context ); // Host/subpath for appview web links; normalized; $context keys: type|did|handle|rkey|tag.

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -1905,9 +1905,30 @@ class Atmosphere {
 			return;
 		}
 
+		/**
+		 * Filters the backoff ladder for transient publish/update failures.
+		 *
+		 * One entry per retry, in seconds — the ladder's length IS the
+		 * retry budget. Return an empty array to disable retries, or a
+		 * longer array to raise the budget (the same knob covers both,
+		 * so the delay schedule and the attempt cap cannot contradict
+		 * each other).
+		 *
+		 * @since unreleased
+		 *
+		 * @param int[] $delays Retry delays in seconds. Default 60, 300, 900.
+		 */
+		$delays = \apply_filters( 'atmosphere_publish_retry_delays', self::PUBLISH_RETRY_DELAYS );
+		$delays = \array_values(
+			\array_filter(
+				\array_map( 'intval', (array) $delays ),
+				static fn( int $delay ): bool => $delay > 0
+			)
+		);
+
 		$attempts = (int) \get_post_meta( $post_id, self::META_PUBLISH_RETRIES, true );
 
-		if ( $attempts >= \count( self::PUBLISH_RETRY_DELAYS ) ) {
+		if ( $attempts >= \count( $delays ) ) {
 			/*
 			 * Ladder exhausted. Clear the counter so a future fresh save
 			 * gets a new budget, and leave a breadcrumb — this is the
@@ -1929,7 +1950,7 @@ class Atmosphere {
 
 		\update_post_meta( $post_id, self::META_PUBLISH_RETRIES, $attempts + 1 );
 		\wp_schedule_single_event(
-			\time() + self::PUBLISH_RETRY_DELAYS[ $attempts ],
+			\time() + $delays[ $attempts ],
 			$hook,
 			array( $post_id )
 		);

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -709,6 +709,16 @@ class Atmosphere {
 		try {
 			\do_action( 'atmosphere_publishing', $post );
 
+			/*
+			 * A status transition is fresh user intent, so it starts a
+			 * new retry budget. Without this, a counter stranded by a
+			 * dead retry event (disconnect cleared the queue, the post
+			 * was trashed mid-ladder, a cron event was lost) would
+			 * silently shrink — or zero out — the ladder of the next
+			 * publish attempt.
+			 */
+			\delete_post_meta( $post->ID, self::META_PUBLISH_RETRIES );
+
 			if ( $is_publishable ) {
 				\wp_clear_scheduled_hook( 'atmosphere_delete_post', array( $post->ID ) );
 			}
@@ -1933,18 +1943,24 @@ class Atmosphere {
 			 * Ladder exhausted. Clear the counter so a future fresh save
 			 * gets a new budget, and leave a breadcrumb — this is the
 			 * point where a post has definitively failed to reach the
-			 * PDS despite retries.
+			 * PDS despite retries. No breadcrumb when the filter
+			 * disabled retries outright: "giving up after 0 retries"
+			 * would misread as a failure of the ladder the operator
+			 * deliberately switched off.
 			 */
 			\delete_post_meta( $post_id, self::META_PUBLISH_RETRIES );
-			debug_log(
-				\sprintf(
-					'%s %d: giving up after %d retries (%s)',
-					$hook,
-					$post_id,
-					$attempts,
-					$result->get_error_code()
-				)
-			);
+
+			if ( ! empty( $delays ) ) {
+				debug_log(
+					\sprintf(
+						'%s %d: giving up after %d retries (%s)',
+						$hook,
+						$post_id,
+						$attempts,
+						$result->get_error_code()
+					)
+				);
+			}
 			return;
 		}
 
@@ -1977,6 +1993,19 @@ class Atmosphere {
 			'atmosphere_missing_tid',
 			'atmosphere_invalid_pre_apply_writes_return',
 			'atmosphere_invalid_pre_apply_writes_response',
+			'atmosphere_invalid_pre_upload_blob_return',
+			'atmosphere_decrypt',
+			'atmosphere_did_mismatch',
+
+			/*
+			 * Never retry a failed thread rollback: the orphan manifest
+			 * records live partial records on the PDS, and a retried
+			 * publish would mint fresh TIDs next to them — a duplicate,
+			 * user-visible copy of the post. This state needs operator
+			 * attention (see Post::META_ORPHAN_RECORDS), not another
+			 * attempt.
+			 */
+			'atmosphere_thread_rollback_failed',
 		);
 
 		if ( \in_array( $error->get_error_code(), $permanent_codes, true ) ) {

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -47,6 +47,36 @@ class Atmosphere {
 	private const META_PUBLISH_ATTEMPTS = '_atmosphere_publish_attempts';
 
 	/**
+	 * Post meta key tracking how many delayed retries a failed
+	 * publish/update cron worker has scheduled for the post.
+	 *
+	 * Deleted on success, on a permanent (non-retryable) failure, and
+	 * when the retry ladder is exhausted, so the next fresh save always
+	 * starts with a full retry budget.
+	 *
+	 * @var string
+	 */
+	private const META_PUBLISH_RETRIES = '_atmosphere_publish_retries';
+
+	/**
+	 * Backoff ladder for transient publish/update failures, in seconds.
+	 *
+	 * `wp_schedule_single_event()` is one-shot: without a re-queue, a
+	 * single PDS 5xx / rate limit / network blip permanently drops the
+	 * post from Bluesky with no operator-visible trace. One entry per
+	 * retry — three attempts spread over ~21 minutes rides out PDS
+	 * restarts and rate-limit windows without hammering a struggling
+	 * server.
+	 *
+	 * @var int[]
+	 */
+	private const PUBLISH_RETRY_DELAYS = array(
+		MINUTE_IN_SECONDS,
+		5 * MINUTE_IN_SECONDS,
+		15 * MINUTE_IN_SECONDS,
+	);
+
+	/**
 	 * Post meta marker set when remote records were removed because a
 	 * previously public post left public visibility.
 	 *
@@ -1457,6 +1487,7 @@ class Atmosphere {
 						? Publisher::update_post( $post )
 						: Publisher::publish_post( $post );
 					self::log_cron_error( 'publish_post', $post_id, $result );
+					self::maybe_schedule_publish_retry( 'atmosphere_publish_post', $post_id, $result );
 					if ( ! \is_wp_error( $result ) ) {
 						self::clear_visibility_cleanup_marker( $post );
 					}
@@ -1481,6 +1512,7 @@ class Atmosphere {
 						? Publisher::update_post( $post )
 						: Publisher::publish_post( $post );
 					self::log_cron_error( 'update_post', $post_id, $result );
+					self::maybe_schedule_publish_retry( 'atmosphere_update_post', $post_id, $result );
 					if ( ! \is_wp_error( $result ) ) {
 						self::clear_visibility_cleanup_marker( $post );
 					}
@@ -1849,6 +1881,102 @@ class Atmosphere {
 	 */
 	public static function log_reconcile_cleanup_error( int $post_id, $result ): void {
 		self::log_cron_error( 'reconcile_cleanup', $post_id, $result );
+	}
+
+	/**
+	 * Re-queue a failed publish/update cron worker with backoff.
+	 *
+	 * Mirrors the comment parent-defer pattern ({@see self::defer_for_parent()}):
+	 * a per-object attempt counter in meta, a bounded ladder, and a
+	 * one-shot re-schedule of the same hook + args. The worker re-checks
+	 * post state when the retry fires, so a post that was unpublished or
+	 * disabled in the meantime routes to cleanup instead of publishing.
+	 *
+	 * Success and permanent failures clear the counter so the next
+	 * fresh save starts with a full retry budget.
+	 *
+	 * @param string $hook    Cron hook to re-schedule (`atmosphere_publish_post` or `atmosphere_update_post`).
+	 * @param int    $post_id Post ID the worker ran for.
+	 * @param mixed  $result  Publisher result: array on success, `WP_Error` on failure.
+	 */
+	private static function maybe_schedule_publish_retry( string $hook, int $post_id, $result ): void {
+		if ( ! \is_wp_error( $result ) || ! self::is_transient_publish_error( $result ) ) {
+			\delete_post_meta( $post_id, self::META_PUBLISH_RETRIES );
+			return;
+		}
+
+		$attempts = (int) \get_post_meta( $post_id, self::META_PUBLISH_RETRIES, true );
+
+		if ( $attempts >= \count( self::PUBLISH_RETRY_DELAYS ) ) {
+			/*
+			 * Ladder exhausted. Clear the counter so a future fresh save
+			 * gets a new budget, and leave a breadcrumb — this is the
+			 * point where a post has definitively failed to reach the
+			 * PDS despite retries.
+			 */
+			\delete_post_meta( $post_id, self::META_PUBLISH_RETRIES );
+			debug_log(
+				\sprintf(
+					'%s %d: giving up after %d retries (%s)',
+					$hook,
+					$post_id,
+					$attempts,
+					$result->get_error_code()
+				)
+			);
+			return;
+		}
+
+		\update_post_meta( $post_id, self::META_PUBLISH_RETRIES, $attempts + 1 );
+		\wp_schedule_single_event(
+			\time() + self::PUBLISH_RETRY_DELAYS[ $attempts ],
+			$hook,
+			array( $post_id )
+		);
+	}
+
+	/**
+	 * Whether a publish failure is worth retrying.
+	 *
+	 * Retry-by-default with a bounded ladder: a wrongly-retried
+	 * permanent error costs at most three extra requests, while a
+	 * wrongly-dropped transient error silently loses the post. Only
+	 * failures that are deterministic — locally-generated preconditions
+	 * or a PDS 4xx that will reject the identical payload again — are
+	 * excluded.
+	 *
+	 * @param \WP_Error $error Failure returned by the Publisher.
+	 * @return bool True when a retry has a chance of succeeding.
+	 */
+	private static function is_transient_publish_error( \WP_Error $error ): bool {
+		$permanent_codes = array(
+			'atmosphere_post_not_publishable',
+			'atmosphere_not_connected',
+			'atmosphere_needs_reauth',
+			'atmosphere_missing_tid',
+			'atmosphere_invalid_pre_apply_writes_return',
+			'atmosphere_invalid_pre_apply_writes_response',
+		);
+
+		if ( \in_array( $error->get_error_code(), $permanent_codes, true ) ) {
+			return false;
+		}
+
+		$data   = $error->get_error_data();
+		$status = \is_array( $data ) && isset( $data['status'] ) ? (int) $data['status'] : 0;
+
+		/*
+		 * No status means the request never completed (DNS, TLS,
+		 * timeout) — the classic transient class. 408/429/5xx are the
+		 * server-side equivalents. Any other 4xx is a deterministic
+		 * rejection of this exact payload and would fail identically
+		 * on every attempt.
+		 */
+		if ( 0 === $status ) {
+			return true;
+		}
+
+		return 408 === $status || 429 === $status || $status >= 500;
 	}
 
 	/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -530,7 +530,14 @@ function get_cron_hooks(): array {
  */
 function clear_scheduled_hooks(): void {
 	foreach ( get_cron_hooks() as $hook ) {
-		\wp_clear_scheduled_hook( $hook );
+		/*
+		 * `wp_unschedule_hook()`, not `wp_clear_scheduled_hook()`: the
+		 * latter only removes events whose args match the given array
+		 * (default: empty), so an argless call would leave every queued
+		 * per-post/per-comment event (`[ $post_id ]`) in place — exactly
+		 * the events that must not fire against a different connection.
+		 */
+		\wp_unschedule_hook( $hook );
 	}
 }
 
@@ -544,7 +551,10 @@ function clear_scheduled_hooks(): void {
  */
 function clear_scheduled_hooks_all(): void {
 	clear_scheduled_hooks();
-	\wp_clear_scheduled_hook( 'atmosphere_revoke_refresh_token' );
+
+	// The revoke event always carries args (the encrypted token payload),
+	// so it likewise needs the args-agnostic unschedule.
+	\wp_unschedule_hook( 'atmosphere_revoke_refresh_token' );
 }
 
 /**

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -2439,4 +2439,207 @@ class Test_Atmosphere extends WP_UnitTestCase {
 
 		return (string) ( \rest_do_request( $request )->get_data()['atmosphere_url'] ?? '' );
 	}
+
+	/**
+	 * Short-circuit applyWrites with a transient (retryable) PDS error.
+	 *
+	 * @param int $status HTTP status carried in the error data.
+	 */
+	private function force_apply_writes_error( int $status ): void {
+		\add_filter(
+			'atmosphere_pre_apply_writes',
+			static fn() => new \WP_Error(
+				'atmosphere_pds',
+				'PDS request failed.',
+				array( 'status' => $status )
+			)
+		);
+	}
+
+	/**
+	 * Short-circuit applyWrites with a plausible per-write success response.
+	 */
+	private function force_apply_writes_success(): void {
+		\add_filter(
+			'atmosphere_pre_apply_writes',
+			static function ( $short_circuit, array $writes ) {
+				$results = array();
+				foreach ( $writes as $write ) {
+					$results[] = array(
+						'uri' => 'at://did:plc:test123/' . ( $write['collection'] ?? 'app.bsky.feed.post' ) . '/' . ( $write['rkey'] ?? 'rk' ),
+						'cid' => 'bafyreib' . \substr( \md5( (string) \wp_json_encode( $write ) ), 0, 20 ),
+					);
+				}
+
+				return array( 'results' => $results );
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * A transient PDS failure (5xx) in the publish worker schedules a
+	 * delayed retry of the same hook and records the attempt.
+	 */
+	public function test_publish_worker_schedules_backoff_retry_on_transient_pds_error() {
+		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+
+		/*
+		 * WP-Cron unschedules an event before running its callback; mirror
+		 * that so the creation-time event doesn't mask the retry.
+		 */
+		\wp_clear_scheduled_hook( 'atmosphere_publish_post', array( $post->ID ) );
+		\wp_clear_scheduled_hook( 'atmosphere_update_post', array( $post->ID ) );
+
+		$this->force_apply_writes_error( 500 );
+
+		\do_action( 'atmosphere_publish_post', $post->ID );
+
+		$next = \wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) );
+
+		$this->assertNotFalse( $next, 'Expected a retry to be scheduled after a transient PDS error.' );
+		$this->assertGreaterThanOrEqual( \time() + 45, $next, 'First retry should back off by about a minute.' );
+		$this->assertLessThanOrEqual( \time() + 75, $next, 'First retry should back off by about a minute.' );
+		$this->assertSame( '1', \get_post_meta( $post->ID, '_atmosphere_publish_retries', true ) );
+	}
+
+	/**
+	 * The retry delay escalates with the attempt count.
+	 */
+	public function test_publish_worker_backoff_escalates_with_attempts() {
+		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post->ID, '_atmosphere_publish_retries', '1' );
+
+		/*
+		 * WP-Cron unschedules an event before running its callback; mirror
+		 * that so the creation-time event doesn't mask the retry.
+		 */
+		\wp_clear_scheduled_hook( 'atmosphere_publish_post', array( $post->ID ) );
+		\wp_clear_scheduled_hook( 'atmosphere_update_post', array( $post->ID ) );
+
+		$this->force_apply_writes_error( 500 );
+
+		\do_action( 'atmosphere_publish_post', $post->ID );
+
+		$next = \wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) );
+
+		$this->assertNotFalse( $next, 'Expected a second retry to be scheduled.' );
+		$this->assertGreaterThanOrEqual( \time() + 4 * MINUTE_IN_SECONDS, $next, 'Second retry should back off by about five minutes.' );
+		$this->assertSame( '2', \get_post_meta( $post->ID, '_atmosphere_publish_retries', true ) );
+	}
+
+	/**
+	 * A permanent PDS rejection (plain 4xx) is not retried.
+	 */
+	public function test_publish_worker_does_not_retry_permanent_pds_error() {
+		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+
+		/*
+		 * WP-Cron unschedules an event before running its callback; mirror
+		 * that so the creation-time event doesn't mask the retry.
+		 */
+		\wp_clear_scheduled_hook( 'atmosphere_publish_post', array( $post->ID ) );
+		\wp_clear_scheduled_hook( 'atmosphere_update_post', array( $post->ID ) );
+
+		$this->force_apply_writes_error( 400 );
+
+		\do_action( 'atmosphere_publish_post', $post->ID );
+
+		$this->assertFalse(
+			\wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) ),
+			'A permanent PDS rejection must not schedule a retry.'
+		);
+		$this->assertSame( '', \get_post_meta( $post->ID, '_atmosphere_publish_retries', true ) );
+	}
+
+	/**
+	 * Retries stop after the ladder is exhausted, and the counter resets
+	 * so a later fresh save starts a new ladder.
+	 */
+	public function test_publish_worker_gives_up_after_max_retries() {
+		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post->ID, '_atmosphere_publish_retries', '3' );
+
+		/*
+		 * WP-Cron unschedules an event before running its callback; mirror
+		 * that so the creation-time event doesn't mask the retry.
+		 */
+		\wp_clear_scheduled_hook( 'atmosphere_publish_post', array( $post->ID ) );
+		\wp_clear_scheduled_hook( 'atmosphere_update_post', array( $post->ID ) );
+
+		$this->force_apply_writes_error( 500 );
+
+		\do_action( 'atmosphere_publish_post', $post->ID );
+
+		$this->assertFalse(
+			\wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) ),
+			'No retry may be scheduled once the ladder is exhausted.'
+		);
+		$this->assertSame( '', \get_post_meta( $post->ID, '_atmosphere_publish_retries', true ) );
+	}
+
+	/**
+	 * A successful publish clears a leftover retry counter.
+	 */
+	public function test_publish_worker_success_clears_retry_counter() {
+		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post->ID, '_atmosphere_publish_retries', '2' );
+
+		/*
+		 * WP-Cron unschedules an event before running its callback; mirror
+		 * that so the creation-time event doesn't mask the retry.
+		 */
+		\wp_clear_scheduled_hook( 'atmosphere_publish_post', array( $post->ID ) );
+		\wp_clear_scheduled_hook( 'atmosphere_update_post', array( $post->ID ) );
+
+		$this->force_apply_writes_success();
+
+		\do_action( 'atmosphere_publish_post', $post->ID );
+
+		$this->assertFalse(
+			\wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) ),
+			'A successful publish must not schedule a retry.'
+		);
+		$this->assertSame( '', \get_post_meta( $post->ID, '_atmosphere_publish_retries', true ) );
+	}
+
+	/**
+	 * The update worker retries transient failures the same way,
+	 * rescheduling its own hook.
+	 */
+	public function test_update_worker_schedules_backoff_retry_on_transient_pds_error() {
+		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+
+		\update_post_meta( $post->ID, Post::META_TID, 'bsky-tid-123' );
+		\update_post_meta(
+			$post->ID,
+			Post::META_THREAD_RECORDS,
+			array(
+				array(
+					'uri' => 'at://did:plc:test123/app.bsky.feed.post/bsky-tid-123',
+					'cid' => 'bafyreiboldcid',
+					'tid' => 'bsky-tid-123',
+				),
+			)
+		);
+		\update_post_meta( $post->ID, Document::META_TID, 'doc-tid-456' );
+		\update_post_meta( $post->ID, Document::META_URI, 'at://did:plc:test123/site.standard.document/doc-tid-456' );
+
+		/*
+		 * WP-Cron unschedules an event before running its callback; mirror
+		 * that so the creation-time event doesn't mask the retry.
+		 */
+		\wp_clear_scheduled_hook( 'atmosphere_publish_post', array( $post->ID ) );
+		\wp_clear_scheduled_hook( 'atmosphere_update_post', array( $post->ID ) );
+
+		$this->force_apply_writes_error( 503 );
+
+		\do_action( 'atmosphere_update_post', $post->ID );
+
+		$next = \wp_next_scheduled( 'atmosphere_update_post', array( $post->ID ) );
+
+		$this->assertNotFalse( $next, 'Expected the update worker to schedule a retry after a transient PDS error.' );
+		$this->assertSame( '1', \get_post_meta( $post->ID, '_atmosphere_publish_retries', true ) );
+	}
 }

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -2642,4 +2642,60 @@ class Test_Atmosphere extends WP_UnitTestCase {
 		$this->assertNotFalse( $next, 'Expected the update worker to schedule a retry after a transient PDS error.' );
 		$this->assertSame( '1', \get_post_meta( $post->ID, '_atmosphere_publish_retries', true ) );
 	}
+
+	/**
+	 * Returning an empty ladder from the delays filter disables
+	 * retries entirely.
+	 */
+	public function test_publish_retry_delays_filter_disables_retries() {
+		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+
+		/*
+		 * WP-Cron unschedules an event before running its callback; mirror
+		 * that so the creation-time event doesn't mask the retry.
+		 */
+		\wp_clear_scheduled_hook( 'atmosphere_publish_post', array( $post->ID ) );
+
+		\add_filter( 'atmosphere_publish_retry_delays', '__return_empty_array' );
+		$this->force_apply_writes_error( 500 );
+
+		\do_action( 'atmosphere_publish_post', $post->ID );
+
+		\remove_filter( 'atmosphere_publish_retry_delays', '__return_empty_array' );
+
+		$this->assertFalse(
+			\wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) ),
+			'An empty delays ladder must disable retries.'
+		);
+		$this->assertSame( '', \get_post_meta( $post->ID, '_atmosphere_publish_retries', true ) );
+	}
+
+	/**
+	 * A longer filtered ladder raises the retry budget: the ladder's
+	 * length is the maximum attempt count.
+	 */
+	public function test_publish_retry_delays_filter_extends_ladder() {
+		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post->ID, '_atmosphere_publish_retries', '3' );
+
+		/*
+		 * WP-Cron unschedules an event before running its callback; mirror
+		 * that so the creation-time event doesn't mask the retry.
+		 */
+		\wp_clear_scheduled_hook( 'atmosphere_publish_post', array( $post->ID ) );
+
+		$ladder = static fn() => array( 10, 20, 30, 40 );
+		\add_filter( 'atmosphere_publish_retry_delays', $ladder );
+		$this->force_apply_writes_error( 500 );
+
+		\do_action( 'atmosphere_publish_post', $post->ID );
+
+		\remove_filter( 'atmosphere_publish_retry_delays', $ladder );
+
+		$this->assertNotFalse(
+			\wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) ),
+			'A fourth attempt must be scheduled when the filtered ladder has four rungs.'
+		);
+		$this->assertSame( '4', \get_post_meta( $post->ID, '_atmosphere_publish_retries', true ) );
+	}
 }

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -58,11 +58,16 @@ class Test_Atmosphere extends WP_UnitTestCase {
 		\delete_option( 'atmosphere_publication_tid' );
 		\delete_option( \Atmosphere\OAuth\Client::DISCONNECTED_OPTION );
 
-		\wp_clear_scheduled_hook( 'atmosphere_publish_post' );
-		\wp_clear_scheduled_hook( 'atmosphere_update_post' );
-		\wp_clear_scheduled_hook( 'atmosphere_delete_post' );
-		\wp_clear_scheduled_hook( 'atmosphere_delete_records' );
-		\wp_clear_scheduled_hook( 'atmosphere_delete_comment_record' );
+		/*
+		 * wp_unschedule_hook(), not wp_clear_scheduled_hook(): the events
+		 * these tests queue carry per-post args, which the argless clear
+		 * would silently skip.
+		 */
+		\wp_unschedule_hook( 'atmosphere_publish_post' );
+		\wp_unschedule_hook( 'atmosphere_update_post' );
+		\wp_unschedule_hook( 'atmosphere_delete_post' );
+		\wp_unschedule_hook( 'atmosphere_delete_records' );
+		\wp_unschedule_hook( 'atmosphere_delete_comment_record' );
 
 		\remove_all_filters( 'atmosphere_should_publish_comment' );
 		\remove_all_filters( 'atmosphere_pre_apply_writes' );
@@ -2697,5 +2702,55 @@ class Test_Atmosphere extends WP_UnitTestCase {
 			'A fourth attempt must be scheduled when the filtered ladder has four rungs.'
 		);
 		$this->assertSame( '4', \get_post_meta( $post->ID, '_atmosphere_publish_retries', true ) );
+	}
+
+	/**
+	 * A failed thread rollback leaves live orphan records on the PDS;
+	 * an automatic retry would mint fresh TIDs and publish a duplicate
+	 * copy next to them. That failure must never be retried.
+	 */
+	public function test_publish_worker_does_not_retry_after_failed_thread_rollback() {
+		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+
+		/*
+		 * WP-Cron unschedules an event before running its callback; mirror
+		 * that so the creation-time event doesn't mask the retry.
+		 */
+		\wp_clear_scheduled_hook( 'atmosphere_publish_post', array( $post->ID ) );
+
+		\add_filter(
+			'atmosphere_pre_apply_writes',
+			static fn() => new \WP_Error(
+				'atmosphere_thread_rollback_failed',
+				'Thread publish failed and rollback also failed.',
+				array( 'partial_records' => array() )
+			)
+		);
+
+		\do_action( 'atmosphere_publish_post', $post->ID );
+
+		$this->assertFalse(
+			\wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) ),
+			'A failed rollback must not be retried — live orphans plus a retry means duplicate posts.'
+		);
+		$this->assertSame( '', \get_post_meta( $post->ID, '_atmosphere_publish_retries', true ) );
+	}
+
+	/**
+	 * A fresh user-intent status transition starts a new retry budget:
+	 * a counter stranded by a dead retry event (disconnect, trash, lost
+	 * cron) must not shrink the next ladder.
+	 */
+	public function test_status_transition_resets_retry_counter() {
+		$post = self::factory()->post->create_and_get( array( 'post_status' => 'draft' ) );
+		\update_post_meta( $post->ID, '_atmosphere_publish_retries', '2' );
+
+		\wp_publish_post( $post->ID );
+
+		$this->assertSame(
+			'',
+			\get_post_meta( $post->ID, '_atmosphere_publish_retries', true ),
+			'Publishing a post must reset any stranded retry counter.'
+		);
 	}
 }

--- a/tests/phpunit/tests/class-test-functions.php
+++ b/tests/phpunit/tests/class-test-functions.php
@@ -809,4 +809,53 @@ class Test_Functions extends \WP_UnitTestCase {
 		$this->assertSame( 'hashtag', $seen['context']['type'] );
 		$this->assertSame( 'WordPress', $seen['context']['tag'] );
 	}
+
+	/**
+	 * Disconnect cleanup must remove queued events regardless of their
+	 * args — per-post publish events carry a post ID, and a leftover
+	 * event firing after a reconnect would issue applyWrites against
+	 * a different repo.
+	 */
+	public function test_clear_scheduled_hooks_removes_events_with_args() {
+		\wp_schedule_single_event( \time() + 60, 'atmosphere_publish_post', array( 123 ) );
+		\wp_schedule_single_event( \time() + 60, 'atmosphere_update_post', array( 456 ) );
+		\wp_schedule_single_event( \time() + 60, 'atmosphere_sync_publication' );
+
+		\Atmosphere\clear_scheduled_hooks();
+
+		$this->assertFalse(
+			\wp_next_scheduled( 'atmosphere_publish_post', array( 123 ) ),
+			'A queued per-post publish event must be cleared on disconnect.'
+		);
+		$this->assertFalse(
+			\wp_next_scheduled( 'atmosphere_update_post', array( 456 ) ),
+			'A queued per-post update event must be cleared on disconnect.'
+		);
+		$this->assertFalse(
+			\wp_next_scheduled( 'atmosphere_sync_publication' ),
+			'An argless event must still be cleared.'
+		);
+	}
+
+	/**
+	 * Deactivation/uninstall cleanup must also remove the queued revoke
+	 * event, which always carries args (the encrypted token payload).
+	 */
+	public function test_clear_scheduled_hooks_all_removes_revoke_event_with_args() {
+		\wp_schedule_single_event(
+			\time() + 60,
+			'atmosphere_revoke_refresh_token',
+			array( 'ciphertext', 'https://auth.example.com/revoke' )
+		);
+
+		\Atmosphere\clear_scheduled_hooks_all();
+
+		$this->assertFalse(
+			\wp_next_scheduled(
+				'atmosphere_revoke_refresh_token',
+				array( 'ciphertext', 'https://auth.example.com/revoke' )
+			),
+			'The queued revoke event must be cleared at deactivation/uninstall.'
+		);
+	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -82,6 +82,7 @@ $atmosphere_meta_keys = array(
 	'_atmosphere_doc_cid',
 	'_atmosphere_doc_ref_pending',
 	'_atmosphere_visibility_cleanup',
+	'_atmosphere_publish_retries',
 	'_atmosphere_blob_ref',
 	'atmosphere_custom_text',
 );


### PR DESCRIPTION
Fixes #179
Fixes #181

## Proposed changes:

* **Retry with backoff for failed publish/update cron workers** (#179). Publishing is deferred to one-shot `wp_schedule_single_event` cron events; a single transient PDS failure (429/5xx/timeout) or missed cron tick previously dropped the post silently — the post showed "Published" in WordPress but never reached Bluesky (reported on wp.org as "inconsistent" publishing). Failed `atmosphere_publish_post` / `atmosphere_update_post` workers now re-queue themselves with an escalating 60s/5m/15m ladder, tracked in `_atmosphere_publish_retries` post meta and cleared on success, permanent rejection, exhaustion, or a fresh save. Mirrors the existing comment parent-defer pattern and the ActivityPub dispatcher's filterable-retry convention.
* **Transient-vs-permanent classification.** Retry-by-default with a permanent blocklist: local preconditions (`not_connected`, `needs_reauth`, `decrypt`, `did_mismatch`, …) and deterministic PDS 4xx are never retried; no-status network failures, 408, 429, and 5xx are. `atmosphere_thread_rollback_failed` is explicitly permanent — retrying after a failed rollback would mint fresh TIDs next to live orphan records and publish a duplicate copy.
* **New `atmosphere_publish_retry_delays` filter.** One entry per retry, so the ladder's length is also the attempt budget — an empty array disables retries, a longer array raises the cap. Documented in the hook reference.
* **Fix: disconnect/uninstall cron cleanup missed arg-carrying events** (#181). `wp_clear_scheduled_hook( $hook )` with no args only removes events scheduled with an empty args array, so every queued per-post event and the revoke event (encrypted token payload in its args) survived `clear_scheduled_hooks()` — the exact events the cleanup exists to stop from firing against a different connection. Both helpers now use `wp_unschedule_hook()`.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Reviewed pre-PR by three parallel review passes (correctness/WP-Cron races, conventions/test hygiene, edge cases/abuse); all blocking findings addressed in the last commit (duplicate-post guard, stranded-counter reset, uninstall sweep).

## Testing instructions:

* Start the environment: `npm run env-start`, connect a Bluesky account, and enable auto-publish.
* Simulate a transient PDS failure: `add_filter( 'atmosphere_pre_apply_writes', fn() => new \WP_Error( 'atmosphere_pds', 'boom', array( 'status' => 500 ) ) );` (e.g. via a mu-plugin), then publish a post.
* Check `wp cron event list` (or WP Crontrol): an `atmosphere_publish_post` event for the post is queued ~60s out; after it fails again, ~5m; then ~15m; then it stops. The post's `_atmosphere_publish_retries` meta tracks the attempt count and is removed at the end.
* Remove the failure filter before the next retry fires: the post publishes and the counter is cleared.
* Repeat with `array( 'status' => 400 )`: no retry is scheduled.
* For #181: publish a post so a per-post event is queued (or schedule one manually), then disconnect the account on the settings page and confirm `wp cron event list` shows no remaining `atmosphere_*` events.
* Run `npm run env-test` — 848 tests pass, including 10 new ones covering the ladder, the filter, the rollback guard, the counter reset, and the arg-carrying cleanup.
