### PR TITLE
Resolve Bluesky reactions on non-post post types

### DIFF
--- a/.github/changelog/fix-reaction-sync-cpt-resolution
+++ b/.github/changelog/fix-reaction-sync-cpt-resolution
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Import Bluesky likes, reposts, and replies on custom post types too. The reaction resolver previously only matched the default `post` type, so interactions on any other published post type it federates (pages, notes, and similar) were dropped silently.
+Import Bluesky likes, reposts, and replies on all your published content types. Previously these interactions were only brought back for standard posts, so likes and replies on pages and other content published to Bluesky were quietly missed.

--- a/.github/changelog/fix-reaction-sync-cpt-resolution
+++ b/.github/changelog/fix-reaction-sync-cpt-resolution
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Import Bluesky likes, reposts, and replies on custom post types too. The reaction resolver previously only matched the default `post` type, so interactions on any other published post type it federates (pages, notes, and similar) were dropped silently.

--- a/includes/class-reaction-sync.php
+++ b/includes/class-reaction-sync.php
@@ -1059,15 +1059,11 @@ class Reaction_Sync {
 	 * fallback, a like/repost targeting a reply post would silently
 	 * fail to resolve back to the originating WordPress post.
 	 *
-	 * Both lookups are scoped to `get_supported_post_types()` rather
-	 * than left to `get_posts()`'s `post_type => 'post'` default.
-	 * Without the explicit scope, reactions targeting a custom post
-	 * type we publish (an `aside`/`status`-style CPT, a note type,
-	 * etc.) resolve to nothing and are dropped silently — no comment
-	 * row, no error. The resolver must cover exactly the types the
-	 * Publisher federates. Passing the types explicitly also picks up
-	 * supported CPTs registered with `exclude_from_search`, which the
-	 * `'any'` shortcut would miss.
+	 * Both lookups are scoped to `get_supported_post_types()` so the
+	 * resolver covers exactly the types the Publisher federates — see
+	 * {@see self::find_post_by_uri_meta()} for why the explicit scope
+	 * matters. When no post types are supported there is nothing to
+	 * resolve, so bail before running any query.
 	 *
 	 * @param string $uri AT-URI.
 	 * @return int|false
@@ -1079,25 +1075,45 @@ class Reaction_Sync {
 
 		$post_types = get_supported_post_types();
 
-		$posts = \get_posts(
-			array(
-				'meta_key'       => BskyPost::META_URI, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				'meta_value'     => $uri, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-				'post_type'      => $post_types,
-				'posts_per_page' => 1,
-				'post_status'    => 'publish',
-				'has_password'   => false,
-				'fields'         => 'ids',
-			)
-		);
-
-		if ( ! empty( $posts ) ) {
-			return (int) $posts[0];
+		/*
+		 * An empty supported-types list means nothing is federated, so
+		 * nothing should resolve. Bail before get_posts(), whose empty
+		 * `post_type` array silently falls back to WordPress's `post`
+		 * default and would reintroduce the exact miss this scoping fixes.
+		 */
+		if ( empty( $post_types ) ) {
+			return false;
 		}
 
+		$post_id = self::find_post_by_uri_meta( BskyPost::META_URI, $uri, $post_types );
+
+		if ( false !== $post_id ) {
+			return $post_id;
+		}
+
+		return self::find_post_by_uri_meta( BskyPost::META_URI_INDEX, $uri, $post_types );
+	}
+
+	/**
+	 * Resolve a published, federated post from a URI-valued meta key.
+	 *
+	 * Scoped to the supported post types rather than left to
+	 * `get_posts()`'s `post_type => 'post'` default. Without the explicit
+	 * scope, reactions targeting a custom post type we publish (an
+	 * `aside`/`status`-style CPT, a note type, etc.) resolve to nothing
+	 * and are dropped silently — no comment row, no error. Passing the
+	 * types explicitly also picks up supported CPTs registered with
+	 * `exclude_from_search`, which the `'any'` shortcut would miss.
+	 *
+	 * @param string   $meta_key   Meta key to match ({@see BskyPost::META_URI} or META_URI_INDEX).
+	 * @param string   $uri        AT-URI to match.
+	 * @param string[] $post_types Supported post types to scope the query to.
+	 * @return int|false
+	 */
+	private static function find_post_by_uri_meta( string $meta_key, string $uri, array $post_types ): int|false {
 		$posts = \get_posts(
 			array(
-				'meta_key'       => BskyPost::META_URI_INDEX, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_key'       => $meta_key, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_value'     => $uri, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 				'post_type'      => $post_types,
 				'posts_per_page' => 1,

--- a/includes/class-reaction-sync.php
+++ b/includes/class-reaction-sync.php
@@ -1059,6 +1059,16 @@ class Reaction_Sync {
 	 * fallback, a like/repost targeting a reply post would silently
 	 * fail to resolve back to the originating WordPress post.
 	 *
+	 * Both lookups are scoped to `get_supported_post_types()` rather
+	 * than left to `get_posts()`'s `post_type => 'post'` default.
+	 * Without the explicit scope, reactions targeting a custom post
+	 * type we publish (an `aside`/`status`-style CPT, a note type,
+	 * etc.) resolve to nothing and are dropped silently — no comment
+	 * row, no error. The resolver must cover exactly the types the
+	 * Publisher federates. Passing the types explicitly also picks up
+	 * supported CPTs registered with `exclude_from_search`, which the
+	 * `'any'` shortcut would miss.
+	 *
 	 * @param string $uri AT-URI.
 	 * @return int|false
 	 */
@@ -1067,10 +1077,13 @@ class Reaction_Sync {
 			return false;
 		}
 
+		$post_types = get_supported_post_types();
+
 		$posts = \get_posts(
 			array(
 				'meta_key'       => BskyPost::META_URI, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_value'     => $uri, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'post_type'      => $post_types,
 				'posts_per_page' => 1,
 				'post_status'    => 'publish',
 				'has_password'   => false,
@@ -1086,6 +1099,7 @@ class Reaction_Sync {
 			array(
 				'meta_key'       => BskyPost::META_URI_INDEX, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_value'     => $uri, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'post_type'      => $post_types,
 				'posts_per_page' => 1,
 				'post_status'    => 'publish',
 				'has_password'   => false,

--- a/tests/phpunit/tests/class-test-reaction-sync.php
+++ b/tests/phpunit/tests/class-test-reaction-sync.php
@@ -150,6 +150,85 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The thread-index fallback must also resolve a supported non-`post` type.
+	 *
+	 * `find_post_by_bsky_uri()` scopes BOTH lookups — the single-record
+	 * `META_URI` key and the `META_URI_INDEX` thread fallback Publisher
+	 * populates for every teaser-thread reply. The other regression tests
+	 * only seed `META_URI`, so they never reach the second query. This one
+	 * seeds only the index key on a `page` to guard the fallback branch
+	 * against a future change that drops its `post_type` scope.
+	 */
+	public function test_find_post_by_bsky_uri_thread_index_resolves_supported_non_default_post_type() {
+		\update_option( 'atmosphere_support_post_types', array( 'post', 'page' ) );
+
+		$post_id   = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			)
+		);
+		$reply_uri = 'at://did:plc:test123/app.bsky.feed.post/pagereply123';
+
+		\add_post_meta( $post_id, BskyPost::META_URI_INDEX, $reply_uri );
+
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'find_post_by_bsky_uri' );
+
+		$this->assertSame( $post_id, $method->invoke( null, $reply_uri ) );
+	}
+
+	/**
+	 * A reaction on an unsupported post type must NOT resolve.
+	 *
+	 * Pins the upper bound of the scoping: the resolver covers exactly the
+	 * federated types, no more. Without this, a future widening back to
+	 * `post_type => 'any'` would silently start importing reactions onto
+	 * content the site never federated, and every positive test would still
+	 * pass. Here `page` carries matching meta but is absent from the
+	 * supported list, so the lookup must miss.
+	 */
+	public function test_find_post_by_bsky_uri_ignores_unsupported_post_type() {
+		\update_option( 'atmosphere_support_post_types', array( 'post' ) );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			)
+		);
+		$uri     = 'at://did:plc:test123/app.bsky.feed.post/unsupported123';
+
+		\update_post_meta( $post_id, BskyPost::META_URI, $uri );
+
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'find_post_by_bsky_uri' );
+
+		$this->assertFalse( $method->invoke( null, $uri ) );
+	}
+
+	/**
+	 * An empty supported-types list must resolve nothing, not fall back to `post`.
+	 *
+	 * When a site owner unticks every type, the option is stored as an empty
+	 * array. Passing `post_type => array()` to `get_posts()` silently defaults
+	 * to `post_type => 'post'`, which would reintroduce the original miss (and
+	 * resolve reactions onto content the Publisher no longer federates). The
+	 * resolver must short-circuit to false instead: a matching `post` exists
+	 * here, yet nothing is federated, so nothing should resolve.
+	 */
+	public function test_find_post_by_bsky_uri_returns_false_when_no_supported_types() {
+		\update_option( 'atmosphere_support_post_types', array() );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$uri     = 'at://did:plc:test123/app.bsky.feed.post/notypes123';
+
+		\update_post_meta( $post_id, BskyPost::META_URI, $uri );
+
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'find_post_by_bsky_uri' );
+
+		$this->assertFalse( $method->invoke( null, $uri ) );
+	}
+
+	/**
 	 * Test that find_comment_by_source_id returns the correct comment.
 	 */
 	public function test_find_comment_by_source_id() {

--- a/tests/phpunit/tests/class-test-reaction-sync.php
+++ b/tests/phpunit/tests/class-test-reaction-sync.php
@@ -19,6 +19,19 @@ use Atmosphere\Transformer\Post as BskyPost;
 class Test_Reaction_Sync extends WP_UnitTestCase {
 
 	/**
+	 * Reset post-type support state leaked by the resolver tests.
+	 */
+	public function tear_down(): void {
+		\delete_option( 'atmosphere_support_post_types' );
+
+		if ( \post_type_exists( 'atmos_hidden_cpt' ) ) {
+			\unregister_post_type( 'atmos_hidden_cpt' );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
 	 * Test that find_post_by_bsky_uri returns the correct post.
 	 */
 	public function test_find_post_by_bsky_uri() {
@@ -73,6 +86,67 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 		$method = new \ReflectionMethod( Reaction_Sync::class, 'find_post_by_bsky_uri' );
 
 		$this->assertFalse( $method->invoke( null, 'at://did:plc:unknown/app.bsky.feed.post/xyz' ) );
+	}
+
+	/**
+	 * A reaction targeting a supported non-`post` post type must resolve.
+	 *
+	 * Regression: `find_post_by_bsky_uri()` called `get_posts()` without a
+	 * `post_type`, so WordPress defaulted the query to `post_type => 'post'`.
+	 * Every like/repost/reply on a supported page or custom post type then
+	 * resolved to nothing and was dropped silently — no comment row, no
+	 * error, no log. Fails before the resolver is scoped to the federated
+	 * post types.
+	 */
+	public function test_find_post_by_bsky_uri_resolves_supported_non_default_post_type() {
+		\update_option( 'atmosphere_support_post_types', array( 'post', 'page' ) );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			)
+		);
+		$uri     = 'at://did:plc:test123/app.bsky.feed.post/page123';
+
+		\update_post_meta( $post_id, BskyPost::META_URI, $uri );
+
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'find_post_by_bsky_uri' );
+
+		$this->assertSame( $post_id, $method->invoke( null, $uri ) );
+	}
+
+	/**
+	 * A supported CPT registered with `exclude_from_search` must resolve too.
+	 *
+	 * This is why the resolver scopes to `get_supported_post_types()` rather
+	 * than the `post_type => 'any'` shortcut: `'any'` omits post types flagged
+	 * `exclude_from_search`, so a naive `'any'` fix would still drop reactions
+	 * on such a type. Fails both before the fix and under an `'any'`-based fix.
+	 */
+	public function test_find_post_by_bsky_uri_resolves_supported_exclude_from_search_cpt() {
+		\register_post_type(
+			'atmos_hidden_cpt',
+			array(
+				'public'              => true,
+				'exclude_from_search' => true,
+			)
+		);
+		\update_option( 'atmosphere_support_post_types', array( 'post', 'atmos_hidden_cpt' ) );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'atmos_hidden_cpt',
+				'post_status' => 'publish',
+			)
+		);
+		$uri     = 'at://did:plc:test123/app.bsky.feed.post/hidden123';
+
+		\update_post_meta( $post_id, BskyPost::META_URI, $uri );
+
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'find_post_by_bsky_uri' );
+
+		$this->assertSame( $post_id, $method->invoke( null, $uri ) );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

`Reaction_Sync::find_post_by_bsky_uri()` queried `get_posts()` without a `post_type`, so WordPress defaulted the lookup to `post_type => 'post'`. Bluesky likes, reposts, and replies targeting any *other* federated post type — a page, or a custom post type such as a note type — resolved to nothing and were dropped silently: no comment row, no error, no log. Only reactions on the default `post` type ever synced back.

This scopes both the single-URI and thread-index lookups to `get_supported_post_types()`, so the resolver covers exactly the post types the Publisher federates. Passing the types explicitly (rather than the `'any'` shortcut) also picks up supported CPTs registered with `exclude_from_search`, which `'any'` would omit.

Found on a live site publishing a `jetpack-social-note` CPT to Bluesky: every reaction on those notes vanished while reactions on regular posts synced fine. Applying this fix restored them (1 → 45 reactions on the affected site after a re-walk).

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Two regression tests, both of which fail before this change:
- a supported non-`post` type (`page`)
- a supported `exclude_from_search` CPT (guards against a naive `post_type => 'any'` fix)

## Testing instructions:

* Enable a non-`post` type for publishing (add `page` to `atmosphere_support_post_types`, or a CPT).
* Publish a post of that type to Bluesky so it gets `_atmosphere_bsky_uri` meta.
* From another Bluesky account, like or reply to it.
* Run `wp cron event run atmosphere_sync_reactions`.
* Before this patch no comment/reaction row appears on the post; after, the like/reply syncs in as a comment.
* Automated: `vendor/bin/phpunit --filter find_post_by_bsky_uri`.

### Changelog entry

A changelog entry is already committed in this branch (`.github/changelog/fix-reaction-sync-cpt-resolution`, Patch / Fixed), so the automatic-entry box is intentionally left unchecked.