### PR TITLE
Process reactions oldest-first so nested replies thread in one run

### DIFF
--- a/.github/changelog/fix-reaction-sync-oldest-first
+++ b/.github/changelog/fix-reaction-sync-oldest-first
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Reliably import nested Bluesky replies. Reactions are now processed oldest-first within each sync, so a reply threads under its parent comment in the same run instead of being dropped when a whole thread arrives between syncs.

--- a/includes/class-reaction-sync.php
+++ b/includes/class-reaction-sync.php
@@ -349,6 +349,7 @@ class Reaction_Sync {
 		$cursor    = null;
 		$pages     = 0;
 		$rewalk    = null;
+		$collected = array();
 
 		while ( $pages < self::MAX_PAGES ) {
 			$response = $fetch( $cursor );
@@ -385,7 +386,7 @@ class Reaction_Sync {
 
 				if ( null === $rewalk && $last_seen && $uri === $last_seen ) {
 					/*
-					 * +1 because the watermark item itself is processed
+					 * +1 because the watermark item itself is collected
 					 * (and dedup-skipped) before this counter decrements;
 					 * initialising to GRACE + 1 means we re-walk exactly
 					 * GRACE items strictly past the watermark.
@@ -397,7 +398,7 @@ class Reaction_Sync {
 					break 2;
 				}
 
-				$process( $item );
+				$collected[] = $item;
 
 				if ( null !== $rewalk ) {
 					--$rewalk;
@@ -410,6 +411,23 @@ class Reaction_Sync {
 			if ( ! $cursor ) {
 				break;
 			}
+		}
+
+		/*
+		 * Process oldest-first. Bluesky streams newest-first, but a reply's
+		 * parent (a post record or an earlier reply) is always older than the
+		 * reply itself. Processing in stream order therefore reaches a child
+		 * reply before its parent exists as a local comment, and
+		 * process_reply() drops any reply whose parent it can't resolve. By
+		 * reversing to oldest-first, a parent is synced before any reply that
+		 * targets it, so an entire thread that arrives within one run resolves
+		 * in that run — instead of relying on the next run's WATERMARK_GRACE
+		 * re-walk, which only reaches GRACE items and loses deeper or bursty
+		 * threads. Dedup via source_id keeps the reprocessing idempotent, and
+		 * the watermark below is still the newest URI regardless of order.
+		 */
+		foreach ( \array_reverse( $collected ) as $item ) {
+			$process( $item );
 		}
 
 		if ( $newest ) {

--- a/tests/phpunit/tests/class-test-reaction-sync.php
+++ b/tests/phpunit/tests/class-test-reaction-sync.php
@@ -1466,7 +1466,9 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 
 		$this->invoke_paginate( $fetch, 'items', $option_key, $process );
 
-		$this->assertSame( array( 'at://a/1', 'at://a/2', 'at://a/3' ), $seen );
+		// Bluesky streams newest-first; paginate processes oldest-first so a
+		// reply's parent is synced before the reply that targets it.
+		$this->assertSame( array( 'at://a/3', 'at://a/2', 'at://a/1' ), $seen );
 		$this->assertSame( 'at://a/1', \get_option( $option_key ) );
 	}
 
@@ -1510,7 +1512,9 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 			'at://a/13',
 			'at://a/14',
 		);
-		$this->assertSame( $expected, $seen );
+		// $expected lists the collected set in stream order; paginate
+		// processes it oldest-first, so assert against the reverse.
+		$this->assertSame( \array_reverse( $expected ), $seen );
 		$this->assertSame( 'at://a/1', \get_option( $option_key ) );
 	}
 
@@ -1575,7 +1579,9 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 			'at://a/13',
 			'at://a/14',
 		);
-		$this->assertSame( $expected, $seen );
+		// $expected lists the collected set in stream order; paginate
+		// processes it oldest-first, so assert against the reverse.
+		$this->assertSame( \array_reverse( $expected ), $seen );
 		$this->assertSame( 'at://a/1', \get_option( $option_key ) );
 	}
 
@@ -1603,8 +1609,100 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 
 		$this->invoke_paginate( $fetch, 'items', $option_key, $process );
 
-		$this->assertSame( array( 'at://a/1', 'at://a/2', 'at://a/3', 'at://a/4' ), $seen );
+		// Processed oldest-first (reverse of the newest-first stream).
+		$this->assertSame( array( 'at://a/4', 'at://a/3', 'at://a/2', 'at://a/1' ), $seen );
 		$this->assertSame( 'at://a/1', \get_option( $option_key ) );
