### PR TITLE
Refresh agent and skill docs for the current plugin surfaces

### DIFF
--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -47,11 +47,14 @@ composer lint
 
 ## WP-CLI Inside wp-env
 
+There is no `env` npm script — call `wp-env` directly via `npx`:
+
 ```bash
-npm run env -- run cli wp plugin list
-npm run env -- run cli wp option get atmosphere_settings
-npm run env -- run cli wp transient delete --all
-npm run env -- run cli wp db cli
+npx wp-env run cli -- wp plugin list
+npx wp-env run cli -- wp option get atmosphere_identity
+npx wp-env run cli -- wp post create --post_title='Test' --post_status=publish --porcelain
+npx wp-env run cli -- wp transient delete --all
+npx wp-env run tests-cli -- wp option list     # Same, against the tests instance (:8885).
 ```
 
 ## When to Read the Full Docs

--- a/.agents/skills/test/SKILL.md
+++ b/.agents/skills/test/SKILL.md
@@ -41,25 +41,18 @@ class Test_Feature extends WP_UnitTestCase {
 
 ### Test File Location
 
-Tests live in `tests/phpunit/tests/` with a directory structure mirroring `includes/`:
+Tests live in `tests/phpunit/tests/`, mirroring `includes/` (run `ls -R tests/phpunit/tests` for the current listing):
 
 ```
 tests/phpunit/tests/
-├── class-test-admin-handle.php
-├── class-test-atmosphere.php
-├── class-test-dpop.php
-├── class-test-functions.php
-├── class-test-handle.php
-├── class-test-long-form-composition-setting.php
-├── class-test-post-types.php
-├── class-test-publisher.php          # Largest fixture; exposes register_capture() etc.
-├── class-test-reaction-sync.php
-├── oauth/
-└── transformer/
-    ├── class-test-facet.php
-    ├── class-test-post.php
-    ├── class-test-publication.php
-    └── class-test-tid.php
+├── class-test-*.php        # Core classes. class-test-publisher.php is the largest fixture;
+│                           # it exposes register_capture() / $captured_calls / $fail_call_indexes.
+├── cli/                    # WP-CLI command tests.
+├── content-parser/         # Parser tests + Fake_Parser / Minimal_Parser stubs + trait-block-fixtures.php.
+├── oauth/                  # Client authorize/refresh, encryption, resolver, redirect-uri filter.
+├── rest/                   # REST controllers (admin/ for the pre-publish controller).
+├── transformer/            # One test file per transformer + class-stub-parser.php.
+└── wp-admin/               # Settings, notices, sanitize callbacks.
 ```
 
 Test files are prefixed with `class-test-` and the class name is `Test_` + feature name.
@@ -101,6 +94,34 @@ npm run env-test -- --stop-on-failure
 # Run single test method.
 npm run env-test -- --filter=test_specific_method
 ```
+
+## Common Fixtures
+
+```php
+// Connected-account fixture — get_did() etc. read the identity option.
+\update_option( 'atmosphere_identity', array( 'did' => 'did:plc:test123' ), false );
+// Delete it in tear_down().
+
+// Stub blob uploads (thumbnails, icons) without HTTP — records the attempt too.
+$attempted     = false;
+$short_circuit = static function () use ( &$attempted ) {
+	$attempted = true;
+	return array( 'blob' => array( 'cid' => 'bafytest' ) );
+};
+\add_filter( 'atmosphere_pre_upload_blob', $short_circuit );
+
+// HTTP tripwire — fail loudly if any code path fires a real request.
+$fetched  = false;
+$tripwire = static function ( $preempt ) use ( &$fetched ) {
+	$fetched = true;
+	return $preempt;
+};
+\add_filter( 'pre_http_request', $tripwire, 1, 1 );
+// ...exercise...
+$this->assertFalse( $fetched, 'No HTTP request should be made.' );
+```
+
+Asserting a path is read-only? Pair the tripwire with a meta assertion (e.g. `Document::META_TID` still empty) — GET-serving preview paths must not write publish-state meta.
 
 ## Stubbing `applyWrites` calls
 

--- a/.claude/agents/code-review.md
+++ b/.claude/agents/code-review.md
@@ -50,6 +50,10 @@ Apply the **code-style** skill standards when reviewing. In addition, check for:
 - URL-safety checks must reject IP-literal hosts (`FILTER_VALIDATE_IP`, IPv6 brackets stripped) — `wp_safe_remote_*` is IPv4-centric, and a URL that doesn't go through that gate (e.g. a `wp_redirect()` target) has no other fallback.
 - Distinct failure modes get distinct error codes. One `WP_Error` code reused across "expired", "legacy session shape", and "decrypt OK but plaintext malformed" leaves support unable to triage.
 - Crypto output computed BEFORE writing partial state — `Encryption::encrypt()` can throw, so inlining it into a `set_transient()` call can leave earlier transients orphaned.
+- Per-object data served behind a blanket capability (`edit_posts` where `edit_post` + post ID is the real boundary) is a cross-author disclosure — mirror the gate the equivalent REST controller uses.
+- GET-serving paths through the transformers (previews, projections) must be read-only: no blob uploads, no meta writes, no TID reservation, no DNS/HTTPS resolution. Publish-state meta written from a GET corrupts create-vs-update detection.
+- Egress caps must bound the *publish*, not one function call — a per-call cap multiplies by thread entries/retries; misses need caching just like hits.
+- When publish output and front-end display both interpret the same content (mentions, links), they must share one tokenizer — separate implementations drift and the two surfaces disagree.
 
 ### Code Quality
 - No unused variables, imports, or dead code
@@ -66,7 +70,7 @@ Apply the **code-style** skill standards when reviewing. In addition, check for:
 
 ### Compatibility
 - PHP 8.2+ compatible syntax (matches `Requires PHP` in `atmosphere.php` and `composer.json`).
-- WordPress 6.2+ compatible (matches `Requires at least` in `readme.txt`).
+- WordPress 6.5+ compatible (matches `Requires at least` in `readme.txt` — verify against the file, it moves).
 - No breaking changes to public APIs (filters, actions, REST shape) without a deprecation path.
 
 ### Tests

--- a/.claude/agents/security-audit.md
+++ b/.claude/agents/security-audit.md
@@ -2,7 +2,7 @@
 name: security-audit
 description: Defensive first-party security review of the plugin's own code to detect and help fix weaknesses (SSRF, OAuth bypass, XSS, token leakage, DPoP issues) before release. Use when asked to check security, harden the plugin, or review the code for vulnerabilities to fix.
 tools: Bash, Read, Glob, Grep, WebFetch
-model: claude-opus-4-7[1m]
+model: opus
 skills: code-style
 ---
 
@@ -21,6 +21,15 @@ You check for weaknesses informed by the plugin's AT Protocol OAuth/DPoP surface
 Past security issues inform what patterns to watch for. Update this list when new issues are discovered or fixed. Sister-plugin findings are included when the same architectural pattern exists in ATmosphere.
 
 *(No ATmosphere CVEs reported yet — track issues as they arise.)*
+
+### In-House Pre-Release Findings (2026)
+
+Caught in review before release; re-check the class whenever the touched surface changes.
+
+1. **Generic capability on a per-object surface** (preview endpoint, fixed in #170 review) — the `?atproto` preview gated on blanket `edit_posts`, letting any author read another author's projected records, including saved custom Bluesky text that role cannot otherwise see. Per-object surfaces must gate on the object-level meta cap (`edit_post`, `$post->ID`), matching the REST pre-publish controller.
+2. **Request-scoped constant outliving its branch** (fixed in #170 review) — `REST_REQUEST` was defined before routing, so early-`return` branches left it defined for the rest of the page render, silently changing unrelated plugin behavior. Constants that mark "this request is special" may only be defined on branches that immediately `exit`.
+3. **Write side effects on a read-only GET** (preview blob uploads, fixed in #165 review) — `Document::transform()` / `Publication::transform()` uploaded uncached cover-image/site-icon blobs to the PDS (and wrote attachment meta) when a preview rendered them. Any GET-serving path through the transformers must run in a projecting/read-only mode: no blob uploads, no meta writes, no rkey reservation (`META_TID` keys are publish-state markers `Publisher::update_post()` depends on).
+4. **Per-call egress caps read as per-publish** (#165 review, residual) — `MAX_RESOLVED_HANDLES` bounds one `Facet::extract()` call, but a teaser thread re-enters `extract()` per entry, multiplying the bound (~5×20 lookups per publish, each up to DNS + 10s HTTPS). When auditing egress caps, compute the worst case per *publish/request*, not per function call.
 
 ### Sister-Plugin Visibility Incidents
 
@@ -152,13 +161,14 @@ Files: `includes/wp-admin/`, `templates/`
 
 ### 7. Authorization & Capability Checks
 
-Files: `includes/wp-admin/`, `includes/class-atmosphere.php`
+Files: `includes/wp-admin/`, `includes/class-atmosphere.php`, `includes/rest/`
 
 - Verify admin pages check `manage_options` or appropriate capabilities
 - Verify nonce checks on all form submissions (settings, OAuth connect/disconnect)
 - Check that the OAuth callback cannot be triggered by unauthorized users
 - Verify per-post meta box controls check `edit_post` capability
 - Check that AJAX/REST handlers verify capabilities before processing
+- **Object-level caps on per-object surfaces.** Any handler that serves data derived from a specific post (REST pre-publish projection, front-end preview, editor panel data) must gate on the meta cap for that post (`current_user_can( 'edit_post', $post->ID )`), not a blanket capability like `edit_posts` — the blanket form lets any author read other authors' per-post data (saved custom Bluesky text, projected records). See In-House Finding #1.
 - Flag any `phpcs:ignore WordPress.Security.NonceVerification` with an explanation of why it's safe
 - Verify that the Settings API registrations use proper sanitize callbacks
 
@@ -175,6 +185,8 @@ Files: `includes/class-publisher.php`, `includes/transformer/`
 - Verify `applyWrites` batch cannot be manipulated to write unexpected records or collections
 - Check TID generation for predictability or collision risks
 - Verify facet detection (`class-facet.php`) cannot inject malicious links or mentions
+- **Mention/handle resolution egress.** Every `@handle` the facet extractor resolves costs a DNS TXT lookup plus a possible HTTPS well-known fetch to a host the *content author* chose. Audit four things together: (a) the worst-case lookup count per publish — sum every `Facet::extract()` call the publish makes (thread entries multiply a per-call cap); (b) whether misses are cached as well as hits (uncached misses re-resolve the same dead handle per call); (c) that commenter-controlled content never triggers resolution unless a site explicitly opts in (boolean filter, explicit `(bool)` cast); (d) that handle syntax validation (`Resolver::is_valid_handle()`) rejects reserved/digit TLDs before any network I/O.
+- **Publish/display mention parity.** Whatever tokenization decides "this `@handle` is a mention" must be shared between the front-end linkifier and the facet extractor. Divergence produces notify-without-link or link-without-notify — including minting `#mention` facets (real Bluesky notifications) for handles inside `<code>`/`<pre>`/`<a>` that the site's own display refuses to link.
 - Check that the bsky post transformer respects Bluesky's character/image limits
 - Verify that backfill operations check post visibility before syncing
 - Verify backfill skips password-protected posts even when they have `publish` status and a public post type.
@@ -292,6 +304,7 @@ Files: `includes/class-atmosphere.php` (cron registration), `includes/class-publ
 - Verify the `atmosphere_publishing` action loop guard cannot be bypassed by a third-party hook that resets it.
 - Verify lifecycle transitions cancel or supersede stale scheduled work. A publish/restore after a queued delete must not leave the delete event alive if it would remove the newly-restored records; a newly-queued delete must not leave an older update event able to rewrite protected content first.
 - Verify any transition out of public queryability has a cleanup signal even when WordPress does not change `post_status`: applying `post_password`, removing post type support, narrowing `atmosphere_syncable_post_types`, or changing an equivalent visibility setting introduced later.
+- Verify every plugin-owned cron hook appears in `Atmosphere\get_cron_hooks()` and that disconnect/deactivate/uninstall clear events via `wp_unschedule_hook()` — NOT `wp_clear_scheduled_hook()`, which only clears events whose args match. Arg-carrying single events (retry ladder events carry `array( $post_id )`) survive an args-less clear and fire against a *different repo* after a disconnect → reconnect-to-another-account flow.
 
 ### 17. Deletion & Revocation Authority
 
@@ -300,6 +313,20 @@ Files: `includes/oauth/class-client.php` (`disconnect()`), `uninstall.php`, dele
 - On disconnect, the OAuth refresh token must be revoked at the auth server (`POST /oauth/revoke`), not just deleted locally. Local-only delete leaves a usable refresh token on the auth server.
 - On uninstall, both local state AND remote tokens should be cleaned up — a leaked credential file from a deleted install must not stay valid forever.
 - For comment / post deletion: verify the `caller-owns-this-record` check before deleting on the PDS. ATmosphere should never let a request from one user delete records owned by another (the AT-URI's repo DID must match the connected account).
+
+### 18. Front-End Record Previews (`?atproto`)
+
+Files: `includes/transformer/class-preview.php`, `includes/transformer/class-base.php` (`get_preview_records()`), the transformers' projecting modes.
+
+The `?atproto` selector serves capability-gated JSON projections of AT Protocol records on public front-end URLs. Audit it as its own surface:
+
+- **Capability scoping.** Singular previews must gate per post (`Preview::current_user_can_preview()` → `edit_post`, `$post->ID`); the front page has no post to scope to and keeps the `edit_posts` floor. Any regression back to a blanket capability is a cross-author disclosure (In-House Finding #1).
+- **Strictly read-only.** The preview is a GET. Trace every transformer path it can reach and confirm: no blob uploads (`Document`/`Publication` must project via cached blob refs — `Post::cached_image_blob()` — never `upload_thumbnail()`), no post/attachment meta writes, no TID reservation (`Document::get_rkey()` writes `META_TID`, a publish-state marker `Publisher::update_post()` keys off — a preview that reserves it corrupts publish-state detection), no DNS/HTTPS mention resolution (`Post::$projecting` must skip `Facet::extract()`).
+- **`REST_REQUEST` scoping.** The constant may only be defined on branches that immediately `exit` (In-House Finding #2). A fall-through branch with the constant defined silently changes every other plugin's behavior for the rest of the render.
+- **Cache headers.** The response is per-user, capability-gated content on a URL-keyed public path. Verify `nocache_headers()` (or equivalent `Cache-Control: private, no-store`) is sent before the JSON — an edge/page cache that keys purely on URL would otherwise serve an authorized preview to anonymous visitors. *(Known open item as of 2026-07 — if still absent, report it.)*
+- **Fall-through, not 404, for the unauthorized.** Requests that fail the gates must render the normal page untouched; error/404 responses for unauthorized `?atproto` hits leak that the parameter is meaningful.
+- **Redaction defense-in-depth.** Even for authorized viewers, password-protected/non-publish posts must project redacted fields (`Base::is_post_redacted()`), so an editor previewing a protected post cannot exfiltrate content into a shareable JSON URL.
+- **Third-party preview transformers.** `atmosphere_atproto_preview_transformers` lets other plugins expose records under the same gates. Confirm the read-only contract is documented on `Base::get_preview_records()` and that filter-added output is covered by the same capability decision.
 
 ## Recently Noted Patterns
 
@@ -334,6 +361,12 @@ Findings from sister-plugin audits (ActivityPub 8.1.x–8.2.x and parallel) and 
 - **Revoke at auth server on disconnect** — local-only token delete leaves a valid refresh token usable from anywhere it leaked to.
 - **Type-confusion via third-party filters** — `apply_filters` chains processing data from external sources must validate return shapes; ActivityPub had a class of fatals where third-party plugins returned `null` into filters that expected arrays.
 - **Cron reentry idempotency** — handlers with user-visible side effects must claim the work atomically (`add_option( $key, $value, '', false )` is race-safe) **before** the side effect runs.
+- **Object-level caps on per-object surfaces** — `edit_posts` on a handler that serves one post's data lets any author read every author's data. Gate on `edit_post` + the post ID; mirror whatever the equivalent REST controller gates on.
+- **Read-only GET invariant** — preview/projection paths through the transformers must not upload blobs, write meta, reserve TIDs, or trigger DNS/HTTPS resolution. Publish-state meta keys written from a GET corrupt the publisher's create-vs-update detection.
+- **`nocache_headers()` on capability-gated front-end responses** — per-user JSON on a public URL is a cache-poisoning disclosure on URL-keyed edge caches. Status + Content-Type alone are not enough.
+- **Per-publish egress budgets, not per-call caps** — a cap enforced inside one function call multiplies by however many times the publish calls it (thread entries, retries). Compute and bound the worst case per publish; cache misses as well as hits.
+- **Publish/display parity for content tokenization** — the code that decides what is a mention/link for the published record and the code that decides for the rendered page must share one tokenizer, or the two surfaces silently disagree (notifications without links, links without notifications).
+- **`wp_unschedule_hook()` for arg-carrying events** — `wp_clear_scheduled_hook( $hook )` without args does not clear events scheduled with args; stale per-post events survive disconnect and fire against the next connected account's repo.
 
 ## Confirming a Fix Against the User's Own Instance
 
@@ -369,6 +402,14 @@ curl -s "$URL/.well-known/site.standard.publication?post_id=999999"
 
 # Response-header hygiene on the public endpoints.
 curl -sI "$URL/.well-known/atproto-did" | grep -iE "x-powered-by|server|x-content-type-options|strict-transport-security"
+
+# Preview endpoint logged out — must fall through to the normal HTML page, never JSON.
+curl -s -o /dev/null -w "%{http_code} %{content_type}\n" "$URL/?p=1&atproto"
+curl -s -o /dev/null -w "%{http_code} %{content_type}\n" "$URL/?p=1&atproto=app.bsky.feed.post"
+
+# Preview cache hygiene — authorized responses must not be publicly cacheable
+# (run with a logged-in editor cookie jar; expect Cache-Control: private/no-store).
+curl -sI -b "$COOKIE_JAR" "$URL/?p=1&atproto" | grep -iE "cache-control|expires"
 ```
 
 ## Output Format

--- a/.claude/agents/spec-check.md
+++ b/.claude/agents/spec-check.md
@@ -18,6 +18,8 @@ Before auditing, fetch the relevant specs for current requirements:
 - **Bluesky Lexicons** — https://docs.bsky.app/ (app.bsky.feed.post and related schemas)
 - **standard.site Lexicons** — https://standard.site/ (site.standard.publication, site.standard.document schemas)
 - **Markpub Lexicons** — https://markpub.at/ (at.markpub.markdown, at.markpub.text schemas for rich content in document records)
+- **org.wordpress.html** — [`docs/org.wordpress.html.md`](../../docs/org.wordpress.html.md) (the plugin's own Lexicon for the HTML content type — the in-repo doc is canonical)
+- **Leaflet / Pckt content types** — `pub.leaflet.content` and `blog.pckt.content` (see [`docs/content-formats.md`](../../docs/content-formats.md) for the survey and pointers to their upstream schemas)
 
 Focus on **required** fields and constraints. Treat optional fields as non-blocking.
 
@@ -38,7 +40,7 @@ If the user specifies a live PDS or handle, use `curl` to test actual responses.
 - **app.bsky.feed.post** — required fields (text, createdAt), facets (mentions, links, hashtags), embed structure, character limits
 - **site.standard.document** — required and recommended properties per Lexicon, content union field
 - **site.standard.publication** — publication metadata record structure
-- **at.markpub.markdown** — content format for document records (text, flavor, facets)
+- **Document content union** — the registered parsers each emit their own content `$type`: `org.wordpress.html` (default HTML), `at.markpub.markdown`, `pub.leaflet.content`, `blog.pckt.content`. Validate each against its Lexicon; parser selection lives in `includes/content-parser/class-registry.php` (`atmosphere_content_format` option, third-party registrations via `Registry::register()`)
 - **OAuth 2.1 flow** — PKCE (S256), DPoP proof generation (ES256), PAR, client metadata document
 - **DPoP** — proof structure, nonce handling, token binding, key thumbprint
 - **Repository operations** — com.atproto.repo.applyWrites batch format, TID generation, rkey constraints


### PR DESCRIPTION
## Proposed changes:

* **security-audit agent** (the bulk): it predated the `?atproto` preview endpoint, the `includes/rest/` controllers, the retry-ladder cron, and the mention-resolution egress surface. It gains:
  * an **In-House Pre-Release Findings (2026)** history section encoding the four regression classes recent reviews caught (blanket-capability disclosure on per-post surfaces, `REST_REQUEST` outliving its branch, write-on-GET blob uploads, per-call egress caps misread as per-publish);
  * a dedicated **Section 18** auditing the `?atproto` preview (object-level caps, strict read-only invariant, `REST_REQUEST` scoping, missing `nocache_headers()` as a known-open item, fall-through behavior, redaction, third-party transformer contract);
  * mention-resolution egress + publish/display parity checks in the record-publishing section;
  * the `wp_unschedule_hook()`-for-arg-carrying-events rule in the cron section;
  * seven new Recently Noted Patterns, preview `curl` probes, and the stale `claude-opus-4-7[1m]` model pin replaced with the `opus` alias.
* **code-review agent**: WordPress 6.2+ → 6.5+ (matches `readme.txt`), plus four checklist bullets from the same review lessons.
* **dev skill**: the documented WP-CLI commands used a nonexistent `npm run env` script — replaced with working `npx wp-env run cli -- wp …` forms (verified against the running environment).
* **test skill**: the hardcoded 13-file test tree was stale (45+ files today) — replaced with a rot-resistant directory map, plus the three fixture patterns newer tests rely on (`atmosphere_identity` option, `atmosphere_pre_upload_blob` stub, `pre_http_request` tripwire).
* **spec-check agent**: knew only `at.markpub.markdown` of the four shipped content formats — now lists `org.wordpress.html` (with the in-repo Lexicon doc as canonical), `pub.leaflet.content`, and `blog.pckt.content`, and points at the `Registry` selection mechanism.

Every symbol, hook, option, command, path, and port referenced by the updated docs was verified to exist on trunk; the corrected CLI commands were executed against a running wp-env.

### Other information:

- [ ] Have you written new tests for your changes, if applicable? — N/A, documentation for agents/skills only; no shipped code touched.

## Testing instructions:

* `composer lint` and `npm run env-test` pass (docs-only diff — 854 tests green).
* Spot-check factual claims: `grep -n "function current_user_can_preview" includes/transformer/class-preview.php`, `grep -n "OPTION_FORMAT" includes/content-parser/class-registry.php`, `python3 -c "import json; print(list(json.load(open('package.json'))['scripts']))"` (no `env` script).
* Run `npx wp-env run cli -- wp plugin list` to confirm the corrected dev-skill command works.

### Changelog entry

Dev-tooling only (`.claude/`, `.agents/`) — nothing end-user facing ships; "Skip Changelog" label applied.

-   [ ] Automatically create a changelog entry from the details below.