### PR TITLE
Fix: Require publishing capability for Bluesky comment replies

### DIFF
--- a/.github/changelog/fix-comment-publishing-capability
+++ b/.github/changelog/fix-comment-publishing-capability
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Comments from Subscribers and other comment-only accounts now stay on WordPress instead of being published through the site's Bluesky account.

--- a/docs/developer-docs.md
+++ b/docs/developer-docs.md
@@ -44,7 +44,7 @@ ATmosphere exposes a small set of filters and actions for plugins to extend beha
 | `atmosphere_publication_labels` | filter | Add standard self-labels to `site.standard.publication` records. |
 | `atmosphere_publication_show_in_discover` | filter | Override `preferences.showInDiscover` (defaults to the site's `blog_public` option) for `site.standard.publication` records. |
 | `atmosphere_syncable_post_types` | filter | Add or remove post types eligible for cross-posting. |
-| `atmosphere_should_publish_comment` | filter | Customise which approved comments are mirrored as Bluesky replies. |
+| `atmosphere_should_publish_comment` | filter | Customise which approved comments from users allowed to publish posts are mirrored as Bluesky replies. |
 | `atmosphere_should_sync_reply` | filter | Customise which inbound Bluesky replies become WordPress comments. |
 | `atmosphere_transform_bsky_post` | filter | Mutate the Bluesky post record before write. |
 | `atmosphere_transform_document` | filter | Mutate the document record before write. |

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -1194,7 +1194,16 @@ class Atmosphere {
 			return false;
 		}
 
-		if ( (int) $comment->user_id <= 0 ) {
+		$user_id = (int) $comment->user_id;
+
+		/*
+		 * Registered users may be Subscribers who can comment but are not
+		 * trusted to publish site content. Outbound replies are written by
+		 * the site's connected Bluesky account, so use the comment author's
+		 * stored capabilities rather than the current user: this gate also
+		 * runs asynchronously in WP-Cron, where nobody is logged in.
+		 */
+		if ( $user_id <= 0 || ! \user_can( $user_id, 'publish_posts' ) ) {
 			return false;
 		}
 

--- a/includes/transformer/class-comment.php
+++ b/includes/transformer/class-comment.php
@@ -3,12 +3,12 @@
  * Transforms an approved WordPress comment into an app.bsky.feed.post
  * reply record.
  *
- * Only comments authored by a registered WordPress user are published;
- * Atmosphere::should_publish_comment() and the comment lifecycle
- * hooks enforce that gate before this transformer runs. Root is
- * always the parent post's bsky record; parent resolves to a
- * previously-published sibling comment, a federated reply ingested
- * via Reaction_Sync, or falls through to the root.
+ * Only comments authored by a WordPress user with the publish_posts
+ * capability are published; Atmosphere::should_publish_comment() and
+ * the comment lifecycle hooks enforce that gate before this transformer
+ * runs. Root is always the parent post's bsky record; parent resolves to
+ * a previously-published sibling comment, a federated reply ingested via
+ * Reaction_Sync, or falls through to the root.
  *
  * @package Atmosphere
  */

--- a/readme.txt
+++ b/readme.txt
@@ -14,7 +14,7 @@ Share your WordPress posts on Bluesky and the wider AT Protocol network — and 
 
 **ATmosphere** turns your WordPress site into a first-class citizen of the AT Protocol — the open network behind [Bluesky](https://bsky.social/).
 
-When you publish a post, ATmosphere automatically shares it on Bluesky and stores the full article on your AT Protocol account so any compatible app can read it. When people on Bluesky reply, like, or repost what you shared, those reactions show up as comments on your post. And approved comments your readers leave on WordPress are sent right back to Bluesky as replies under your original post — so the same conversation happens in both places without you having to copy anything by hand.
+When you publish a post, ATmosphere automatically shares it on Bluesky and stores the full article on your AT Protocol account so any compatible app can read it. When people on Bluesky reply, like, or repost what you shared, those reactions show up as comments on your post. And approved comments left by WordPress users who are allowed to publish posts are sent right back to Bluesky as replies under your original post — so the same conversation happens in both places without you having to copy anything by hand.
 
 = What you get =
 
@@ -22,7 +22,7 @@ When you publish a post, ATmosphere automatically shares it on Bluesky and store
 * **Long posts done right.** A long article becomes a short, readable Bluesky thread that links back to the full piece on your site. Edits are kept tidy so existing replies and reposts on Bluesky don't get orphaned.
 * **Use your own domain as your Bluesky handle.** With one click, your handle becomes something like `@yourblog.com` instead of `@you.bsky.social`. ATmosphere does the technical bit; Bluesky verifies it.
 * **Bluesky reactions become WordPress comments.** Replies appear in your comments. Likes and reposts show up alongside them with their own counts so the engagement is visible to your readers.
-* **WordPress comments become Bluesky replies.** When a logged-in reader leaves an approved comment on a cross-posted article, it's sent to Bluesky as a reply under the original post.
+* **Publishing-team comments become Bluesky replies.** When an Author, Editor, Administrator, or custom role allowed to publish posts leaves an approved comment on a cross-posted article, it's sent to Bluesky as a reply under the original post. Subscriber and other comment-only accounts stay local.
 * **Catch up on older posts.** A `wp atmosphere backfill` command can publish posts you wrote before installing the plugin.
 * **Per-post control.** You can opt individual posts out of cross-posting straight from the editor sidebar.
 * **No middleman.** ATmosphere talks directly to your Bluesky account using modern, secure sign-in. Nothing is routed through a third-party service, and your tokens never leave your WordPress site.
@@ -35,7 +35,7 @@ When you publish a post, ATmosphere automatically shares it on Bluesky and store
 3. Fill in a name, description, and icon for your "publication" — this is how your site is represented on the AT Protocol.
 4. Publish a post.
 5. Open Bluesky — your post is there. People can reply, like, repost, and follow as they normally would.
-6. Replies, likes, and reposts will start appearing as comments on your WordPress post. Comments you approve on WordPress will appear as replies on Bluesky.
+6. Replies, likes, and reposts will start appearing as comments on your WordPress post. Approved comments from users who can publish WordPress posts will appear as replies on Bluesky.
 
 **Note:** Cross-posting only kicks in for posts you publish *after* connecting. To bring older posts across, run `wp atmosphere backfill` from WP-CLI.
 
@@ -75,7 +75,7 @@ Long posts are turned into a short Bluesky thread of a few connected posts, with
 
 = Are my WordPress comments published to Bluesky? =
 
-Yes — approved comments left by logged-in readers on cross-posted articles are sent to Bluesky as replies under your original post. Anonymous comments, trackbacks, and pingbacks are skipped.
+Yes — approved comments left by WordPress users who are allowed to publish posts are sent to Bluesky as replies under your original post. Comments from Subscribers and other comment-only accounts stay local, as do anonymous comments, trackbacks, and pingbacks.
 
 = Are Bluesky replies and reposts pulled back into WordPress? =
 

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -824,7 +824,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 
 	/**
 	 * Third parties can force-allow publication via filter (e.g.
-	 * overriding the author-capability guard for a specific integration).
+	 * overriding the core eligibility gates for a specific integration).
 	 */
 	public function test_comment_filter_can_force_publish() {
 		$comment = $this->make_eligible_comment( array( 'user_id' => 0 ) );

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -85,6 +85,15 @@ class Test_Atmosphere extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Create a user authorized to publish outbound comments.
+	 *
+	 * @return int User ID.
+	 */
+	private function make_publishing_user(): int {
+		return self::factory()->user->create( array( 'role' => 'author' ) );
+	}
+
+	/**
 	 * Build a WP_Comment on a published post for comment eligibility tests.
 	 *
 	 * A fresh post is created each call: WP_UnitTestCase rolls back
@@ -104,7 +113,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 			'comment_post_ID'  => $post_id,
 			'comment_approved' => '1',
 			'comment_type'     => 'comment',
-			'user_id'          => self::factory()->user->create(),
+			'user_id'          => $this->make_publishing_user(),
 			'comment_content'  => 'Hello.',
 		);
 
@@ -693,13 +702,28 @@ class Test_Atmosphere extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Baseline: approved comment from a registered user on a published
-	 * post is publishable.
+	 * Baseline: an approved comment from an author on a published post
+	 * is publishable.
 	 */
-	public function test_eligible_registered_user_approved_comment_publishes() {
+	public function test_eligible_author_approved_comment_publishes() {
 		$comment = $this->make_eligible_comment();
 
 		$this->assertTrue( Atmosphere::should_publish_comment( $comment ) );
+	}
+
+	/**
+	 * A registered Subscriber can comment but cannot publish site content.
+	 */
+	public function test_subscriber_comment_is_skipped() {
+		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$comment       = $this->make_eligible_comment( array( 'user_id' => $subscriber_id ) );
+
+		$this->assertFalse( Atmosphere::should_publish_comment( $comment ) );
+		$this->atmosphere->on_comment_insert( (int) $comment->comment_ID, 1 );
+		$this->assertFalse(
+			\wp_next_scheduled( 'atmosphere_publish_comment', array( (int) $comment->comment_ID ) ),
+			'Subscriber comments must not schedule an outbound publish.'
+		);
 	}
 
 	/**
@@ -800,7 +824,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 
 	/**
 	 * Third parties can force-allow publication via filter (e.g.
-	 * overriding the anonymous-only guard for a specific integration).
+	 * overriding the author-capability guard for a specific integration).
 	 */
 	public function test_comment_filter_can_force_publish() {
 		$comment = $this->make_eligible_comment( array( 'user_id' => 0 ) );
@@ -837,7 +861,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 			array(
 				'comment_post_ID'  => $post_id,
 				'comment_approved' => '1',
-				'user_id'          => self::factory()->user->create(),
+				'user_id'          => $this->make_publishing_user(),
 			)
 		);
 
@@ -859,7 +883,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 			array(
 				'comment_post_ID'  => $post_id,
 				'comment_approved' => '1',
-				'user_id'          => self::factory()->user->create(),
+				'user_id'          => $this->make_publishing_user(),
 			)
 		);
 		\update_comment_meta( $comment_id, Comment::META_URI, 'at://did:plc:test123/app.bsky.feed.post/reply' );
@@ -885,7 +909,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 		$comment_id = self::factory()->comment->create(
 			array(
 				'comment_post_ID' => $post_id,
-				'user_id'         => self::factory()->user->create(),
+				'user_id'         => $this->make_publishing_user(),
 			)
 		);
 		\update_comment_meta( $comment_id, Comment::META_TID, 'deadbeef' );
@@ -940,6 +964,39 @@ class Test_Atmosphere extends WP_UnitTestCase {
 		\remove_all_filters( 'pre_http_request' );
 
 		$this->assertFalse( $captured, 'applyWrites must not be called for a no-longer-eligible comment.' );
+	}
+
+	/**
+	 * The publish cron handler must use the comment author's current
+	 * capabilities, not the user who happens to run WP-Cron.
+	 */
+	public function test_publish_comment_cron_rechecks_author_capability() {
+		$comment    = $this->make_eligible_comment();
+		$comment_id = (int) $comment->comment_ID;
+		$author     = \get_user_by( 'id', (int) $comment->user_id );
+
+		$this->assertInstanceOf( \WP_User::class, $author );
+		$this->atmosphere->on_comment_insert( $comment_id, 1 );
+		$this->assertNotFalse(
+			\wp_next_scheduled( 'atmosphere_publish_comment', array( $comment_id ) ),
+			'Author comment should be queued before the role downgrade.'
+		);
+		$author->set_role( 'subscriber' );
+
+		$captured = false;
+		\add_filter(
+			'atmosphere_pre_apply_writes',
+			static function () use ( &$captured ) {
+				$captured = true;
+				return new \WP_Error( 'unexpected_write', 'Subscriber comment reached the PDS write path.' );
+			}
+		);
+
+		\do_action( 'atmosphere_publish_comment', $comment_id );
+		\remove_all_filters( 'atmosphere_pre_apply_writes' );
+		\wp_clear_scheduled_hook( 'atmosphere_publish_comment', array( $comment_id ) );
+
+		$this->assertFalse( $captured, 'A role downgrade before cron execution must prevent publication.' );
 	}
 
 	/**
@@ -1141,7 +1198,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 		\update_post_meta( $post_id, Post::META_URI, 'at://did:plc:test123/app.bsky.feed.post/root' );
 		\update_post_meta( $post_id, Post::META_CID, 'bafyroot' );
 
-		$user_id = self::factory()->user->create();
+		$user_id = $this->make_publishing_user();
 
 		$parent_id = self::factory()->comment->create(
 			array(
@@ -1354,7 +1411,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 		\update_post_meta( $post_id, Post::META_URI, 'at://did:plc:test123/app.bsky.feed.post/root' );
 		\update_post_meta( $post_id, Post::META_CID, 'bafyroot' );
 
-		$user_id = self::factory()->user->create();
+		$user_id = $this->make_publishing_user();
 
 		$parent_id = self::factory()->comment->create(
 			array(
@@ -2150,7 +2207,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 				'comment_post_ID'  => $post_id,
 				'comment_approved' => '1',
 				'comment_type'     => 'comment',
-				'user_id'          => self::factory()->user->create(),
+				'user_id'          => $this->make_publishing_user(),
 				'comment_content'  => 'Reply to anon.',
 				'comment_parent'   => $parent_id,
 			)
@@ -2201,7 +2258,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 				'comment_post_ID'  => $post_id,
 				'comment_approved' => '1',
 				'comment_type'     => 'comment',
-				'user_id'          => self::factory()->user->create(),
+				'user_id'          => $this->make_publishing_user(),
 				'comment_content'  => 'Already-published parent.',
 			)
 		);
@@ -2213,7 +2270,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 				'comment_post_ID'  => $post_id,
 				'comment_approved' => '1',
 				'comment_type'     => 'comment',
-				'user_id'          => self::factory()->user->create(),
+				'user_id'          => $this->make_publishing_user(),
 				'comment_content'  => 'Reply.',
 				'comment_parent'   => $parent_id,
 			)
@@ -2276,7 +2333,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 				'comment_post_ID'  => $post_id,
 				'comment_approved' => '1',
 				'comment_type'     => 'comment',
-				'user_id'          => self::factory()->user->create(),
+				'user_id'          => $this->make_publishing_user(),
 				'comment_content'  => 'Reply to federated.',
 				'comment_parent'   => $parent_id,
 			)
@@ -2320,7 +2377,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 				'comment_post_ID'  => $post_id,
 				'comment_approved' => '1',
 				'comment_type'     => 'comment',
-				'user_id'          => self::factory()->user->create(),
+				'user_id'          => $this->make_publishing_user(),
 				'comment_content'  => 'Top-level comment.',
 			)
 		);
@@ -2368,7 +2425,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 				'comment_post_ID'  => $post_id,
 				'comment_approved' => '1',
 				'comment_type'     => 'comment',
-				'user_id'          => self::factory()->user->create(),
+				'user_id'          => $this->make_publishing_user(),
 				'comment_content'  => 'Half-published parent.',
 			)
 		);
@@ -2382,7 +2439,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 				'comment_post_ID'  => $post_id,
 				'comment_approved' => '1',
 				'comment_type'     => 'comment',
-				'user_id'          => self::factory()->user->create(),
+				'user_id'          => $this->make_publishing_user(),
 				'comment_content'  => 'Reply to half-state.',
 				'comment_parent'   => $parent_id,
 			)


### PR DESCRIPTION
Fixes #196

## Proposed changes:
* WordPress account registration currently lets Subscriber comments be republished through the site-connected Bluesky account, even though Subscribers cannot publish site content.
* Require the comment author to have the current `publish_posts` capability before scheduling or executing an outbound reply. This uses the stored author ID so the check remains valid in WP-Cron.
* Preserve the existing filter override and all other comment eligibility checks.
* Update public and developer documentation so it no longer says every logged-in reader comment is cross-posted.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- No visual changes; screenshots are not applicable.

## Testing instructions:

* Run `composer lint`.
* Run `npm run env-test`.
* For the focused regression coverage, run `npm run env-test -- --filter="test_(eligible_author|subscriber_comment|publish_comment_cron_rechecks_author_capability)"`.
* Confirm the focused tests show that Author comments remain eligible, Subscriber comments do not schedule an outbound publish, and a queued comment is not written after its author is downgraded to Subscriber.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

A manual changelog entry is included in `.github/changelog/fix-comment-publishing-capability`.

</details>