+	}
+
+	/**
+	 * A reply that arrives before the parent it targets — the normal case,
+	 * since Bluesky streams newest-first — must still thread correctly within
+	 * a single run.
+	 *
+	 * Before oldest-first processing, the child reply was reached first, its
+	 * parent comment did not yet exist, and process_reply() dropped it — left
+	 * to the next run's bounded WATERMARK_GRACE re-walk, which loses deeper or
+	 * bursty threads. Processing oldest-first syncs the parent reply first, so
+	 * the child resolves against it in the same run.
+	 */
+	public function test_nested_reply_arriving_before_parent_resolves_in_one_run() {
+		$post_id  = self::factory()->post->create();
+		$post_uri = 'at://did:plc:me/app.bsky.feed.post/rootpost';
+		\update_post_meta( $post_id, BskyPost::META_URI, $post_uri );
+
+		$parent_uri = 'at://did:plc:alice/app.bsky.feed.post/parentreply';
+		$child_uri  = 'at://did:plc:bob/app.bsky.feed.post/childreply';
+
+		// Keep resolve_author() off the network — cache both profiles.
+		\set_transient( 'atmosphere_profile_' . \md5( 'did:plc:alice' ), array( 'handle' => 'alice.bsky.social' ), \HOUR_IN_SECONDS );
+		\set_transient( 'atmosphere_profile_' . \md5( 'did:plc:bob' ), array( 'handle' => 'bob.bsky.social' ), \HOUR_IN_SECONDS );
+
+		// Stream order is newest-first: the child reply (later) comes before
+		// the parent reply (earlier) that it targets.
+		$notifications = array(
+			array(
+				'reason' => 'reply',
+				'uri'    => $child_uri,
+				'cid'    => 'cidchild',
+				'record' => array(
+					'text'      => 'Replying to Alice',
+					'createdAt' => '2026-03-21T12:05:00.000Z',
+					'reply'     => array(
+						'parent' => array( 'uri' => $parent_uri ),
+						'root'   => array( 'uri' => $post_uri ),
+					),
+				),
+				'author' => array(
+					'did'    => 'did:plc:bob',
+					'handle' => 'bob.bsky.social',
+				),
+			),
+			array(
+				'reason' => 'reply',
+				'uri'    => $parent_uri,
+				'cid'    => 'cidparent',
+				'record' => array(
+					'text'      => 'Replying to the post',
+					'createdAt' => '2026-03-21T12:00:00.000Z',
+					'reply'     => array(
+						'parent' => array( 'uri' => $post_uri ),
+						'root'   => array( 'uri' => $post_uri ),
+					),
+				),
+				'author' => array(
+					'did'    => 'did:plc:alice',
+					'handle' => 'alice.bsky.social',
+				),
+			),
+		);
+
+		$dispatch = new \ReflectionMethod( Reaction_Sync::class, 'process_notification' );
+		$process  = static function ( array $item ) use ( $dispatch ) {
+			$dispatch->invoke( null, $item );
+		};
+
+		$option_key = 'atmosphere_test_nested_reply';
+		\delete_option( $option_key );
+
+		$this->invoke_paginate(
+			static fn() => array( 'notifications' => $notifications ),
+			'notifications',
+			$option_key,
+			$process
+		);
+
+		$find      = new \ReflectionMethod( Reaction_Sync::class, 'find_comment_by_source_id' );
+		$parent_id = $find->invoke( null, $parent_uri );
+		$child_id  = $find->invoke( null, $child_uri );
+
+		$this->assertIsInt( $parent_id, 'parent reply synced' );
+		$this->assertIsInt( $child_id, 'child reply synced in the same run' );
+
+		$this->assertSame(
+			(string) $parent_id,
+			\get_comment( $child_id )->comment_parent,
+			'child reply threads under the parent reply, not the root post'
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

Bluesky's `listNotifications` streams **newest-first**, and `Reaction_Sync::paginate()` processed items in that order. But a reply's parent — a post record, or an earlier reply — is always *older* than the reply. So a nested reply was reached **before** its parent existed as a local comment, and `process_reply()` drops any reply whose parent it can't resolve (neither a local post nor an already-synced comment).

The only recovery was the next run's `WATERMARK_GRACE` re-walk (10 items). That loses deeper or bursty threads: a live-tweeted thread that lands entirely between two hourly syncs has its replies dropped, and the child several items back never re-enters the grace window.

This collects each stream and then processes it **oldest-first** (`array_reverse`), so a parent is synced before any reply that targets it — a whole thread arriving in one run now resolves in that run. Dedup via `source_id` keeps reprocessing idempotent, and the watermark is still the newest URI regardless of processing order.

Note: a child of a **spam/trash** parent still won't thread, since `find_comment_by_source_id()`'s `get_comments()` defaults to `status = 'all'` (approved + hold only). A **pending** (held) parent *does* resolve. That's intended — don't nest under spam.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

- Updated the four `paginate()` tests to expect oldest-first processing (the collected set and watermark are unchanged; only order flips).
- Added `test_nested_reply_arriving_before_parent_resolves_in_one_run`: a child reply ahead of its parent in the stream. It **fails before this change** (child dropped) and passes after (child threads under the parent in a single run).

## Testing instructions:

* From a Bluesky account, reply to one of your published posts, then reply again to your own first reply — so a two-level thread exists.
* Ensure both arrive between sync runs (delete `atmosphere_last_seen_notification` to force a fresh walk).
* Run `wp cron event run atmosphere_sync_reactions`.
* Before this patch, the nested reply is missing (only the first-level reply syncs); after, both sync and the nested one is threaded under its parent in the same run.
* Automated: `vendor/bin/phpunit --filter 'paginate|nested_reply'`.

### Changelog entry

A changelog entry is already committed in this branch (`.github/changelog/fix-reaction-sync-oldest-first`, Patch / Fixed), so the automatic-entry box is intentionally left unchecked.