### PR TITLE
Send no-cache headers on the record preview response

### DIFF
--- a/.github/changelog/fix-preview-cache-headers
+++ b/.github/changelog/fix-preview-cache-headers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Send private, no-cache headers on the record preview so a caching layer cannot store a logged-in preview and show it to other visitors.

--- a/includes/transformer/class-preview.php
+++ b/includes/transformer/class-preview.php
@@ -77,6 +77,9 @@ class Preview {
 		}
 
 		if ( ! is_supported_post_type( $post->post_type ) ) {
+			// No-cache this exit too, so a fronting cache can't pin the 404
+			// for a post type later added to the syncable allowlist.
+			\nocache_headers();
 			\status_header( 404 );
 			exit;
 		}
@@ -273,6 +276,16 @@ class Preview {
 	 * @param array|\WP_Error $payload Preview payload or error.
 	 */
 	private static function send( array|\WP_Error $payload ): void {
+		/*
+		 * The preview is served on a public front-end URL but carries
+		 * per-object, `edit_post`-gated data (the post's custom Bluesky
+		 * text, third-party preview-transformer output). Send no-cache
+		 * headers on every branch so a URL-keyed edge/page cache cannot
+		 * retain an authorized projection and replay it to a later
+		 * unauthorized visitor — mirroring the well-known handlers.
+		 */
+		\nocache_headers();
+
 		if ( \is_wp_error( $payload ) ) {
 			\status_header( 400 );
 			$payload = array(


### PR DESCRIPTION
## Proposed changes:

The `?atproto` record preview is served on a public front-end URL but carries per-object, `edit_post`-gated data — a post's saved custom Bluesky text and any third-party preview-transformer output. `Preview::send()` sent no cache-control headers, so a URL-keyed edge/page cache that stores a logged-in response could replay an authorized projection to a later unauthorized visitor.

This calls `\nocache_headers()` on every branch that emits a preview response — the 200 record payload, the 400 error, and the unsupported-post-type 404 — mirroring the well-known handlers (`serve_wellknown_atproto_did` / `serve_wellknown_publication`), which already no-cache every branch. It does not hoist the call to the top of `render()`, because `render()`'s many fall-through `return` branches must leave the normal (cacheable) page render untouched.

Context: surfaced by a full-codebase security audit as the one open item; classified as **defense-in-depth hardening** (not an exploitable vulnerability) — the leak only bites under a misconfigured cache that stores logged-in responses and keys purely on URL, a config under which far more sensitive authenticated content would already leak site-wide. Fixing it brings the preview in line with the plugin's two other public GET surfaces.

### Other information:

- [ ] Have you written new tests for your changes, if applicable? — No: header emission on this `exit`-ing path can't be exercised under PHPUnit (the CLI harness has already sent headers), the same reason the sibling well-known handlers carry no header assertions. Verified instead against a live wp-env response (see below).

## Testing instructions:

* `composer lint` and `npm run env-test` pass (854 tests).
* Connect a test account (or set `atmosphere_identity`), then as a logged-in editor request a post preview and inspect headers:
  ```
  curl -sI -b <editor-cookie-jar> 'http://localhost:8884/<post>/?atproto=app.bsky.feed.post' | grep -i cache-control
  # -> Cache-Control: no-cache, must-revalidate, max-age=0, no-store, private
  ```
* Confirm a logged-out request to the same URL still falls through to the normal HTML page (no JSON, no plugin cache header).
* Confirm an unsupported post type (e.g. a `page`) returns `404` with the same `Cache-Control` header.

### Changelog entry

A patch/fixed entry is included at `.github/changelog/fix-preview-cache-headers`.