### PR TITLE
Add custom publication theme color settings and filter

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -10,3 +10,11 @@
 	display: inline-block;
 	margin-top: 2px;
 }
+
+.atmosphere-color-input {
+	width: 8rem;
+}
+
+.wp-picker-container {
+	vertical-align: middle;
+}

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -282,6 +282,9 @@ class Atmosphere {
 		\add_action( 'update_option_site_icon', array( $this, 'schedule_publication_sync' ) );
 		\add_action( 'update_option_home', array( $this, 'schedule_publication_sync' ) );
 		\add_action( 'update_option_siteurl', array( $this, 'schedule_publication_sync' ) );
+		\add_action( 'update_option_atmosphere_publication_theme_background', array( $this, 'schedule_publication_sync' ) );
+		\add_action( 'update_option_atmosphere_publication_theme_foreground', array( $this, 'schedule_publication_sync' ) );
+		\add_action( 'update_option_atmosphere_publication_theme_accent', array( $this, 'schedule_publication_sync' ) );
 		\add_action( 'switch_theme', array( $this, 'schedule_publication_sync' ) );
 		\add_action( 'save_post_wp_global_styles', array( $this, 'schedule_publication_sync' ) );
 		\add_action( 'customize_save_after', array( $this, 'schedule_publication_sync' ) );

--- a/includes/class-options.php
+++ b/includes/class-options.php
@@ -10,6 +10,7 @@ namespace Atmosphere;
 \defined( 'ABSPATH' ) || exit;
 
 use Atmosphere\Content_Parser\Registry;
+use Atmosphere\Transformer\Publication;
 
 /**
  * Registers every stored plugin option with the Settings API.
@@ -124,6 +125,42 @@ class Options {
 						'items' => array( 'type' => 'string' ),
 					),
 				),
+			)
+		);
+
+		\register_setting(
+			'atmosphere',
+			Publication::OPTION_THEME_BACKGROUND,
+			array(
+				'type'              => 'string',
+				'description'       => 'Custom background color for the publication basic theme.',
+				'default'           => '',
+				'show_in_rest'      => true,
+				'sanitize_callback' => array( Sanitize::class, 'hex_color' ),
+			)
+		);
+
+		\register_setting(
+			'atmosphere',
+			Publication::OPTION_THEME_FOREGROUND,
+			array(
+				'type'              => 'string',
+				'description'       => 'Custom foreground color for the publication basic theme.',
+				'default'           => '',
+				'show_in_rest'      => true,
+				'sanitize_callback' => array( Sanitize::class, 'hex_color' ),
+			)
+		);
+
+		\register_setting(
+			'atmosphere',
+			Publication::OPTION_THEME_ACCENT,
+			array(
+				'type'              => 'string',
+				'description'       => 'Custom accent color for the publication basic theme.',
+				'default'           => '',
+				'show_in_rest'      => true,
+				'sanitize_callback' => array( Sanitize::class, 'hex_color' ),
 			)
 		);
 

--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -11,6 +11,7 @@ namespace Atmosphere;
 
 use Atmosphere\Content_Parser\Registry;
 use Atmosphere\OAuth\Client;
+use Atmosphere\Transformer\Publication;
 
 /**
  * Stateless sanitize helpers wired to `register_setting()` callbacks.
@@ -153,5 +154,35 @@ class Sanitize {
 		}
 
 		return Registry::has( $value ) ? $value : '';
+	}
+
+	/**
+	 * Sanitize a publication-theme hex color.
+	 *
+	 * Accepts empty string or a valid `#RGB` / `#RRGGBB` value.
+	 * Valid colors are normalized to lowercase `#rrggbb`.
+	 *
+	 * @param mixed $value Submitted value.
+	 * @return string
+	 */
+	public static function hex_color( $value ): string {
+		if ( ! \is_string( $value ) ) {
+			return '';
+		}
+
+		$value = \sanitize_text_field( $value );
+		$value = \trim( $value );
+
+		if ( '' === $value ) {
+			return '';
+		}
+
+		$rgb = Publication::hex_to_rgb( $value );
+
+		if ( null === $rgb ) {
+			return '';
+		}
+
+		return \sprintf( '#%02x%02x%02x', $rgb['r'], $rgb['g'], $rgb['b'] );
 	}
 }

