### PR TITLE
Docs: document the programmatic publishing surface for integrating plugins

### DIFF
--- a/.github/changelog/add-programmatic-publishing-docs
+++ b/.github/changelog/add-programmatic-publishing-docs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Developer docs: document the programmatic publishing surface (per-post metas, Publisher::publish_post(), record read-back) for integrating plugins.

--- a/.github/changelog/add-programmatic-publishing-docs
+++ b/.github/changelog/add-programmatic-publishing-docs
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Developer docs: document the programmatic publishing surface (per-post metas, Publisher::publish_post(), record read-back) for integrating plugins.

--- a/docs/developer-docs.md
+++ b/docs/developer-docs.md
@@ -7,6 +7,7 @@
 - [Previewing AT Protocol Records](#previewing-at-protocol-records)
 - [Extending Content Formats](#extending-content-formats)
 - [Custom Post Type Support](#custom-post-type-support)
+- [Publishing Programmatically](#publishing-programmatically)
 - [Templates and Admin UI](#templates-and-admin-ui)
 
 ## Introduction
@@ -276,6 +277,65 @@ ATmosphere only cross-posts post types that opt in. Two ways to add one:
 ```
 
 The plugin merges all three sources, dedupes, and sanitises.
+
+## Publishing Programmatically
+
+Publishing UIs, syndication managers, and other companion plugins can drive
+cross-posting per post instead of relying on the automatic save-flow.
+
+### Per-post controls
+
+Two registered post metas (both `show_in_rest`, writable with `edit_post`)
+control what a cross-post looks like before it happens:
+
+| Meta key | Constant | Effect |
+|----------|----------|--------|
+| `atmosphere_disabled` | `ATMOSPHERE_META_DISABLED` | Sharing is opt-out: `'1'` excludes the post from cross-posting (and removes already-published remote records). |
+| `atmosphere_custom_text` | `ATMOSPHERE_META_CUSTOM_TEXT` | Replaces the derived Bluesky post text for this post. |
+
+### Taking over the publish flow
+
+The automatic save-flow is gated by the `atmosphere_auto_publish` option
+(`'1'` by default). An integration that wants to decide *when* a post is
+cross-posted can disable it and call the publisher directly:
+
+```php
+\update_option( 'atmosphere_auto_publish', '0' );
+
+$result = \Atmosphere\Publisher::publish_post( $post );
+
+if ( \is_wp_error( $result ) ) {
+    // Post was ineligible or the write failed.
+}
+```
+
+`publish_post()` enforces `\Atmosphere\is_post_publishable()` — the post
+must be published, not password-protected, of a [supported post
+type](#custom-post-type-support), and not opted out via
+`atmosphere_disabled`. It fires
+[`atmosphere_publish_post_result`](#public-hooks) once with the final
+outcome, and returns the `applyWrites` response(s) or a `WP_Error`.
+`Publisher::update_post()` and `Publisher::delete_post()` complete the
+lifecycle.
+
+### Reading back the published record
+
+After a successful publish the post carries the created record's
+references:
+
+| Meta key | Constant | Value |
+|----------|----------|-------|
+| `_atmosphere_bsky_uri` | `\Atmosphere\Transformer\Post::META_URI` | The `at://` URI of the Bluesky post. |
+| `_atmosphere_bsky_tid` | `\Atmosphere\Transformer\Post::META_TID` | The record key (TID). |
+
+```php
+$at_uri = \get_post_meta( $post_id, \Atmosphere\Transformer\Post::META_URI, true );
+```
+
+Replies and reposts synced back from Bluesky arrive as native WordPress
+comments (`protocol` comment meta `atproto`, source link in `source_url`);
+integrations can react to each via
+[`atmosphere_reaction_synced`](#public-hooks).
 
 ## Templates and Admin UI
 

--- a/docs/developer-docs.md
+++ b/docs/developer-docs.md
@@ -290,8 +290,15 @@ control what a cross-post looks like before it happens:
 
 | Meta key | Constant | Effect |
 |----------|----------|--------|
-| `atmosphere_disabled` | `ATMOSPHERE_META_DISABLED` | Sharing is opt-out: `'1'` excludes the post from cross-posting (and removes already-published remote records). |
+| `atmosphere_disabled` | `ATMOSPHERE_META_DISABLED` | Sharing is opt-out: `'1'` excludes the post from cross-posting. |
 | `atmosphere_custom_text` | `ATMOSPHERE_META_CUSTOM_TEXT` | Replaces the derived Bluesky post text for this post. |
+
+While the automatic save-flow is active, changing either meta schedules a
+reconcile that publishes, updates, or removes the remote records to match.
+Integrations that disable `atmosphere_auto_publish` (below) must run that
+reconcile themselves by calling `\Atmosphere\Publisher::update_post()`
+after changing the metas — setting `atmosphere_disabled` alone does not
+remove already-published records.
 
 ### Taking over the publish flow
 
@@ -315,8 +322,11 @@ type](#custom-post-type-support), and not opted out via
 `atmosphere_disabled`. It fires
 [`atmosphere_publish_post_result`](#public-hooks) once with the final
 outcome, and returns the `applyWrites` response(s) or a `WP_Error`.
-`Publisher::update_post()` and `Publisher::delete_post()` complete the
-lifecycle.
+`\Atmosphere\Publisher::update_post()` and
+`\Atmosphere\Publisher::delete_post()` complete the lifecycle;
+`update_post()` doubles as the reconcile — when the post is no longer
+publishable (trashed, unpublished, or opted out via `atmosphere_disabled`)
+it removes the remote records.
 
 ### Reading back the published record
 
@@ -332,9 +342,13 @@ references:
 $at_uri = \get_post_meta( $post_id, \Atmosphere\Transformer\Post::META_URI, true );
 ```
 
-Replies and reposts synced back from Bluesky arrive as native WordPress
-comments (`protocol` comment meta `atproto`, source link in `source_url`);
-integrations can react to each via
+Replies, likes, and reposts synced back from Bluesky arrive as native
+WordPress comments (comment types `comment`, `like`, and `repost`, all
+with `protocol` comment meta `atproto`). Replies carry a link to the
+reply's Bluesky page in `source_url`; likes and reposts have no Bluesky
+landing page, so their `source_url` is intentionally empty and
+`comment_author_url` (the author's profile) is the outbound link.
+Integrations can react to each via
 [`atmosphere_reaction_synced`](#public-hooks).
 
 ## Templates and Admin UI


### PR DESCRIPTION
## What

Adds a **Publishing Programmatically** section to `docs/developer-docs.md` (plus ToC entry and a changelog file), documenting the integration surface a companion plugin needs to drive cross-posting per post:

- The registered per-post metas — `atmosphere_disabled` (opt-out) and `atmosphere_custom_text` (per-post Bluesky text)
- Taking over the save-flow: `atmosphere_auto_publish` option + `\Atmosphere\Publisher::publish_post()` (with its `is_post_publishable()` gate and `update_post()`/`delete_post()` lifecycle)
- Reading back the created record via `_atmosphere_bsky_uri` / `_atmosphere_bsky_tid`
- Pointers to the existing `atmosphere_publish_post_result` / `atmosphere_reaction_synced` hooks and the comment `protocol`/`source_url` markers for synced replies

## Why

I'm building a WordPress publishing plugin ([Moment](https://github.com/jeffpaul/moment) — a phone-first publishing prototype) that wants to delegate its Bluesky syndication to ATmosphere rather than maintain its own AT Protocol client. Everything needed for that already exists in ATmosphere — this PR just documents it as the supported integration surface, so integrators can rely on it (and so gaps get spotted if any of it isn't meant to be public API).

## Testing

Docs + changelog only, no code changes. `composer lint` passes; `npm run env-test` not run since no PHP changed.

🤖 Drafted with [Claude Code](https://claude.com/claude-code), human-reviewed.