--- a/includes/transformer/class-publication.php
+++ b/includes/transformer/class-publication.php
@@ -46,6 +46,30 @@ class Publication extends Base {
 	public const OPTION_CID = 'atmosphere_publication_cid';
 
 	/**
+	 * Option key for a custom publication background color.
+	 *
+	 * @since unreleased
+	 * @var string
+	 */
+	public const OPTION_THEME_BACKGROUND = 'atmosphere_publication_theme_background';
+
+	/**
+	 * Option key for a custom publication foreground color.
+	 *
+	 * @since unreleased
+	 * @var string
+	 */
+	public const OPTION_THEME_FOREGROUND = 'atmosphere_publication_theme_foreground';
+
+	/**
+	 * Option key for a custom publication accent color.
+	 *
+	 * @since unreleased
+	 * @var string
+	 */
+	public const OPTION_THEME_ACCENT = 'atmosphere_publication_theme_accent';
+
+	/**
 	 * Whether the current transform is a read-only preview projection.
 	 *
 	 * Set for the duration of {@see self::get_preview_records()}. In
@@ -269,8 +293,106 @@ class Publication extends Base {
 
 		$styles  = \wp_get_global_styles();
 		$palette = self::get_palette_lookup();
+		$styles  = \is_array( $styles ) ? $styles : array();
 
-		return self::build_basic_theme( \is_array( $styles ) ? $styles : array(), $palette );
+		$basic_theme = self::build_basic_theme( $styles, $palette );
+		$basic_theme = self::apply_theme_option_overrides( $basic_theme );
+
+		/**
+		 * Filters the publication basicTheme object before record assembly.
+		 *
+		 * Return a `site.standard.theme.basic`-shaped array to override
+		 * the derived value, or null to omit `basicTheme`.
+		 *
+		 * @since unreleased
+		 *
+		 * @param array|null          $basic_theme Current basicTheme object or null.
+		 * @param array               $styles      Output of `wp_get_global_styles()`.
+		 * @param array<string,string> $palette    Slug => hex palette lookup.
+		 */
+		$filtered_theme = \apply_filters( 'atmosphere_publication_basic_theme', $basic_theme, $styles, $palette );
+
+		if ( null !== $filtered_theme && ! \is_array( $filtered_theme ) ) {
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'atmosphere_publication_basic_theme must return an array or null; falling back to the unfiltered basicTheme value.', 'atmosphere' ),
+				'unreleased'
+			);
+
+			return $basic_theme;
+		}
+
+		return $filtered_theme;
+	}
+
+	/**
+	 * Override derived theme colors with user-defined option values.
+	 *
+	 * Custom values are optional; when present they always override the
+	 * corresponding derived color. A full spec record is returned only when
+	 * all required colors can be resolved from the merged result.
+	 *
+	 * @param array|null $basic_theme Derived basicTheme object.
+	 * @return array|null
+	 */
+	private static function apply_theme_option_overrides( ?array $basic_theme ): ?array {
+		$background_override = self::hex_to_rgb( (string) \get_option( self::OPTION_THEME_BACKGROUND, '' ) );
+		$foreground_override = self::hex_to_rgb( (string) \get_option( self::OPTION_THEME_FOREGROUND, '' ) );
+		$accent_override     = self::hex_to_rgb( (string) \get_option( self::OPTION_THEME_ACCENT, '' ) );
+
+		if ( null === $background_override && null === $foreground_override && null === $accent_override ) {
+			return $basic_theme;
+		}
+
+		$background = null !== $background_override
+			? $background_override
+			: self::color_object_to_rgb( $basic_theme['background'] ?? null );
+
+		$foreground = null !== $foreground_override
+			? $foreground_override
+			: self::color_object_to_rgb( $basic_theme['foreground'] ?? null );
+
+		$accent = null !== $accent_override
+			? $accent_override
+			: self::color_object_to_rgb( $basic_theme['accent'] ?? null );
+
+		if ( null === $background || null === $foreground || null === $accent ) {
+			return null;
+		}
+
+		return array(
+			'$type'            => 'site.standard.theme.basic',
+			'background'       => self::color_object( $background ),
+			'foreground'       => self::color_object( $foreground ),
+			'accent'           => self::color_object( $accent ),
+			'accentForeground' => self::color_object( self::contrast_color( $accent ) ),
+		);
+	}
+
+	/**
+	 * Extract an RGB triple from a `site.standard.theme.color#rgb` object.
+	 *
+	 * @param mixed $color Color object candidate.
+	 * @return array{r: int, g: int, b: int}|null
+	 */
+	private static function color_object_to_rgb( $color ): ?array {
+		if ( ! \is_array( $color ) ) {
+			return null;
+		}
+
+		if ( ! isset( $color['r'], $color['g'], $color['b'] ) ) {
+			return null;
+		}
+
+		if ( ! \is_int( $color['r'] ) || ! \is_int( $color['g'] ) || ! \is_int( $color['b'] ) ) {
+			return null;
+		}
+
+		return array(
+			'r' => $color['r'],
+			'g' => $color['g'],
+			'b' => $color['b'],
+		);
 	}
 
 	/**

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -90,6 +90,14 @@ class Admin {
 			array(),
 			ATMOSPHERE_VERSION
 		);
+
+		\wp_enqueue_style( 'wp-color-picker' );
+		\wp_enqueue_script( 'wp-color-picker' );
+
+		\wp_add_inline_script(
+			'wp-color-picker',
+			"jQuery( function ( $ ) { $( '.atmosphere-color-input' ).wpColorPicker(); } );"
+		);
 	}
 
 	/**

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -16,6 +16,7 @@ use Atmosphere\Content_Parser\Markpub;
 use Atmosphere\Content_Parser\Pckt;
 use Atmosphere\Content_Parser\Registry;
 use Atmosphere\Handle;
+use Atmosphere\Transformer\Publication;
 use function Atmosphere\get_connection;
 use function Atmosphere\get_supported_post_types;
 use function Atmosphere\has_identity;
@@ -112,6 +113,38 @@ class Settings_Fields {
 			array( self::class, 'render_content_format_field' ),
 			'atmosphere',
 			'atmosphere_publishing'
+		);
+
+		// Publication theme section.
+		\add_settings_section(
+			'atmosphere_publication_theme',
+			\__( 'Publication theme', 'atmosphere' ),
+			array( self::class, 'render_publication_theme_section' ),
+			'atmosphere'
+		);
+
+		\add_settings_field(
+			Publication::OPTION_THEME_BACKGROUND,
+			\__( 'Background color', 'atmosphere' ),
+			array( self::class, 'render_publication_theme_background_field' ),
+			'atmosphere',
+			'atmosphere_publication_theme'
+		);
+
+		\add_settings_field(
+			Publication::OPTION_THEME_FOREGROUND,
+			\__( 'Foreground color', 'atmosphere' ),
+			array( self::class, 'render_publication_theme_foreground_field' ),
+			'atmosphere',
+			'atmosphere_publication_theme'
+		);
+
+		\add_settings_field(
+			Publication::OPTION_THEME_ACCENT,
+			\__( 'Accent color', 'atmosphere' ),
+			array( self::class, 'render_publication_theme_accent_field' ),
+			'atmosphere',
+			'atmosphere_publication_theme'
 		);
 
 		// Reactions section.
@@ -528,6 +561,64 @@ class Settings_Fields {
 	public static function render_reactions_section(): void {
 		?>
 		<p><?php \esc_html_e( 'Choose which interactions are sent to Bluesky and which are saved to WordPress.', 'atmosphere' ); ?></p>
+		<?php
+	}
+
+	/**
+	 * Render the Publication theme section description.
+	 */
+	public static function render_publication_theme_section(): void {
+		echo '<p>' . \esc_html__( 'Set custom colors for your standard.site basic theme. Leave a field blank to keep the color derived from your active WordPress theme.', 'atmosphere' ) . '</p>';
+	}
+
+	/**
+	 * Render the publication background color field.
+	 */
+	public static function render_publication_theme_background_field(): void {
+		$value = (string) \get_option( Publication::OPTION_THEME_BACKGROUND, '' );
+		?>
+		<input
+			type="text"
+			name="<?php echo \esc_attr( Publication::OPTION_THEME_BACKGROUND ); ?>"
+			id="<?php echo \esc_attr( Publication::OPTION_THEME_BACKGROUND ); ?>"
+			class="atmosphere-color-input"
+			value="<?php echo \esc_attr( $value ); ?>"
+		>
+		<p class="description"><?php \esc_html_e( 'Overrides the publication background color.', 'atmosphere' ); ?></p>
+		<?php
+	}
+
+	/**
+	 * Render the publication foreground color field.
+	 */
+	public static function render_publication_theme_foreground_field(): void {
+		$value = (string) \get_option( Publication::OPTION_THEME_FOREGROUND, '' );
+		?>
+		<input
+			type="text"
+			name="<?php echo \esc_attr( Publication::OPTION_THEME_FOREGROUND ); ?>"
+			id="<?php echo \esc_attr( Publication::OPTION_THEME_FOREGROUND ); ?>"
+			class="atmosphere-color-input"
+			value="<?php echo \esc_attr( $value ); ?>"
+		>
+		<p class="description"><?php \esc_html_e( 'Overrides the publication foreground/text color.', 'atmosphere' ); ?></p>
+		<?php
+	}
+
+	/**
+	 * Render the publication accent color field.
+	 */
+	public static function render_publication_theme_accent_field(): void {
+		$value = (string) \get_option( Publication::OPTION_THEME_ACCENT, '' );
+		?>
+		<input
+			type="text"
+			name="<?php echo \esc_attr( Publication::OPTION_THEME_ACCENT ); ?>"
+			id="<?php echo \esc_attr( Publication::OPTION_THEME_ACCENT ); ?>"
+			class="atmosphere-color-input"
+			value="<?php echo \esc_attr( $value ); ?>"
+		>
+		<p class="description"><?php \esc_html_e( 'Overrides the publication accent color. Accent foreground is computed automatically for contrast.', 'atmosphere' ); ?></p>
 		<?php
 	}
 

--- a/tests/phpunit/tests/transformer/class-test-publication.php
+++ b/tests/phpunit/tests/transformer/class-test-publication.php
@@ -22,8 +22,12 @@ class Test_Publication extends \WP_UnitTestCase {
 	public function tear_down(): void {
 		\remove_all_filters( 'atmosphere_publication_labels' );
 		\remove_all_filters( 'atmosphere_publication_show_in_discover' );
+		\remove_all_filters( 'atmosphere_publication_basic_theme' );
 		\delete_option( 'site_icon' );
 		\update_option( 'blog_public', 1 );
+		\delete_option( Publication::OPTION_THEME_BACKGROUND );
+		\delete_option( Publication::OPTION_THEME_FOREGROUND );
+		\delete_option( Publication::OPTION_THEME_ACCENT );
 
 		parent::tear_down();
 	}
@@ -630,6 +634,87 @@ class Test_Publication extends \WP_UnitTestCase {
 			$dark['accentForeground'],
 			'Dark accent should yield white foreground.'
 		);
+	}
+
+	/**
+	 * Stored publication-theme options override the derived theme colors.
+	 */
+	public function test_publication_theme_options_override_basic_theme_colors() {
+		\update_option( Publication::OPTION_THEME_BACKGROUND, '#112233' );
+		\update_option( Publication::OPTION_THEME_FOREGROUND, '#fafafa' );
+		\update_option( Publication::OPTION_THEME_ACCENT, '#ff0000' );
+
+		$record = ( new Publication( null ) )->transform();
+
+		$this->assertArrayHasKey( 'basicTheme', $record );
+		$this->assertSame( 17, $record['basicTheme']['background']['r'] );
+		$this->assertSame( 34, $record['basicTheme']['background']['g'] );
+		$this->assertSame( 51, $record['basicTheme']['background']['b'] );
+		$this->assertSame( 250, $record['basicTheme']['foreground']['r'] );
+		$this->assertSame( 250, $record['basicTheme']['foreground']['g'] );
+		$this->assertSame( 250, $record['basicTheme']['foreground']['b'] );
+		$this->assertSame( 255, $record['basicTheme']['accent']['r'] );
+		$this->assertSame( 0, $record['basicTheme']['accent']['g'] );
+		$this->assertSame( 0, $record['basicTheme']['accent']['b'] );
+
+		// Red is dark enough to require a white accent foreground at our threshold.
+		$this->assertSame( 255, $record['basicTheme']['accentForeground']['r'] );
+		$this->assertSame( 255, $record['basicTheme']['accentForeground']['g'] );
+		$this->assertSame( 255, $record['basicTheme']['accentForeground']['b'] );
+	}
+
+	/**
+	 * The dedicated basicTheme filter can override the transformed value.
+	 */
+	public function test_publication_basic_theme_filter_overrides_theme() {
+		\add_filter(
+			'atmosphere_publication_basic_theme',
+			static function () {
+				return array(
+					'$type'            => 'site.standard.theme.basic',
+					'background'       => array(
+						'$type' => 'site.standard.theme.color#rgb',
+						'r'     => 1,
+						'g'     => 2,
+						'b'     => 3,
+					),
+					'foreground'       => array(
+						'$type' => 'site.standard.theme.color#rgb',
+						'r'     => 4,
+						'g'     => 5,
+						'b'     => 6,
+					),
+					'accent'           => array(
+						'$type' => 'site.standard.theme.color#rgb',
+						'r'     => 7,
+						'g'     => 8,
+						'b'     => 9,
+					),
+					'accentForeground' => array(
+						'$type' => 'site.standard.theme.color#rgb',
+						'r'     => 10,
+						'g'     => 11,
+						'b'     => 12,
+					),
+				);
+			}
+		);
+
+		$record = ( new Publication( null ) )->transform();
+
+		$this->assertSame( 1, $record['basicTheme']['background']['r'] );
+		$this->assertSame( 10, $record['basicTheme']['accentForeground']['r'] );
+	}
+
+	/**
+	 * A null return from the basicTheme filter omits the field.
+	 */
+	public function test_publication_basic_theme_filter_can_omit_basic_theme() {
+		\add_filter( 'atmosphere_publication_basic_theme', '__return_null' );
+
+		$record = ( new Publication( null ) )->transform();
+
+		$this->assertArrayNotHasKey( 'basicTheme', $record );
 	}
 
 	/**

--- a/tests/phpunit/tests/wp-admin/class-test-theme-color-setting.php
+++ b/tests/phpunit/tests/wp-admin/class-test-theme-color-setting.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Tests for publication theme color setting sanitization.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group settings
+ */
+
+namespace Atmosphere\Tests\WP_Admin;
+
+use Atmosphere\Sanitize;
+
+/**
+ * Theme color setting sanitization tests.
+ */
+class Test_Theme_Color_Setting extends \WP_UnitTestCase {
+
+	/**
+	 * Valid hex values are normalized to six-character lowercase form.
+	 */
+	public function test_hex_color_accepts_valid_values() {
+		$this->assertSame( '#ff8800', Sanitize::hex_color( '#ff8800' ) );
+		$this->assertSame( '#ff8800', Sanitize::hex_color( '#F80' ) );
+		$this->assertSame( '#112233', Sanitize::hex_color( ' #112233 ' ) );
+	}
+
+	/**
+	 * Invalid values sanitize to empty string.
+	 */
+	public function test_hex_color_rejects_invalid_values() {
+		$this->assertSame( '', Sanitize::hex_color( 'nope' ) );
+		$this->assertSame( '', Sanitize::hex_color( '#zzzzzz' ) );
+		$this->assertSame( '', Sanitize::hex_color( 'rgb(1,2,3)' ) );
+		$this->assertSame( '', Sanitize::hex_color( null ) );
+		$this->assertSame( '', Sanitize::hex_color( array( '#fff' ) ) );
+	}
+
+	/**
+	 * Empty input remains empty so derived theme values can be used.
+	 */
+	public function test_hex_color_allows_empty_value() {
+		$this->assertSame( '', Sanitize::hex_color( '' ) );
+	}
+}


### PR DESCRIPTION
Lets site owners set the `site.standard.publication` `basicTheme` colors from Settings → ATmosphere, instead of the colors being pinned to whatever `theme.json` derives. Grew out of "Experiment 2" in #205.

Fixes #205

## Proposed changes:

* Adds three options — background, foreground, and accent — each stored as a hex value and sanitized to `#rrggbb` (blank means "keep the color derived from the active theme").
* Renders them as a **Publication theme** section on the settings screen using `wp-color-picker`.
* Applies the stored values in the Publication transformer, recomputing `accentForeground` so a custom accent keeps its contrast guarantee.
* Adds an `atmosphere_publication_basic_theme` filter so the whole theme object can be replaced (or omitted) in code — the filter form floated in #205's Experiment 1, kept alongside the settings UI.
* Re-syncs the publication record when any of the three settings change.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Note that a theme object is only published when all four colors resolve. If the active theme exposes no usable colors (a classic theme, or a theme that styles links with a gradient), setting only one or two colors here still results in no `basicTheme` — all three have to be set. The section copy says so.

## Testing instructions:

No Bluesky connection is needed to verify the record shape:

1. Go to **Settings → ATmosphere → Publication theme**. Confirm the three color fields render, that each label focuses its input, and that the picker offers your active theme's palette as swatches.
2. Leave all three blank and save, then inspect the derived record:
   ```
   wp eval 'print_r( ( new \Atmosphere\Transformer\Publication( null ) )->transform()["basicTheme"] );'
   ```
   The colors should match your theme.
3. Set just the **accent** color and save. Re-run the command: only `accent` changes, `background` / `foreground` stay derived, and `accentForeground` flips to black or white for contrast.
4. Set all three and save. Re-run: all three are yours.
5. Clear a field and save. Re-run: that color reverts to the derived value.
6. Paste something invalid (`rgb(1,2,3)`, `javascript:alert(1)`) into a field and save — it stores empty rather than being persisted, and the derived color is used.
7. With a connection active, saving any of the three should queue a publication sync (`wp cron event list | grep atmosphere`).

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Add color settings for your publication theme, so you can choose the background, text, and accent colors apps use when they display your site.

</details>
