### PR TITLE
Add custom publication theme colors, and fix accent derivation on default themes

### DIFF
--- a/.github/changelog/add-publication-theme-colors
+++ b/.github/changelog/add-publication-theme-colors
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add color settings for your publication theme, so you can choose the background, text, and accent colors apps use when they display your site.

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -20,11 +20,3 @@
 .atmosphere-handle-typeahead-mount .atmosphere-handle-field {
 	max-width: 25em;
 }
-
-.atmosphere-color-input {
-	width: 8rem;
-}
-
-.wp-picker-container {
-	vertical-align: middle;
-}

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -20,3 +20,11 @@
 .atmosphere-handle-typeahead-mount .atmosphere-handle-field {
 	max-width: 25em;
 }
+
+.atmosphere-color-input {
+	width: 8rem;
+}
+
+.wp-picker-container {
+	vertical-align: middle;
+}

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -285,6 +285,9 @@ class Atmosphere {
 		\add_action( 'update_option_site_icon', array( $this, 'schedule_publication_sync' ) );
 		\add_action( 'update_option_home', array( $this, 'schedule_publication_sync' ) );
 		\add_action( 'update_option_siteurl', array( $this, 'schedule_publication_sync' ) );
+		\add_action( 'update_option_atmosphere_publication_theme_background', array( $this, 'schedule_publication_sync' ) );
+		\add_action( 'update_option_atmosphere_publication_theme_foreground', array( $this, 'schedule_publication_sync' ) );
+		\add_action( 'update_option_atmosphere_publication_theme_accent', array( $this, 'schedule_publication_sync' ) );
 		\add_action( 'switch_theme', array( $this, 'schedule_publication_sync' ) );
 		\add_action( 'save_post_wp_global_styles', array( $this, 'schedule_publication_sync' ) );
 		\add_action( 'customize_save_after', array( $this, 'schedule_publication_sync' ) );

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -279,30 +279,22 @@ class Atmosphere {
 		 * theme colours from: classic-theme Customizer saves
 		 * (`customize_save_after`) and block-theme Site Editor saves
 		 * (the `wp_global_styles` post update).
-		 */
-		\add_action( 'update_option_blogname', array( $this, 'schedule_publication_sync' ) );
-		\add_action( 'update_option_blogdescription', array( $this, 'schedule_publication_sync' ) );
-		\add_action( 'update_option_site_icon', array( $this, 'schedule_publication_sync' ) );
-		\add_action( 'update_option_home', array( $this, 'schedule_publication_sync' ) );
-		\add_action( 'update_option_siteurl', array( $this, 'schedule_publication_sync' ) );
-
-		/*
-		 * Both `add_option_*` and `update_option_*` for the theme colours:
-		 * they have no option row until a colour is first picked, and
-		 * WordPress routes that first save through `add_option()`, where
-		 * `update_option_*` never fires. Without the add hook the opening
-		 * colour choice would not reach the publication record. The core
-		 * options above always exist, so they need the update hook only.
+		 *
+		 * Each option gets both `add_option_*` and `update_option_*`: an
+		 * option with no row yet is written by `add_option()`, where
+		 * `update_option_*` never fires, which is the case a plugin
+		 * option hits the first time it is saved. Registering both for
+		 * every option keeps the list uniform, and the add hook is
+		 * simply never reached for the core options, which always exist.
 		 */
 		foreach (
-			array(
-				Publication::OPTION_THEME_BACKGROUND,
-				Publication::OPTION_THEME_FOREGROUND,
-				Publication::OPTION_THEME_ACCENT,
-			) as $theme_color_option
+			\array_merge(
+				array( 'blogname', 'blogdescription', 'site_icon', 'home', 'siteurl' ),
+				\array_values( Publication::get_theme_color_options() )
+			) as $publication_option
 		) {
-			\add_action( 'add_option_' . $theme_color_option, array( $this, 'schedule_publication_sync' ) );
-			\add_action( 'update_option_' . $theme_color_option, array( $this, 'schedule_publication_sync' ) );
+			\add_action( 'add_option_' . $publication_option, array( $this, 'schedule_publication_sync' ) );
+			\add_action( 'update_option_' . $publication_option, array( $this, 'schedule_publication_sync' ) );
 		}
 		\add_action( 'switch_theme', array( $this, 'schedule_publication_sync' ) );
 		\add_action( 'save_post_wp_global_styles', array( $this, 'schedule_publication_sync' ) );

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -285,9 +285,25 @@ class Atmosphere {
 		\add_action( 'update_option_site_icon', array( $this, 'schedule_publication_sync' ) );
 		\add_action( 'update_option_home', array( $this, 'schedule_publication_sync' ) );
 		\add_action( 'update_option_siteurl', array( $this, 'schedule_publication_sync' ) );
-		\add_action( 'update_option_atmosphere_publication_theme_background', array( $this, 'schedule_publication_sync' ) );
-		\add_action( 'update_option_atmosphere_publication_theme_foreground', array( $this, 'schedule_publication_sync' ) );
-		\add_action( 'update_option_atmosphere_publication_theme_accent', array( $this, 'schedule_publication_sync' ) );
+
+		/*
+		 * Both `add_option_*` and `update_option_*` for the theme colours:
+		 * they have no option row until a colour is first picked, and
+		 * WordPress routes that first save through `add_option()`, where
+		 * `update_option_*` never fires. Without the add hook the opening
+		 * colour choice would not reach the publication record. The core
+		 * options above always exist, so they need the update hook only.
+		 */
+		foreach (
+			array(
+				Publication::OPTION_THEME_BACKGROUND,
+				Publication::OPTION_THEME_FOREGROUND,
+				Publication::OPTION_THEME_ACCENT,
+			) as $theme_color_option
+		) {
+			\add_action( 'add_option_' . $theme_color_option, array( $this, 'schedule_publication_sync' ) );
+			\add_action( 'update_option_' . $theme_color_option, array( $this, 'schedule_publication_sync' ) );
+		}
 		\add_action( 'switch_theme', array( $this, 'schedule_publication_sync' ) );
 		\add_action( 'save_post_wp_global_styles', array( $this, 'schedule_publication_sync' ) );
 		\add_action( 'customize_save_after', array( $this, 'schedule_publication_sync' ) );

--- a/includes/class-options.php
+++ b/includes/class-options.php
@@ -10,6 +10,7 @@ namespace Atmosphere;
 \defined( 'ABSPATH' ) || exit;
 
 use Atmosphere\Content_Parser\Registry;
+use Atmosphere\Transformer\Publication;
 
 /**
  * Registers every stored plugin option with the Settings API.
@@ -124,6 +125,42 @@ class Options {
 						'items' => array( 'type' => 'string' ),
 					),
 				),
+			)
+		);
+
+		\register_setting(
+			'atmosphere',
+			Publication::OPTION_THEME_BACKGROUND,
+			array(
+				'type'              => 'string',
+				'description'       => 'Custom background color for the publication basic theme.',
+				'default'           => '',
+				'show_in_rest'      => true,
+				'sanitize_callback' => array( Sanitize::class, 'hex_color' ),
+			)
+		);
+
+		\register_setting(
+			'atmosphere',
+			Publication::OPTION_THEME_FOREGROUND,
+			array(
+				'type'              => 'string',
+				'description'       => 'Custom foreground color for the publication basic theme.',
+				'default'           => '',
+				'show_in_rest'      => true,
+				'sanitize_callback' => array( Sanitize::class, 'hex_color' ),
+			)
+		);
+
+		\register_setting(
+			'atmosphere',
+			Publication::OPTION_THEME_ACCENT,
+			array(
+				'type'              => 'string',
+				'description'       => 'Custom accent color for the publication basic theme.',
+				'default'           => '',
+				'show_in_rest'      => true,
+				'sanitize_callback' => array( Sanitize::class, 'hex_color' ),
 			)
 		);
 

--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -11,6 +11,7 @@ namespace Atmosphere;
 
 use Atmosphere\Content_Parser\Registry;
 use Atmosphere\OAuth\Client;
+use Atmosphere\Transformer\Publication;
 
 /**
  * Stateless sanitize helpers wired to `register_setting()` callbacks.
@@ -168,5 +169,35 @@ class Sanitize {
 		}
 
 		return Registry::has( $value ) ? $value : '';
+	}
+
+	/**
+	 * Sanitize a publication-theme hex color.
+	 *
+	 * Accepts empty string or a valid `#RGB` / `#RRGGBB` value.
+	 * Valid colors are normalized to lowercase `#rrggbb`.
+	 *
+	 * @param mixed $value Submitted value.
+	 * @return string
+	 */
+	public static function hex_color( $value ): string {
+		if ( ! \is_string( $value ) ) {
+			return '';
+		}
+
+		$value = \sanitize_text_field( $value );
+		$value = \trim( $value );
+
+		if ( '' === $value ) {
+			return '';
+		}
+
+		$rgb = Publication::hex_to_rgb( $value );
+
+		if ( null === $rgb ) {
+			return '';
+		}
+
+		return \sprintf( '#%02x%02x%02x', $rgb['r'], $rgb['g'], $rgb['b'] );
 	}
 }

--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -11,7 +11,6 @@ namespace Atmosphere;
 
 use Atmosphere\Content_Parser\Registry;
 use Atmosphere\OAuth\Client;
-use Atmosphere\Transformer\Publication;
 
 /**
  * Stateless sanitize helpers wired to `register_setting()` callbacks.
@@ -174,8 +173,11 @@ class Sanitize {
 	/**
 	 * Sanitize a publication-theme hex color.
 	 *
-	 * Accepts empty string or a valid `#RGB` / `#RRGGBB` value.
-	 * Valid colors are normalized to lowercase `#rrggbb`.
+	 * Accepts an empty string — which means "keep the colour derived from
+	 * the active theme" — or a `#RGB` / `#RRGGBB` value, lower-cased.
+	 * Anything else sanitizes to empty rather than being stored, so a
+	 * malformed paste degrades to the derived colour instead of dropping
+	 * the whole theme object from the record.
 	 *
 	 * @param mixed $value Submitted value.
 	 * @return string
@@ -185,19 +187,14 @@ class Sanitize {
 			return '';
 		}
 
-		$value = \sanitize_text_field( $value );
-		$value = \trim( $value );
+		// Core validates the `#RGB` / `#RRGGBB` shape and returns null otherwise.
+		$color = \strtolower( (string) \sanitize_hex_color( \trim( $value ) ) );
 
-		if ( '' === $value ) {
-			return '';
+		// Normalize the shorthand form so stored values are always `#rrggbb`.
+		if ( 4 === \strlen( $color ) ) {
+			$color = '#' . $color[1] . $color[1] . $color[2] . $color[2] . $color[3] . $color[3];
 		}
 
-		$rgb = Publication::hex_to_rgb( $value );
-
-		if ( null === $rgb ) {
-			return '';
-		}
-
-		return \sprintf( '#%02x%02x%02x', $rgb['r'], $rgb['g'], $rgb['b'] );
+		return $color;
 	}
 }

--- a/includes/transformer/class-publication.php
+++ b/includes/transformer/class-publication.php
@@ -287,16 +287,17 @@ class Publication extends Base {
 	 * @return array|null
 	 */
 	private function extract_basic_theme(): ?array {
-		if ( ! \function_exists( 'wp_get_global_styles' ) ) {
-			return null;
-		}
+		/*
+		 * Global styles drive the *derived* colours only. Stored
+		 * overrides and the filter below still apply without them, so
+		 * this degrades to an empty style array rather than bailing.
+		 */
+		$styles = \function_exists( 'wp_get_global_styles' ) ? \wp_get_global_styles() : array();
+		$styles = \is_array( $styles ) ? $styles : array();
 
-		$styles  = \wp_get_global_styles();
 		$palette = self::get_palette_lookup();
-		$styles  = \is_array( $styles ) ? $styles : array();
 
-		$basic_theme = self::build_basic_theme( $styles, $palette );
-		$basic_theme = self::apply_theme_option_overrides( $basic_theme );
+		$basic_theme = self::build_basic_theme( $styles, $palette, self::get_theme_option_overrides() );
 
 		/**
 		 * Filters the publication basicTheme object before record assembly.
@@ -326,73 +327,32 @@ class Publication extends Base {
 	}
 
 	/**
-	 * Override derived theme colors with user-defined option values.
+	 * Read the stored theme-colour overrides as resolved RGB triples.
 	 *
-	 * Custom values are optional; when present they always override the
-	 * corresponding derived color. A full spec record is returned only when
-	 * all required colors can be resolved from the merged result.
+	 * Unset or unparseable options are omitted, so each colour falls
+	 * through to the value derived from the active theme.
 	 *
-	 * @param array|null $basic_theme Derived basicTheme object.
-	 * @return array|null
+	 * @return array<string, array{r: int, g: int, b: int}> Keyed by
+	 *                background / foreground / accent.
 	 */
-	private static function apply_theme_option_overrides( ?array $basic_theme ): ?array {
-		$background_override = self::hex_to_rgb( (string) \get_option( self::OPTION_THEME_BACKGROUND, '' ) );
-		$foreground_override = self::hex_to_rgb( (string) \get_option( self::OPTION_THEME_FOREGROUND, '' ) );
-		$accent_override     = self::hex_to_rgb( (string) \get_option( self::OPTION_THEME_ACCENT, '' ) );
-
-		if ( null === $background_override && null === $foreground_override && null === $accent_override ) {
-			return $basic_theme;
-		}
-
-		$background = null !== $background_override
-			? $background_override
-			: self::color_object_to_rgb( $basic_theme['background'] ?? null );
-
-		$foreground = null !== $foreground_override
-			? $foreground_override
-			: self::color_object_to_rgb( $basic_theme['foreground'] ?? null );
-
-		$accent = null !== $accent_override
-			? $accent_override
-			: self::color_object_to_rgb( $basic_theme['accent'] ?? null );
-
-		if ( null === $background || null === $foreground || null === $accent ) {
-			return null;
-		}
-
-		return array(
-			'$type'            => 'site.standard.theme.basic',
-			'background'       => self::color_object( $background ),
-			'foreground'       => self::color_object( $foreground ),
-			'accent'           => self::color_object( $accent ),
-			'accentForeground' => self::color_object( self::contrast_color( $accent ) ),
+	public static function get_theme_option_overrides(): array {
+		$options = array(
+			'background' => self::OPTION_THEME_BACKGROUND,
+			'foreground' => self::OPTION_THEME_FOREGROUND,
+			'accent'     => self::OPTION_THEME_ACCENT,
 		);
-	}
 
-	/**
-	 * Extract an RGB triple from a `site.standard.theme.color#rgb` object.
-	 *
-	 * @param mixed $color Color object candidate.
-	 * @return array{r: int, g: int, b: int}|null
-	 */
-	private static function color_object_to_rgb( $color ): ?array {
-		if ( ! \is_array( $color ) ) {
-			return null;
+		$overrides = array();
+
+		foreach ( $options as $key => $option ) {
+			$rgb = self::hex_to_rgb( (string) \get_option( $option, '' ) );
+
+			if ( null !== $rgb ) {
+				$overrides[ $key ] = $rgb;
+			}
 		}
 
-		if ( ! isset( $color['r'], $color['g'], $color['b'] ) ) {
-			return null;
-		}
-
-		if ( ! \is_int( $color['r'] ) || ! \is_int( $color['g'] ) || ! \is_int( $color['b'] ) ) {
-			return null;
-		}
-
-		return array(
-			'r' => $color['r'],
-			'g' => $color['g'],
-			'b' => $color['b'],
-		);
+		return $overrides;
 	}
 
 	/**
@@ -404,14 +364,23 @@ class Publication extends Base {
 	 * theme.json merge. The record carries the `site.standard.theme.basic`
 	 * `$type` discriminator so it passes lexicon validation.
 	 *
-	 * @param array                $styles  Output of `wp_get_global_styles()`.
-	 * @param array<string,string> $palette Slug => hex map from the theme palette.
+	 * Site-owner overrides take precedence over the derived colours,
+	 * per colour: an override for one channel leaves the rest derived.
+	 * `accentForeground` is always computed from the winning accent, so
+	 * a custom accent keeps its contrast guarantee.
+	 *
+	 * @param array                $styles    Output of `wp_get_global_styles()`.
+	 * @param array<string,string> $palette   Slug => hex map from the theme palette.
+	 * @param array                $overrides Optional. Resolved RGB triples keyed by
+	 *                                        background / foreground / accent.
 	 * @return array|null Spec-shaped record, or null when any required colour
 	 *                    is missing.
 	 */
-	public static function build_basic_theme( array $styles, array $palette ): ?array {
-		$background = self::resolve_color( (string) ( $styles['color']['background'] ?? '' ), $palette );
-		$foreground = self::resolve_color( (string) ( $styles['color']['text'] ?? '' ), $palette );
+	public static function build_basic_theme( array $styles, array $palette, array $overrides = array() ): ?array {
+		$background = $overrides['background']
+			?? self::resolve_color( (string) ( $styles['color']['background'] ?? '' ), $palette );
+		$foreground = $overrides['foreground']
+			?? self::resolve_color( (string) ( $styles['color']['text'] ?? '' ), $palette );
 
 		/*
 		 * Link colour is the conventional accent source in WP themes —
@@ -419,7 +388,7 @@ class Publication extends Base {
 		 * Falls back to a palette slug literally named `accent` for
 		 * themes that don't restyle links.
 		 */
-		$accent = self::resolve_color(
+		$accent = $overrides['accent'] ?? self::resolve_color(
 			(string) ( $styles['elements']['link']['color']['text'] ?? '' ),
 			$palette
 		);

--- a/includes/transformer/class-publication.php
+++ b/includes/transformer/class-publication.php
@@ -46,6 +46,30 @@ class Publication extends Base {
 	public const OPTION_CID = 'atmosphere_publication_cid';
 
 	/**
+	 * Option key for a custom publication background color.
+	 *
+	 * @since unreleased
+	 * @var string
+	 */
+	public const OPTION_THEME_BACKGROUND = 'atmosphere_publication_theme_background';
+
+	/**
+	 * Option key for a custom publication foreground color.
+	 *
+	 * @since unreleased
+	 * @var string
+	 */
+	public const OPTION_THEME_FOREGROUND = 'atmosphere_publication_theme_foreground';
+
+	/**
+	 * Option key for a custom publication accent color.
+	 *
+	 * @since unreleased
+	 * @var string
+	 */
+	public const OPTION_THEME_ACCENT = 'atmosphere_publication_theme_accent';
+
+	/**
 	 * Whether the current transform is a read-only preview projection.
 	 *
 	 * Set for the duration of {@see self::get_preview_records()}. In
@@ -269,8 +293,106 @@ class Publication extends Base {
 
 		$styles  = \wp_get_global_styles();
 		$palette = self::get_palette_lookup();
+		$styles  = \is_array( $styles ) ? $styles : array();
 
-		return self::build_basic_theme( \is_array( $styles ) ? $styles : array(), $palette );
+		$basic_theme = self::build_basic_theme( $styles, $palette );
+		$basic_theme = self::apply_theme_option_overrides( $basic_theme );
+
+		/**
+		 * Filters the publication basicTheme object before record assembly.
+		 *
+		 * Return a `site.standard.theme.basic`-shaped array to override
+		 * the derived value, or null to omit `basicTheme`.
+		 *
+		 * @since unreleased
+		 *
+		 * @param array|null          $basic_theme Current basicTheme object or null.
+		 * @param array               $styles      Output of `wp_get_global_styles()`.
+		 * @param array<string,string> $palette    Slug => hex palette lookup.
+		 */
+		$filtered_theme = \apply_filters( 'atmosphere_publication_basic_theme', $basic_theme, $styles, $palette );
+
+		if ( null !== $filtered_theme && ! \is_array( $filtered_theme ) ) {
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'atmosphere_publication_basic_theme must return an array or null; falling back to the unfiltered basicTheme value.', 'atmosphere' ),
+				'unreleased'
+			);
+
+			return $basic_theme;
+		}
+
+		return $filtered_theme;
+	}
+
+	/**
+	 * Override derived theme colors with user-defined option values.
+	 *
+	 * Custom values are optional; when present they always override the
+	 * corresponding derived color. A full spec record is returned only when
+	 * all required colors can be resolved from the merged result.
+	 *
+	 * @param array|null $basic_theme Derived basicTheme object.
+	 * @return array|null
+	 */
+	private static function apply_theme_option_overrides( ?array $basic_theme ): ?array {
+		$background_override = self::hex_to_rgb( (string) \get_option( self::OPTION_THEME_BACKGROUND, '' ) );
+		$foreground_override = self::hex_to_rgb( (string) \get_option( self::OPTION_THEME_FOREGROUND, '' ) );
+		$accent_override     = self::hex_to_rgb( (string) \get_option( self::OPTION_THEME_ACCENT, '' ) );
+
+		if ( null === $background_override && null === $foreground_override && null === $accent_override ) {
+			return $basic_theme;
+		}
+
+		$background = null !== $background_override
+			? $background_override
+			: self::color_object_to_rgb( $basic_theme['background'] ?? null );
+
+		$foreground = null !== $foreground_override
+			? $foreground_override
+			: self::color_object_to_rgb( $basic_theme['foreground'] ?? null );
+
+		$accent = null !== $accent_override
+			? $accent_override
+			: self::color_object_to_rgb( $basic_theme['accent'] ?? null );
+
+		if ( null === $background || null === $foreground || null === $accent ) {
+			return null;
+		}
+
+		return array(
+			'$type'            => 'site.standard.theme.basic',
+			'background'       => self::color_object( $background ),
+			'foreground'       => self::color_object( $foreground ),
+			'accent'           => self::color_object( $accent ),
+			'accentForeground' => self::color_object( self::contrast_color( $accent ) ),
+		);
+	}
+
+	/**
+	 * Extract an RGB triple from a `site.standard.theme.color#rgb` object.
+	 *
+	 * @param mixed $color Color object candidate.
+	 * @return array{r: int, g: int, b: int}|null
+	 */
+	private static function color_object_to_rgb( $color ): ?array {
+		if ( ! \is_array( $color ) ) {
+			return null;
+		}
+
+		if ( ! isset( $color['r'], $color['g'], $color['b'] ) ) {
+			return null;
+		}
+
+		if ( ! \is_int( $color['r'] ) || ! \is_int( $color['g'] ) || ! \is_int( $color['b'] ) ) {
+			return null;
+		}
+
+		return array(
+			'r' => $color['r'],
+			'g' => $color['g'],
+			'b' => $color['b'],
+		);
 	}
 
 	/**

--- a/includes/transformer/class-publication.php
+++ b/includes/transformer/class-publication.php
@@ -327,6 +327,40 @@ class Publication extends Base {
 	}
 
 	/**
+	 * The colours derived from the active theme, as hex strings.
+	 *
+	 * Mirrors what {@see self::build_basic_theme()} derives with no
+	 * overrides applied, so the settings screen can show a site owner
+	 * what a blank field will actually publish. Channels that can't be
+	 * derived are omitted.
+	 *
+	 * @return array<string, string> Keyed by background / foreground / accent.
+	 */
+	public static function get_derived_theme_colors(): array {
+		$styles = \function_exists( 'wp_get_global_styles' ) ? \wp_get_global_styles() : array();
+		$styles = \is_array( $styles ) ? $styles : array();
+
+		$palette = self::get_palette_lookup();
+
+		$derived = array(
+			'background' => self::resolve_color( (string) ( $styles['color']['background'] ?? '' ), $palette ),
+			'foreground' => self::resolve_color( (string) ( $styles['color']['text'] ?? '' ), $palette ),
+			'accent'     => self::resolve_color( (string) ( $styles['elements']['link']['color']['text'] ?? '' ), $palette )
+				?? self::resolve_palette_accent( $palette ),
+		);
+
+		$colors = array();
+
+		foreach ( $derived as $key => $rgb ) {
+			if ( null !== $rgb ) {
+				$colors[ $key ] = \sprintf( '#%02x%02x%02x', $rgb['r'], $rgb['g'], $rgb['b'] );
+			}
+		}
+
+		return $colors;
+	}
+
+	/**
 	 * Read the stored theme-colour overrides as resolved RGB triples.
 	 *
 	 * Unset or unparseable options are omitted, so each colour falls
@@ -393,8 +427,8 @@ class Publication extends Base {
 			$palette
 		);
 
-		if ( null === $accent && isset( $palette['accent'] ) ) {
-			$accent = self::resolve_color( $palette['accent'], $palette );
+		if ( null === $accent ) {
+			$accent = self::resolve_palette_accent( $palette );
 		}
 
 		if ( null === $background || null === $foreground || null === $accent ) {
@@ -408,6 +442,49 @@ class Publication extends Base {
 			'accent'           => self::color_object( $accent ),
 			'accentForeground' => self::color_object( self::contrast_color( $accent ) ),
 		);
+	}
+
+	/**
+	 * Pick an accent colour out of the theme palette.
+	 *
+	 * Themes that style links with `currentColor` — including the default
+	 * Twenty Twenty-Five — leave nothing to derive from the link element,
+	 * so fall back to the palette's own accent slugs. An exact `accent`
+	 * wins; otherwise the lowest-numbered `accent-N` does, which is the
+	 * slug core's own themes use for their primary accent. Values that
+	 * aren't plain colours (`color-mix(...)`, gradients) are skipped.
+	 *
+	 * @param array<string,string> $palette Slug => hex map.
+	 * @return array{r: int, g: int, b: int}|null
+	 */
+	private static function resolve_palette_accent( array $palette ): ?array {
+		if ( isset( $palette['accent'] ) ) {
+			$accent = self::resolve_color( $palette['accent'], $palette );
+
+			if ( null !== $accent ) {
+				return $accent;
+			}
+		}
+
+		$numbered = array();
+
+		foreach ( $palette as $slug => $value ) {
+			if ( \preg_match( '/^accent-(\d+)$/', (string) $slug, $matches ) ) {
+				$numbered[ (int) $matches[1] ] = $value;
+			}
+		}
+
+		\ksort( $numbered );
+
+		foreach ( $numbered as $value ) {
+			$accent = self::resolve_color( (string) $value, $palette );
+
+			if ( null !== $accent ) {
+				return $accent;
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/includes/transformer/class-publication.php
+++ b/includes/transformer/class-publication.php
@@ -287,14 +287,7 @@ class Publication extends Base {
 	 * @return array|null
 	 */
 	private function extract_basic_theme(): ?array {
-		/*
-		 * Global styles drive the *derived* colours only. Stored
-		 * overrides and the filter below still apply without them, so
-		 * this degrades to an empty style array rather than bailing.
-		 */
-		$styles = \function_exists( 'wp_get_global_styles' ) ? \wp_get_global_styles() : array();
-		$styles = \is_array( $styles ) ? $styles : array();
-
+		$styles  = self::get_global_styles();
 		$palette = self::get_palette_lookup();
 
 		$basic_theme = self::build_basic_theme( $styles, $palette, self::get_theme_option_overrides() );
@@ -327,37 +320,85 @@ class Publication extends Base {
 	}
 
 	/**
+	 * The theme colours a site owner can override, mapped to the option
+	 * that stores each one.
+	 *
+	 * Single source of truth for the channel set: the transformer, the
+	 * settings screen, and the publication-sync triggers all build off
+	 * this, so adding a channel is one edit rather than four.
+	 *
+	 * @return array<string, string> Channel key => option name.
+	 */
+	public static function get_theme_color_options(): array {
+		return array(
+			'background' => self::OPTION_THEME_BACKGROUND,
+			'foreground' => self::OPTION_THEME_FOREGROUND,
+			'accent'     => self::OPTION_THEME_ACCENT,
+		);
+	}
+
+	/**
 	 * The colours derived from the active theme, as hex strings.
 	 *
-	 * Mirrors what {@see self::build_basic_theme()} derives with no
-	 * overrides applied, so the settings screen can show a site owner
-	 * what a blank field will actually publish. Channels that can't be
-	 * derived are omitted.
+	 * The settings screen shows these so a site owner can see what a
+	 * blank field will publish. Channels that can't be derived are
+	 * omitted.
 	 *
 	 * @return array<string, string> Keyed by background / foreground / accent.
 	 */
 	public static function get_derived_theme_colors(): array {
-		$styles = \function_exists( 'wp_get_global_styles' ) ? \wp_get_global_styles() : array();
-		$styles = \is_array( $styles ) ? $styles : array();
-
-		$palette = self::get_palette_lookup();
-
-		$derived = array(
-			'background' => self::resolve_color( (string) ( $styles['color']['background'] ?? '' ), $palette ),
-			'foreground' => self::resolve_color( (string) ( $styles['color']['text'] ?? '' ), $palette ),
-			'accent'     => self::resolve_color( (string) ( $styles['elements']['link']['color']['text'] ?? '' ), $palette )
-				?? self::resolve_palette_accent( $palette ),
-		);
-
 		$colors = array();
 
-		foreach ( $derived as $key => $rgb ) {
+		foreach ( self::derive_colors( self::get_global_styles(), self::get_palette_lookup() ) as $key => $rgb ) {
 			if ( null !== $rgb ) {
 				$colors[ $key ] = \sprintf( '#%02x%02x%02x', $rgb['r'], $rgb['g'], $rgb['b'] );
 			}
 		}
 
 		return $colors;
+	}
+
+	/**
+	 * Resolve the active theme's global styles.
+	 *
+	 * Global styles drive the *derived* colours only. Stored overrides
+	 * and the `atmosphere_publication_basic_theme` filter still apply
+	 * without them, so a missing or malformed result degrades to an
+	 * empty array rather than bailing out of theme assembly.
+	 *
+	 * @return array
+	 */
+	private static function get_global_styles(): array {
+		$styles = \function_exists( 'wp_get_global_styles' ) ? \wp_get_global_styles() : array();
+
+		return \is_array( $styles ) ? $styles : array();
+	}
+
+	/**
+	 * Derive each theme colour from global styles and the palette.
+	 *
+	 * The single definition of where each colour comes from. Every
+	 * channel is present in the return value; a channel that cannot be
+	 * resolved is null.
+	 *
+	 * @param array                $styles  Output of `wp_get_global_styles()`.
+	 * @param array<string,string> $palette Slug => hex map from the theme palette.
+	 * @return array<string, array{r: int, g: int, b: int}|null>
+	 */
+	private static function derive_colors( array $styles, array $palette ): array {
+		return array(
+			'background' => self::resolve_color( (string) ( $styles['color']['background'] ?? '' ), $palette ),
+			'foreground' => self::resolve_color( (string) ( $styles['color']['text'] ?? '' ), $palette ),
+
+			/*
+			 * Link colour is the conventional accent source in WP themes —
+			 * it's the one element nearly every theme styles explicitly.
+			 * Falls back to the palette's own accent slugs for themes that
+			 * don't restyle links.
+			 */
+			'accent'     => self::resolve_color( (string) ( $styles['elements']['link']['color']['text'] ?? '' ), $palette )
+				?? self::resolve_palette_accent( $palette ),
+		);
 	}
 
 	/**
@@ -369,16 +410,10 @@ class Publication extends Base {
 	 * @return array<string, array{r: int, g: int, b: int}> Keyed by
 	 *                background / foreground / accent.
 	 */
-	public static function get_theme_option_overrides(): array {
-		$options = array(
-			'background' => self::OPTION_THEME_BACKGROUND,
-			'foreground' => self::OPTION_THEME_FOREGROUND,
-			'accent'     => self::OPTION_THEME_ACCENT,
-		);
-
+	private static function get_theme_option_overrides(): array {
 		$overrides = array();
 
-		foreach ( $options as $key => $option ) {
+		foreach ( self::get_theme_color_options() as $key => $option ) {
 			$rgb = self::hex_to_rgb( (string) \get_option( $option, '' ) );
 
 			if ( null !== $rgb ) {
@@ -411,36 +446,20 @@ class Publication extends Base {
 	 *                    is missing.
 	 */
 	public static function build_basic_theme( array $styles, array $palette, array $overrides = array() ): ?array {
-		$background = $overrides['background']
-			?? self::resolve_color( (string) ( $styles['color']['background'] ?? '' ), $palette );
-		$foreground = $overrides['foreground']
-			?? self::resolve_color( (string) ( $styles['color']['text'] ?? '' ), $palette );
+		// Union, not merge: a stored override wins per channel, and every
+		// channel the owner left blank falls through to the derived value.
+		$colors = $overrides + self::derive_colors( $styles, $palette );
 
-		/*
-		 * Link colour is the conventional accent source in WP themes —
-		 * it's the one element nearly every theme styles explicitly.
-		 * Falls back to a palette slug literally named `accent` for
-		 * themes that don't restyle links.
-		 */
-		$accent = $overrides['accent'] ?? self::resolve_color(
-			(string) ( $styles['elements']['link']['color']['text'] ?? '' ),
-			$palette
-		);
-
-		if ( null === $accent ) {
-			$accent = self::resolve_palette_accent( $palette );
-		}
-
-		if ( null === $background || null === $foreground || null === $accent ) {
+		if ( null === $colors['background'] || null === $colors['foreground'] || null === $colors['accent'] ) {
 			return null;
 		}
 
 		return array(
 			'$type'            => 'site.standard.theme.basic',
-			'background'       => self::color_object( $background ),
-			'foreground'       => self::color_object( $foreground ),
-			'accent'           => self::color_object( $accent ),
-			'accentForeground' => self::color_object( self::contrast_color( $accent ) ),
+			'background'       => self::color_object( $colors['background'] ),
+			'foreground'       => self::color_object( $colors['foreground'] ),
+			'accent'           => self::color_object( $colors['accent'] ),
+			'accentForeground' => self::color_object( self::contrast_color( $colors['accent'] ) ),
 		);
 	}
 
@@ -458,25 +477,20 @@ class Publication extends Base {
 	 * @return array{r: int, g: int, b: int}|null
 	 */
 	private static function resolve_palette_accent( array $palette ): ?array {
-		if ( isset( $palette['accent'] ) ) {
-			$accent = self::resolve_color( $palette['accent'], $palette );
-
-			if ( null !== $accent ) {
-				return $accent;
-			}
-		}
-
-		$numbered = array();
+		$candidates = array();
 
 		foreach ( $palette as $slug => $value ) {
-			if ( \preg_match( '/^accent-(\d+)$/', (string) $slug, $matches ) ) {
-				$numbered[ (int) $matches[1] ] = $value;
+			if ( 'accent' === $slug ) {
+				// Ranks ahead of every numbered slug.
+				$candidates[-1] = $value;
+			} elseif ( \preg_match( '/^accent-(\d+)$/', (string) $slug, $matches ) ) {
+				$candidates[ (int) $matches[1] ] = $value;
 			}
 		}
 
-		\ksort( $numbered );
+		\ksort( $candidates );
 
-		foreach ( $numbered as $value ) {
+		foreach ( $candidates as $value ) {
 			$accent = self::resolve_color( (string) $value, $palette );
 
 			if ( null !== $accent ) {

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -14,6 +14,7 @@ use Atmosphere\Connectors;
 use Atmosphere\Handle;
 use Atmosphere\OAuth\Client;
 use Atmosphere\Publisher;
+use Atmosphere\Transformer\Publication;
 use function Atmosphere\get_identity;
 use function Atmosphere\get_supported_post_types;
 use function Atmosphere\handle_typeahead_url;
@@ -185,9 +186,27 @@ class Admin {
 		\wp_enqueue_style( 'wp-color-picker' );
 		\wp_enqueue_script( 'wp-color-picker' );
 
+		/*
+		 * Offer the active theme's own palette as swatches: those are the
+		 * colours the publication record would otherwise derive, so the
+		 * common case ("same as my theme, but pinned") is one click.
+		 */
+		$swatches = array();
+
+		foreach ( Publication::get_palette_lookup() as $hex ) {
+			$hex = \sanitize_hex_color( (string) $hex );
+
+			if ( $hex && ! \in_array( $hex, $swatches, true ) ) {
+				$swatches[] = $hex;
+			}
+		}
+
 		\wp_add_inline_script(
 			'wp-color-picker',
-			"jQuery( function ( $ ) { $( '.atmosphere-color-input' ).wpColorPicker(); } );"
+			\sprintf(
+				'jQuery( function ( $ ) { $( ".atmosphere-color-input" ).wpColorPicker( %s ); } );',
+				\wp_json_encode( array( 'palettes' => \array_slice( $swatches, 0, 8 ) ) )
+			)
 		);
 
 		/*

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -182,6 +182,14 @@ class Admin {
 			ATMOSPHERE_VERSION
 		);
 
+		\wp_enqueue_style( 'wp-color-picker' );
+		\wp_enqueue_script( 'wp-color-picker' );
+
+		\wp_add_inline_script(
+			'wp-color-picker',
+			"jQuery( function ( $ ) { $( '.atmosphere-color-input' ).wpColorPicker(); } );"
+		);
+
 		/*
 		 * The connect handle field — and so the typeahead that enhances it —
 		 * only renders while disconnected.

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -580,7 +580,7 @@ class Settings_Fields {
 	 * Render the Publication theme section description.
 	 */
 	public static function render_publication_theme_section(): void {
-		echo '<p>' . \esc_html__( 'Choose the colors apps use when they display your site. Leave a field blank to keep the matching color from your active WordPress theme. If a color cannot be read from your theme, set all three here so your colors are published.', 'atmosphere' ) . '</p>';
+		echo '<p>' . \esc_html__( 'Choose the colors apps use when they display your site. Empty a field to go back to the matching color from your active WordPress theme. If a color cannot be read from your theme, set all three here so your colors are published.', 'atmosphere' ) . '</p>';
 	}
 
 	/**
@@ -605,6 +605,7 @@ class Settings_Fields {
 			id="<?php echo \esc_attr( $option ); ?>"
 			class="atmosphere-color-input"
 			value="<?php echo \esc_attr( (string) \get_option( $option, '' ) ); ?>"
+			data-default-color="<?php echo \esc_attr( $derived ); ?>"
 		>
 		<p class="description">
 			<?php echo \esc_html( (string) ( $args['description'] ?? '' ) ); ?>

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -126,14 +126,17 @@ class Settings_Fields {
 
 		$theme_color_fields = array(
 			Publication::OPTION_THEME_BACKGROUND => array(
+				'key'         => 'background',
 				'label'       => \__( 'Background color', 'atmosphere' ),
 				'description' => \__( 'Overrides the publication background color.', 'atmosphere' ),
 			),
 			Publication::OPTION_THEME_FOREGROUND => array(
+				'key'         => 'foreground',
 				'label'       => \__( 'Foreground color', 'atmosphere' ),
 				'description' => \__( 'Overrides the publication foreground/text color.', 'atmosphere' ),
 			),
 			Publication::OPTION_THEME_ACCENT     => array(
+				'key'         => 'accent',
 				'label'       => \__( 'Accent color', 'atmosphere' ),
 				'description' => \__( 'Overrides the publication accent color. Accent foreground is computed automatically for contrast.', 'atmosphere' ),
 			),
@@ -150,6 +153,7 @@ class Settings_Fields {
 					// Ties the row's <th> label to the input for screen readers.
 					'label_for'   => $option,
 					'option'      => $option,
+					'key'         => $field['key'],
 					'description' => $field['description'],
 				)
 			);
@@ -576,7 +580,7 @@ class Settings_Fields {
 	 * Render the Publication theme section description.
 	 */
 	public static function render_publication_theme_section(): void {
-		echo '<p>' . \esc_html__( 'Choose the colors apps use when they display your site. Leave a field blank to keep the matching color from your active WordPress theme — but if a color cannot be read from your theme, set all three here so your colors are published.', 'atmosphere' ) . '</p>';
+		echo '<p>' . \esc_html__( 'Choose the colors apps use when they display your site. Leave a field blank to keep the matching color from your active WordPress theme. If a color cannot be read from your theme, set all three here so your colors are published.', 'atmosphere' ) . '</p>';
 	}
 
 	/**
@@ -586,10 +590,13 @@ class Settings_Fields {
 	 */
 	public static function render_publication_theme_color_field( array $args ): void {
 		$option = (string) ( $args['option'] ?? '' );
+		$key    = (string) ( $args['key'] ?? '' );
 
 		if ( '' === $option ) {
 			return;
 		}
+
+		$derived = Publication::get_derived_theme_colors()[ $key ] ?? '';
 
 		?>
 		<input
@@ -598,8 +605,24 @@ class Settings_Fields {
 			id="<?php echo \esc_attr( $option ); ?>"
 			class="atmosphere-color-input"
 			value="<?php echo \esc_attr( (string) \get_option( $option, '' ) ); ?>"
+			data-default-color="<?php echo \esc_attr( $derived ); ?>"
 		>
-		<p class="description"><?php echo \esc_html( (string) ( $args['description'] ?? '' ) ); ?></p>
+		<p class="description">
+			<?php echo \esc_html( (string) ( $args['description'] ?? '' ) ); ?>
+			<?php if ( '' !== $derived ) : ?>
+				<br>
+				<?php
+				\printf(
+					/* translators: %s: hex color derived from the active theme, e.g. #ffffff. */
+					\esc_html__( 'Your theme currently provides %s.', 'atmosphere' ),
+					'<code>' . \esc_html( $derived ) . '</code>'
+				);
+				?>
+			<?php else : ?>
+				<br>
+				<strong><?php \esc_html_e( 'Your theme does not provide this color. Set it here, along with the other two, for any colors to be published.', 'atmosphere' ); ?></strong>
+			<?php endif; ?>
+		</p>
 		<?php
 	}
 

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -119,7 +119,7 @@ class Settings_Fields {
 		// Publication theme section.
 		\add_settings_section(
 			'atmosphere_publication_theme',
-			\__( 'Publication theme', 'atmosphere' ),
+			\__( 'Theme', 'atmosphere' ),
 			array( self::class, 'render_publication_theme_section' ),
 			'atmosphere'
 		);

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -140,7 +140,12 @@ class Settings_Fields {
 		);
 
 		foreach ( Publication::get_theme_color_options() as $key => $option ) {
-			list( $label, $description ) = $theme_color_labels[ $key ];
+			/*
+			 * Falls back to the raw option name so a channel added to the
+			 * canonical map without a label here still renders — visibly
+			 * unlabelled, rather than warning and rendering blank.
+			 */
+			list( $label, $description ) = $theme_color_labels[ $key ] ?? array( $option, '' );
 
 			\add_settings_field(
 				$option,

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -16,6 +16,7 @@ use Atmosphere\Content_Parser\Markpub;
 use Atmosphere\Content_Parser\Pckt;
 use Atmosphere\Content_Parser\Registry;
 use Atmosphere\Handle;
+use Atmosphere\Transformer\Publication;
 use function Atmosphere\get_connection;
 use function Atmosphere\get_supported_post_types;
 use function Atmosphere\has_identity;
@@ -113,6 +114,38 @@ class Settings_Fields {
 			array( self::class, 'render_content_format_field' ),
 			'atmosphere',
 			'atmosphere_publishing'
+		);
+
+		// Publication theme section.
+		\add_settings_section(
+			'atmosphere_publication_theme',
+			\__( 'Publication theme', 'atmosphere' ),
+			array( self::class, 'render_publication_theme_section' ),
+			'atmosphere'
+		);
+
+		\add_settings_field(
+			Publication::OPTION_THEME_BACKGROUND,
+			\__( 'Background color', 'atmosphere' ),
+			array( self::class, 'render_publication_theme_background_field' ),
+			'atmosphere',
+			'atmosphere_publication_theme'
+		);
+
+		\add_settings_field(
+			Publication::OPTION_THEME_FOREGROUND,
+			\__( 'Foreground color', 'atmosphere' ),
+			array( self::class, 'render_publication_theme_foreground_field' ),
+			'atmosphere',
+			'atmosphere_publication_theme'
+		);
+
+		\add_settings_field(
+			Publication::OPTION_THEME_ACCENT,
+			\__( 'Accent color', 'atmosphere' ),
+			array( self::class, 'render_publication_theme_accent_field' ),
+			'atmosphere',
+			'atmosphere_publication_theme'
 		);
 
 		// Reactions section.
@@ -529,6 +562,64 @@ class Settings_Fields {
 	public static function render_reactions_section(): void {
 		?>
 		<p><?php \esc_html_e( 'Choose which interactions are sent to Bluesky and which are saved to WordPress.', 'atmosphere' ); ?></p>
+		<?php
+	}
+
+	/**
+	 * Render the Publication theme section description.
+	 */
+	public static function render_publication_theme_section(): void {
+		echo '<p>' . \esc_html__( 'Set custom colors for your standard.site basic theme. Leave a field blank to keep the color derived from your active WordPress theme.', 'atmosphere' ) . '</p>';
+	}
+
+	/**
+	 * Render the publication background color field.
+	 */
+	public static function render_publication_theme_background_field(): void {
+		$value = (string) \get_option( Publication::OPTION_THEME_BACKGROUND, '' );
+		?>
+		<input
+			type="text"
+			name="<?php echo \esc_attr( Publication::OPTION_THEME_BACKGROUND ); ?>"
+			id="<?php echo \esc_attr( Publication::OPTION_THEME_BACKGROUND ); ?>"
+			class="atmosphere-color-input"
+			value="<?php echo \esc_attr( $value ); ?>"
+		>
+		<p class="description"><?php \esc_html_e( 'Overrides the publication background color.', 'atmosphere' ); ?></p>
+		<?php
+	}
+
+	/**
+	 * Render the publication foreground color field.
+	 */
+	public static function render_publication_theme_foreground_field(): void {
+		$value = (string) \get_option( Publication::OPTION_THEME_FOREGROUND, '' );
+		?>
+		<input
+			type="text"
+			name="<?php echo \esc_attr( Publication::OPTION_THEME_FOREGROUND ); ?>"
+			id="<?php echo \esc_attr( Publication::OPTION_THEME_FOREGROUND ); ?>"
+			class="atmosphere-color-input"
+			value="<?php echo \esc_attr( $value ); ?>"
+		>
+		<p class="description"><?php \esc_html_e( 'Overrides the publication foreground/text color.', 'atmosphere' ); ?></p>
+		<?php
+	}
+
+	/**
+	 * Render the publication accent color field.
+	 */
+	public static function render_publication_theme_accent_field(): void {
+		$value = (string) \get_option( Publication::OPTION_THEME_ACCENT, '' );
+		?>
+		<input
+			type="text"
+			name="<?php echo \esc_attr( Publication::OPTION_THEME_ACCENT ); ?>"
+			id="<?php echo \esc_attr( Publication::OPTION_THEME_ACCENT ); ?>"
+			class="atmosphere-color-input"
+			value="<?php echo \esc_attr( $value ); ?>"
+		>
+		<p class="description"><?php \esc_html_e( 'Overrides the publication accent color. Accent foreground is computed automatically for contrast.', 'atmosphere' ); ?></p>
 		<?php
 	}
 

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -124,29 +124,36 @@ class Settings_Fields {
 			'atmosphere'
 		);
 
-		\add_settings_field(
-			Publication::OPTION_THEME_BACKGROUND,
-			\__( 'Background color', 'atmosphere' ),
-			array( self::class, 'render_publication_theme_background_field' ),
-			'atmosphere',
-			'atmosphere_publication_theme'
+		$theme_color_fields = array(
+			Publication::OPTION_THEME_BACKGROUND => array(
+				'label'       => \__( 'Background color', 'atmosphere' ),
+				'description' => \__( 'Overrides the publication background color.', 'atmosphere' ),
+			),
+			Publication::OPTION_THEME_FOREGROUND => array(
+				'label'       => \__( 'Foreground color', 'atmosphere' ),
+				'description' => \__( 'Overrides the publication foreground/text color.', 'atmosphere' ),
+			),
+			Publication::OPTION_THEME_ACCENT     => array(
+				'label'       => \__( 'Accent color', 'atmosphere' ),
+				'description' => \__( 'Overrides the publication accent color. Accent foreground is computed automatically for contrast.', 'atmosphere' ),
+			),
 		);
 
-		\add_settings_field(
-			Publication::OPTION_THEME_FOREGROUND,
-			\__( 'Foreground color', 'atmosphere' ),
-			array( self::class, 'render_publication_theme_foreground_field' ),
-			'atmosphere',
-			'atmosphere_publication_theme'
-		);
-
-		\add_settings_field(
-			Publication::OPTION_THEME_ACCENT,
-			\__( 'Accent color', 'atmosphere' ),
-			array( self::class, 'render_publication_theme_accent_field' ),
-			'atmosphere',
-			'atmosphere_publication_theme'
-		);
+		foreach ( $theme_color_fields as $option => $field ) {
+			\add_settings_field(
+				$option,
+				$field['label'],
+				array( self::class, 'render_publication_theme_color_field' ),
+				'atmosphere',
+				'atmosphere_publication_theme',
+				array(
+					// Ties the row's <th> label to the input for screen readers.
+					'label_for'   => $option,
+					'option'      => $option,
+					'description' => $field['description'],
+				)
+			);
+		}
 
 		// Reactions section.
 		\add_settings_section(
@@ -569,57 +576,30 @@ class Settings_Fields {
 	 * Render the Publication theme section description.
 	 */
 	public static function render_publication_theme_section(): void {
-		echo '<p>' . \esc_html__( 'Set custom colors for your standard.site basic theme. Leave a field blank to keep the color derived from your active WordPress theme.', 'atmosphere' ) . '</p>';
+		echo '<p>' . \esc_html__( 'Choose the colors apps use when they display your site. Leave a field blank to keep the matching color from your active WordPress theme — but if a color cannot be read from your theme, set all three here so your colors are published.', 'atmosphere' ) . '</p>';
 	}
 
 	/**
-	 * Render the publication background color field.
+	 * Render a publication theme color field.
+	 *
+	 * @param array $args Field args: `option` and `description`.
 	 */
-	public static function render_publication_theme_background_field(): void {
-		$value = (string) \get_option( Publication::OPTION_THEME_BACKGROUND, '' );
-		?>
-		<input
-			type="text"
-			name="<?php echo \esc_attr( Publication::OPTION_THEME_BACKGROUND ); ?>"
-			id="<?php echo \esc_attr( Publication::OPTION_THEME_BACKGROUND ); ?>"
-			class="atmosphere-color-input"
-			value="<?php echo \esc_attr( $value ); ?>"
-		>
-		<p class="description"><?php \esc_html_e( 'Overrides the publication background color.', 'atmosphere' ); ?></p>
-		<?php
-	}
+	public static function render_publication_theme_color_field( array $args ): void {
+		$option = (string) ( $args['option'] ?? '' );
 
-	/**
-	 * Render the publication foreground color field.
-	 */
-	public static function render_publication_theme_foreground_field(): void {
-		$value = (string) \get_option( Publication::OPTION_THEME_FOREGROUND, '' );
-		?>
-		<input
-			type="text"
-			name="<?php echo \esc_attr( Publication::OPTION_THEME_FOREGROUND ); ?>"
-			id="<?php echo \esc_attr( Publication::OPTION_THEME_FOREGROUND ); ?>"
-			class="atmosphere-color-input"
-			value="<?php echo \esc_attr( $value ); ?>"
-		>
-		<p class="description"><?php \esc_html_e( 'Overrides the publication foreground/text color.', 'atmosphere' ); ?></p>
-		<?php
-	}
+		if ( '' === $option ) {
+			return;
+		}
 
-	/**
-	 * Render the publication accent color field.
-	 */
-	public static function render_publication_theme_accent_field(): void {
-		$value = (string) \get_option( Publication::OPTION_THEME_ACCENT, '' );
 		?>
 		<input
 			type="text"
-			name="<?php echo \esc_attr( Publication::OPTION_THEME_ACCENT ); ?>"
-			id="<?php echo \esc_attr( Publication::OPTION_THEME_ACCENT ); ?>"
+			name="<?php echo \esc_attr( $option ); ?>"
+			id="<?php echo \esc_attr( $option ); ?>"
 			class="atmosphere-color-input"
-			value="<?php echo \esc_attr( $value ); ?>"
+			value="<?php echo \esc_attr( (string) \get_option( $option, '' ) ); ?>"
 		>
-		<p class="description"><?php \esc_html_e( 'Overrides the publication accent color. Accent foreground is computed automatically for contrast.', 'atmosphere' ); ?></p>
+		<p class="description"><?php echo \esc_html( (string) ( $args['description'] ?? '' ) ); ?></p>
 		<?php
 	}
 

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -124,28 +124,27 @@ class Settings_Fields {
 			'atmosphere'
 		);
 
-		$theme_color_fields = array(
-			Publication::OPTION_THEME_BACKGROUND => array(
-				'key'         => 'background',
-				'label'       => \__( 'Background color', 'atmosphere' ),
-				'description' => \__( 'Overrides the publication background color.', 'atmosphere' ),
+		$theme_color_labels = array(
+			'background' => array(
+				\__( 'Background color', 'atmosphere' ),
+				\__( 'Overrides the publication background color.', 'atmosphere' ),
 			),
-			Publication::OPTION_THEME_FOREGROUND => array(
-				'key'         => 'foreground',
-				'label'       => \__( 'Foreground color', 'atmosphere' ),
-				'description' => \__( 'Overrides the publication foreground/text color.', 'atmosphere' ),
+			'foreground' => array(
+				\__( 'Foreground color', 'atmosphere' ),
+				\__( 'Overrides the publication foreground/text color.', 'atmosphere' ),
 			),
-			Publication::OPTION_THEME_ACCENT     => array(
-				'key'         => 'accent',
-				'label'       => \__( 'Accent color', 'atmosphere' ),
-				'description' => \__( 'Overrides the publication accent color. Accent foreground is computed automatically for contrast.', 'atmosphere' ),
+			'accent'     => array(
+				\__( 'Accent color', 'atmosphere' ),
+				\__( 'Overrides the publication accent color. Accent foreground is computed automatically for contrast.', 'atmosphere' ),
 			),
 		);
 
-		foreach ( $theme_color_fields as $option => $field ) {
+		foreach ( Publication::get_theme_color_options() as $key => $option ) {
+			list( $label, $description ) = $theme_color_labels[ $key ];
+
 			\add_settings_field(
 				$option,
-				$field['label'],
+				$label,
 				array( self::class, 'render_publication_theme_color_field' ),
 				'atmosphere',
 				'atmosphere_publication_theme',
@@ -153,8 +152,8 @@ class Settings_Fields {
 					// Ties the row's <th> label to the input for screen readers.
 					'label_for'   => $option,
 					'option'      => $option,
-					'key'         => $field['key'],
-					'description' => $field['description'],
+					'key'         => $key,
+					'description' => $description,
 				)
 			);
 		}
@@ -597,19 +596,14 @@ class Settings_Fields {
 	public static function render_publication_theme_color_field( array $args ): void {
 		static $derived_colors = null;
 
-		$option = (string) ( $args['option'] ?? '' );
-		$key    = (string) ( $args['key'] ?? '' );
-
-		if ( '' === $option ) {
-			return;
-		}
-
-		// Resolved once per request; all three fields render on the same screen.
+		// Resolved once per request; all three fields render on the same
+		// screen and the derivation runs an uncached theme.json merge.
 		if ( null === $derived_colors ) {
 			$derived_colors = Publication::get_derived_theme_colors();
 		}
 
-		$derived = $derived_colors[ $key ] ?? '';
+		$option  = $args['option'];
+		$derived = $derived_colors[ $args['key'] ] ?? '';
 
 		?>
 		<input

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -605,7 +605,6 @@ class Settings_Fields {
 			id="<?php echo \esc_attr( $option ); ?>"
 			class="atmosphere-color-input"
 			value="<?php echo \esc_attr( (string) \get_option( $option, '' ) ); ?>"
-			data-default-color="<?php echo \esc_attr( $derived ); ?>"
 		>
 		<p class="description">
 			<?php echo \esc_html( (string) ( $args['description'] ?? '' ) ); ?>

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -586,9 +586,17 @@ class Settings_Fields {
 	/**
 	 * Render a publication theme color field.
 	 *
-	 * @param array $args Field args: `option` and `description`.
+	 * @param array $args {
+	 *     Field arguments.
+	 *
+	 *     @type string $option      Option name to read and save.
+	 *     @type string $key         Derived-color key: background, foreground, or accent.
+	 *     @type string $description Help text shown under the input.
+	 * }
 	 */
 	public static function render_publication_theme_color_field( array $args ): void {
+		static $derived_colors = null;
+
 		$option = (string) ( $args['option'] ?? '' );
 		$key    = (string) ( $args['key'] ?? '' );
 
@@ -596,7 +604,12 @@ class Settings_Fields {
 			return;
 		}
 
-		$derived = Publication::get_derived_theme_colors()[ $key ] ?? '';
+		// Resolved once per request; all three fields render on the same screen.
+		if ( null === $derived_colors ) {
+			$derived_colors = Publication::get_derived_theme_colors();
+		}
+
+		$derived = $derived_colors[ $key ] ?? '';
 
 		?>
 		<input

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -2264,16 +2264,26 @@ class Test_Atmosphere extends WP_UnitTestCase {
 	 * trigger set so a future refactor can't silently drop one.
 	 */
 	public function test_init_wires_publication_sync_triggers() {
+		$option_triggers = \array_merge(
+			array( 'blogname', 'blogdescription', 'site_icon', 'home', 'siteurl' ),
+			\array_values( \Atmosphere\Transformer\Publication::get_theme_color_options() )
+		);
+
 		$triggers = array(
-			'update_option_blogname',
-			'update_option_blogdescription',
-			'update_option_site_icon',
-			'update_option_home',
-			'update_option_siteurl',
 			'switch_theme',
 			'save_post_wp_global_styles',
 			'customize_save_after',
 		);
+
+		/*
+		 * Both hooks per option: an option with no row yet is written by
+		 * `add_option()`, where `update_option_*` never fires — the case a
+		 * plugin option hits the first time it is saved.
+		 */
+		foreach ( $option_triggers as $option ) {
+			$triggers[] = 'add_option_' . $option;
+			$triggers[] = 'update_option_' . $option;
+		}
 
 		$this->atmosphere->init();
 

--- a/tests/phpunit/tests/transformer/class-test-publication.php
+++ b/tests/phpunit/tests/transformer/class-test-publication.php
@@ -22,8 +22,12 @@ class Test_Publication extends \WP_UnitTestCase {
 	public function tear_down(): void {
 		\remove_all_filters( 'atmosphere_publication_labels' );
 		\remove_all_filters( 'atmosphere_publication_show_in_discover' );
+		\remove_all_filters( 'atmosphere_publication_basic_theme' );
 		\delete_option( 'site_icon' );
 		\update_option( 'blog_public', 1 );
+		\delete_option( Publication::OPTION_THEME_BACKGROUND );
+		\delete_option( Publication::OPTION_THEME_FOREGROUND );
+		\delete_option( Publication::OPTION_THEME_ACCENT );
 
 		parent::tear_down();
 	}
@@ -630,6 +634,87 @@ class Test_Publication extends \WP_UnitTestCase {
 			$dark['accentForeground'],
 			'Dark accent should yield white foreground.'
 		);
+	}
+
+	/**
+	 * Stored publication-theme options override the derived theme colors.
+	 */
+	public function test_publication_theme_options_override_basic_theme_colors() {
+		\update_option( Publication::OPTION_THEME_BACKGROUND, '#112233' );
+		\update_option( Publication::OPTION_THEME_FOREGROUND, '#fafafa' );
+		\update_option( Publication::OPTION_THEME_ACCENT, '#ff0000' );
+
+		$record = ( new Publication( null ) )->transform();
+
+		$this->assertArrayHasKey( 'basicTheme', $record );
+		$this->assertSame( 17, $record['basicTheme']['background']['r'] );
+		$this->assertSame( 34, $record['basicTheme']['background']['g'] );
+		$this->assertSame( 51, $record['basicTheme']['background']['b'] );
+		$this->assertSame( 250, $record['basicTheme']['foreground']['r'] );
+		$this->assertSame( 250, $record['basicTheme']['foreground']['g'] );
+		$this->assertSame( 250, $record['basicTheme']['foreground']['b'] );
+		$this->assertSame( 255, $record['basicTheme']['accent']['r'] );
+		$this->assertSame( 0, $record['basicTheme']['accent']['g'] );
+		$this->assertSame( 0, $record['basicTheme']['accent']['b'] );
+
+		// Red is dark enough to require a white accent foreground at our threshold.
+		$this->assertSame( 255, $record['basicTheme']['accentForeground']['r'] );
+		$this->assertSame( 255, $record['basicTheme']['accentForeground']['g'] );
+		$this->assertSame( 255, $record['basicTheme']['accentForeground']['b'] );
+	}
+
+	/**
+	 * The dedicated basicTheme filter can override the transformed value.
+	 */
+	public function test_publication_basic_theme_filter_overrides_theme() {
+		\add_filter(
+			'atmosphere_publication_basic_theme',
+			static function () {
+				return array(
+					'$type'            => 'site.standard.theme.basic',
+					'background'       => array(
+						'$type' => 'site.standard.theme.color#rgb',
+						'r'     => 1,
+						'g'     => 2,
+						'b'     => 3,
+					),
+					'foreground'       => array(
+						'$type' => 'site.standard.theme.color#rgb',
+						'r'     => 4,
+						'g'     => 5,
+						'b'     => 6,
+					),
+					'accent'           => array(
+						'$type' => 'site.standard.theme.color#rgb',
+						'r'     => 7,
+						'g'     => 8,
+						'b'     => 9,
+					),
+					'accentForeground' => array(
+						'$type' => 'site.standard.theme.color#rgb',
+						'r'     => 10,
+						'g'     => 11,
+						'b'     => 12,
+					),
+				);
+			}
+		);
+
+		$record = ( new Publication( null ) )->transform();
+
+		$this->assertSame( 1, $record['basicTheme']['background']['r'] );
+		$this->assertSame( 10, $record['basicTheme']['accentForeground']['r'] );
+	}
+
+	/**
+	 * A null return from the basicTheme filter omits the field.
+	 */
+	public function test_publication_basic_theme_filter_can_omit_basic_theme() {
+		\add_filter( 'atmosphere_publication_basic_theme', '__return_null' );
+
+		$record = ( new Publication( null ) )->transform();
+
+		$this->assertArrayNotHasKey( 'basicTheme', $record );
 	}
 
 	/**

--- a/tests/phpunit/tests/transformer/class-test-publication.php
+++ b/tests/phpunit/tests/transformer/class-test-publication.php
@@ -664,12 +664,13 @@ class Test_Publication extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Themes that style links with `currentColor` and number their accent
-	 * palette slugs — Twenty Twenty-Five, the default theme, does both —
-	 * still yield an accent, and therefore a complete theme object.
+	 * Global styles for a theme that styles links with `currentColor`,
+	 * leaving the accent to come from the palette.
+	 *
+	 * @return array
 	 */
-	public function test_build_basic_theme_falls_back_to_numbered_palette_accent() {
-		$styles = array(
+	private static function styles_with_current_color_link(): array {
+		return array(
 			'color'    => array(
 				'background' => '#ffffff',
 				'text'       => '#111111',
@@ -678,7 +679,14 @@ class Test_Publication extends \WP_UnitTestCase {
 				'link' => array( 'color' => array( 'text' => 'currentColor' ) ),
 			),
 		);
+	}
 
+	/**
+	 * Themes that style links with `currentColor` and number their accent
+	 * palette slugs — Twenty Twenty-Five, the default theme, does both —
+	 * still yield an accent, and therefore a complete theme object.
+	 */
+	public function test_build_basic_theme_falls_back_to_numbered_palette_accent() {
 		$palette = array(
 			'base'     => '#ffffff',
 			'contrast' => '#111111',
@@ -686,7 +694,7 @@ class Test_Publication extends \WP_UnitTestCase {
 			'accent-2' => '#f6cff4',
 		);
 
-		$theme = Publication::build_basic_theme( $styles, $palette );
+		$theme = Publication::build_basic_theme( self::styles_with_current_color_link(), $palette );
 
 		$this->assertNotNull( $theme, 'A numbered accent slug must satisfy the accent requirement.' );
 		$this->assertSame( 255, $theme['accent']['r'] );
@@ -699,22 +707,12 @@ class Test_Publication extends \WP_UnitTestCase {
 	 * picking a numbered accent.
 	 */
 	public function test_build_basic_theme_skips_unresolvable_palette_accents() {
-		$styles = array(
-			'color'    => array(
-				'background' => '#ffffff',
-				'text'       => '#111111',
-			),
-			'elements' => array(
-				'link' => array( 'color' => array( 'text' => 'currentColor' ) ),
-			),
-		);
-
 		$palette = array(
 			'accent-1' => 'color-mix(in srgb, currentColor 20%, transparent)',
 			'accent-2' => '#0693e3',
 		);
 
-		$theme = Publication::build_basic_theme( $styles, $palette );
+		$theme = Publication::build_basic_theme( self::styles_with_current_color_link(), $palette );
 
 		$this->assertNotNull( $theme );
 		$this->assertSame( 6, $theme['accent']['r'] );
@@ -813,52 +811,30 @@ class Test_Publication extends \WP_UnitTestCase {
 	 * theme object from the record.
 	 */
 	public function test_publication_theme_option_ignores_unparseable_value() {
+		$derived = ( new Publication( null ) )->transform()['basicTheme'] ?? null;
+
 		\update_option( Publication::OPTION_THEME_ACCENT, 'not-a-color' );
 
-		$this->assertSame( array(), Publication::get_theme_option_overrides() );
+		$this->assertSame(
+			$derived,
+			( new Publication( null ) )->transform()['basicTheme'] ?? null,
+			'A malformed stored color must fall through to the derived theme.'
+		);
 	}
 
 	/**
 	 * The dedicated basicTheme filter can override the transformed value.
 	 */
 	public function test_publication_basic_theme_filter_overrides_theme() {
-		\add_filter(
-			'atmosphere_publication_basic_theme',
-			static function () {
-				return array(
-					'$type'            => 'site.standard.theme.basic',
-					'background'       => array(
-						'$type' => 'site.standard.theme.color#rgb',
-						'r'     => 1,
-						'g'     => 2,
-						'b'     => 3,
-					),
-					'foreground'       => array(
-						'$type' => 'site.standard.theme.color#rgb',
-						'r'     => 4,
-						'g'     => 5,
-						'b'     => 6,
-					),
-					'accent'           => array(
-						'$type' => 'site.standard.theme.color#rgb',
-						'r'     => 7,
-						'g'     => 8,
-						'b'     => 9,
-					),
-					'accentForeground' => array(
-						'$type' => 'site.standard.theme.color#rgb',
-						'r'     => 10,
-						'g'     => 11,
-						'b'     => 12,
-					),
-				);
-			}
-		);
+		// The filter's return value is passed through untouched, so the
+		// fixture only has to be distinguishable from a derived theme.
+		$replacement = array( 'background' => array( 'r' => 1 ) );
+
+		\add_filter( 'atmosphere_publication_basic_theme', static fn() => $replacement );
 
 		$record = ( new Publication( null ) )->transform();
 
-		$this->assertSame( 1, $record['basicTheme']['background']['r'] );
-		$this->assertSame( 10, $record['basicTheme']['accentForeground']['r'] );
+		$this->assertSame( $replacement, $record['basicTheme'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/transformer/class-test-publication.php
+++ b/tests/phpunit/tests/transformer/class-test-publication.php
@@ -664,6 +664,102 @@ class Test_Publication extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A single stored override replaces only its own colour; the rest
+	 * stay derived from the active theme.
+	 */
+	public function test_publication_theme_option_overrides_single_color() {
+		$styles = array(
+			'color'    => array(
+				'background' => '#ffffff',
+				'text'       => '#111111',
+			),
+			'elements' => array(
+				'link' => array( 'color' => array( 'text' => '#0000ff' ) ),
+			),
+		);
+
+		$derived = Publication::build_basic_theme( $styles, array() );
+		$merged  = Publication::build_basic_theme(
+			$styles,
+			array(),
+			array(
+				'accent' => array(
+					'r' => 255,
+					'g' => 0,
+					'b' => 0,
+				),
+			)
+		);
+
+		// Background and foreground keep the derived values.
+		$this->assertSame( $derived['background'], $merged['background'] );
+		$this->assertSame( $derived['foreground'], $merged['foreground'] );
+
+		// Only the accent changes — and its contrast colour is recomputed.
+		$this->assertSame( 255, $merged['accent']['r'] );
+		$this->assertSame( 0, $merged['accent']['g'] );
+		$this->assertSame( 255, $merged['accentForeground']['r'] );
+	}
+
+	/**
+	 * Overrides still apply when the active theme exposes no usable
+	 * colours, as long as all three are set — otherwise the record has
+	 * no complete theme to publish.
+	 */
+	public function test_publication_theme_options_apply_without_derivable_theme() {
+		$this->assertNull( Publication::build_basic_theme( array(), array() ) );
+
+		$complete = Publication::build_basic_theme(
+			array(),
+			array(),
+			array(
+				'background' => array(
+					'r' => 1,
+					'g' => 2,
+					'b' => 3,
+				),
+				'foreground' => array(
+					'r' => 4,
+					'g' => 5,
+					'b' => 6,
+				),
+				'accent'     => array(
+					'r' => 7,
+					'g' => 8,
+					'b' => 9,
+				),
+			)
+		);
+
+		$this->assertSame( 1, $complete['background']['r'] );
+		$this->assertSame( 'site.standard.theme.basic', $complete['$type'] );
+
+		$partial = Publication::build_basic_theme(
+			array(),
+			array(),
+			array(
+				'accent' => array(
+					'r' => 7,
+					'g' => 8,
+					'b' => 9,
+				),
+			)
+		);
+
+		$this->assertNull( $partial, 'An incomplete theme must be omitted rather than half-published.' );
+	}
+
+	/**
+	 * A malformed stored value is ignored rather than dropping the whole
+	 * theme object from the record.
+	 */
+	public function test_publication_theme_option_ignores_unparseable_value() {
+		\update_option( Publication::OPTION_THEME_ACCENT, 'not-a-color' );
+
+		$this->assertSame( array(), Publication::get_theme_option_overrides() );
+	}
+
+	/**
 	 * The dedicated basicTheme filter can override the transformed value.
 	 */
 	public function test_publication_basic_theme_filter_overrides_theme() {

--- a/tests/phpunit/tests/transformer/class-test-publication.php
+++ b/tests/phpunit/tests/transformer/class-test-publication.php
@@ -664,6 +664,65 @@ class Test_Publication extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Themes that style links with `currentColor` and number their accent
+	 * palette slugs — Twenty Twenty-Five, the default theme, does both —
+	 * still yield an accent, and therefore a complete theme object.
+	 */
+	public function test_build_basic_theme_falls_back_to_numbered_palette_accent() {
+		$styles = array(
+			'color'    => array(
+				'background' => '#ffffff',
+				'text'       => '#111111',
+			),
+			'elements' => array(
+				'link' => array( 'color' => array( 'text' => 'currentColor' ) ),
+			),
+		);
+
+		$palette = array(
+			'base'     => '#ffffff',
+			'contrast' => '#111111',
+			'accent-1' => '#ffee58',
+			'accent-2' => '#f6cff4',
+		);
+
+		$theme = Publication::build_basic_theme( $styles, $palette );
+
+		$this->assertNotNull( $theme, 'A numbered accent slug must satisfy the accent requirement.' );
+		$this->assertSame( 255, $theme['accent']['r'] );
+		$this->assertSame( 238, $theme['accent']['g'] );
+		$this->assertSame( 88, $theme['accent']['b'] );
+	}
+
+	/**
+	 * Palette entries that are not plain colours are skipped when
+	 * picking a numbered accent.
+	 */
+	public function test_build_basic_theme_skips_unresolvable_palette_accents() {
+		$styles = array(
+			'color'    => array(
+				'background' => '#ffffff',
+				'text'       => '#111111',
+			),
+			'elements' => array(
+				'link' => array( 'color' => array( 'text' => 'currentColor' ) ),
+			),
+		);
+
+		$palette = array(
+			'accent-1' => 'color-mix(in srgb, currentColor 20%, transparent)',
+			'accent-2' => '#0693e3',
+		);
+
+		$theme = Publication::build_basic_theme( $styles, $palette );
+
+		$this->assertNotNull( $theme );
+		$this->assertSame( 6, $theme['accent']['r'] );
+		$this->assertSame( 147, $theme['accent']['g'] );
+		$this->assertSame( 227, $theme['accent']['b'] );
+	}
+
+	/**
 	 * A single stored override replaces only its own colour; the rest
 	 * stay derived from the active theme.
 	 */

--- a/tests/phpunit/tests/wp-admin/class-test-theme-color-setting.php
+++ b/tests/phpunit/tests/wp-admin/class-test-theme-color-setting.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Tests for publication theme color setting sanitization.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group settings
+ */
+
+namespace Atmosphere\Tests\WP_Admin;
+
+use Atmosphere\Sanitize;
+
+/**
+ * Theme color setting sanitization tests.
+ */
+class Test_Theme_Color_Setting extends \WP_UnitTestCase {
+
+	/**
+	 * Valid hex values are normalized to six-character lowercase form.
+	 */
+	public function test_hex_color_accepts_valid_values() {
+		$this->assertSame( '#ff8800', Sanitize::hex_color( '#ff8800' ) );
+		$this->assertSame( '#ff8800', Sanitize::hex_color( '#F80' ) );
+		$this->assertSame( '#112233', Sanitize::hex_color( ' #112233 ' ) );
+	}
+
+	/**
+	 * Invalid values sanitize to empty string.
+	 */
+	public function test_hex_color_rejects_invalid_values() {
+		$this->assertSame( '', Sanitize::hex_color( 'nope' ) );
+		$this->assertSame( '', Sanitize::hex_color( '#zzzzzz' ) );
+		$this->assertSame( '', Sanitize::hex_color( 'rgb(1,2,3)' ) );
+		$this->assertSame( '', Sanitize::hex_color( null ) );
+		$this->assertSame( '', Sanitize::hex_color( array( '#fff' ) ) );
+	}
+
+	/**
+	 * Empty input remains empty so derived theme values can be used.
+	 */
+	public function test_hex_color_allows_empty_value() {
+		$this->assertSame( '', Sanitize::hex_color( '' ) );
+	}
+}

--- a/tests/phpunit/tests/wp-admin/class-test-theme-color-setting.php
+++ b/tests/phpunit/tests/wp-admin/class-test-theme-color-setting.php
@@ -9,12 +9,25 @@
 
 namespace Atmosphere\Tests\WP_Admin;
 
+use Atmosphere\Options;
 use Atmosphere\Sanitize;
+use Atmosphere\Transformer\Publication;
 
 /**
  * Theme color setting sanitization tests.
  */
 class Test_Theme_Color_Setting extends \WP_UnitTestCase {
+
+	/**
+	 * Clear stored theme colors between tests.
+	 */
+	public function tear_down(): void {
+		\delete_option( Publication::OPTION_THEME_BACKGROUND );
+		\delete_option( Publication::OPTION_THEME_FOREGROUND );
+		\delete_option( Publication::OPTION_THEME_ACCENT );
+
+		parent::tear_down();
+	}
 
 	/**
 	 * Valid hex values are normalized to six-character lowercase form.
@@ -41,5 +54,32 @@ class Test_Theme_Color_Setting extends \WP_UnitTestCase {
 	 */
 	public function test_hex_color_allows_empty_value() {
 		$this->assertSame( '', Sanitize::hex_color( '' ) );
+	}
+
+	/**
+	 * The sanitizer is actually wired to the registered setting, so a
+	 * malformed value never reaches the database.
+	 */
+	public function test_registered_setting_sanitizes_on_save() {
+		Options::register_settings();
+
+		\update_option( Publication::OPTION_THEME_ACCENT, '#AABBCC' );
+		$this->assertSame( '#aabbcc', \get_option( Publication::OPTION_THEME_ACCENT ) );
+
+		\update_option( Publication::OPTION_THEME_ACCENT, 'javascript:alert(1)' );
+		$this->assertSame( '', \get_option( Publication::OPTION_THEME_ACCENT ) );
+	}
+
+	/**
+	 * Saving a theme color queues a publication sync so the record
+	 * reflects the new colors.
+	 */
+	public function test_saving_theme_color_schedules_publication_sync() {
+		\update_option( Publication::OPTION_THEME_BACKGROUND, '#123456' );
+
+		$this->assertNotFalse(
+			\has_action( 'update_option_' . Publication::OPTION_THEME_BACKGROUND ),
+			'The background color option must trigger a publication sync.'
+		);
 	}
 }

--- a/tests/phpunit/tests/wp-admin/class-test-theme-color-setting.php
+++ b/tests/phpunit/tests/wp-admin/class-test-theme-color-setting.php
@@ -9,6 +9,7 @@
 
 namespace Atmosphere\Tests\WP_Admin;
 
+use Atmosphere\Atmosphere;
 use Atmosphere\Options;
 use Atmosphere\Sanitize;
 use Atmosphere\Transformer\Publication;
@@ -25,6 +26,9 @@ class Test_Theme_Color_Setting extends \WP_UnitTestCase {
 		\delete_option( Publication::OPTION_THEME_BACKGROUND );
 		\delete_option( Publication::OPTION_THEME_FOREGROUND );
 		\delete_option( Publication::OPTION_THEME_ACCENT );
+		\delete_option( 'atmosphere_connection' );
+		\delete_option( 'atmosphere_identity' );
+		\wp_unschedule_hook( 'atmosphere_sync_publication' );
 
 		parent::tear_down();
 	}
@@ -75,11 +79,49 @@ class Test_Theme_Color_Setting extends \WP_UnitTestCase {
 	 * reflects the new colors.
 	 */
 	public function test_saving_theme_color_schedules_publication_sync() {
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'access_token' => 'encrypted-token',
+				'did'          => 'did:plc:test123',
+				'pds_endpoint' => 'https://pds.example.com',
+			)
+		);
+		\update_option(
+			'atmosphere_identity',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'example.com',
+				'pds_endpoint' => 'https://pds.example.com',
+			)
+		);
+
+		( new Atmosphere() )->init();
+
+		/*
+		 * The first save of a colour creates the option row, which
+		 * WordPress routes through add_option() rather than
+		 * update_option(). That path is the one a site owner hits when
+		 * they pick a colour for the first time.
+		 */
+		\delete_option( Publication::OPTION_THEME_BACKGROUND );
+		\wp_unschedule_hook( 'atmosphere_sync_publication' );
+
 		\update_option( Publication::OPTION_THEME_BACKGROUND, '#123456' );
 
 		$this->assertNotFalse(
-			\has_action( 'update_option_' . Publication::OPTION_THEME_BACKGROUND ),
-			'The background color option must trigger a publication sync.'
+			\wp_next_scheduled( 'atmosphere_sync_publication' ),
+			'Picking a color for the first time must queue a publication sync.'
+		);
+
+		// Changing an existing colour must keep working too.
+		\wp_unschedule_hook( 'atmosphere_sync_publication' );
+
+		\update_option( Publication::OPTION_THEME_BACKGROUND, '#654321' );
+
+		$this->assertNotFalse(
+			\wp_next_scheduled( 'atmosphere_sync_publication' ),
+			'Changing a stored color must queue a publication sync.'
 		);
 	}
 }


### PR DESCRIPTION
Lets site owners set the `site.standard.publication` `basicTheme` colors from Settings → ATmosphere, instead of the colors being pinned to whatever `theme.json` derives.

Supersedes #206, which could not be pushed to (fork branch with maintainer edits disabled). @davekellam's original commit is preserved here as-is, with review follow-ups on top.

Fixes #205

## Proposed changes:

**The feature** (@davekellam's commit, unchanged):

* Three options, background, foreground, and accent, each stored as a hex value and sanitized to `#rrggbb`. Blank means "keep the color from the active theme".
* A **Theme** section on the settings screen using `wp-color-picker`.
* The stored values applied in the Publication transformer, recomputing `accentForeground` so a custom accent keeps its contrast guarantee.
* An `atmosphere_publication_basic_theme` filter so the whole theme object can be replaced or omitted in code. This was the filter shape floated as Experiment 1 in #205, kept alongside the settings UI.
* A publication re-sync when any of the three settings change.

**Fixes a bug in trunk that this feature made visible.** On Twenty Twenty-Five, the default theme, no `basicTheme` was ever published: TT5 styles links with `currentColor`, which `resolve_color()` cannot resolve, and the accent fallback only looked for a palette slug named exactly `accent` while TT5 ships `accent-1` through `accent-6`. Accent came back null, and a single null color drops the whole theme object. The accent fallback now takes the lowest-numbered resolvable `accent-N` slug, skipping entries that are not plain colors such as `color-mix(...)`. TT5 now yields `#ffffff` / `#111111` / `#ffee58` with a black accent foreground. This part stands on its own and is worth reviewing independently of the settings UI.

**Review follow-ups on top of the feature commit:**

* Overrides are resolved *before* derivation and passed into `build_basic_theme()`, so the record is assembled and `accentForeground` computed in one place. This drops `apply_theme_option_overrides()` and `color_object_to_rgb()`, the latter of which existed only to unwrap what `color_object()` had just wrapped.
* Overrides and the filter keep working when global styles are unavailable, rather than an early return skipping both.
* Sanitizing goes through core's `sanitize_hex_color()`, keeping the shorthand-to-`#rrggbb` normalization, so the settings layer no longer imports the transformer.
* One field callback instead of three near-identical ones, each row label tied to its input via `label_for`.
* The color picker is seeded with the active theme's palette as swatches, and each field's `data-default-color` is the color derived from the active theme, so adopting it is one click. Core renders its Default button in place of Clear when a default color is set, so the section copy tells you to empty a field to go back to the theme's color.
* Each field now states the color the active theme provides, and says so plainly when the theme provides none, because empty inputs gave no clue what a blank field publishes.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

A theme object is only published when all four colors resolve. If the active theme exposes no usable colors, setting only one or two here still results in no `basicTheme`. All three have to be set, and the section copy says so.

Fields are intentionally *not* pre-filled with the derived colors: an empty field means "follow my theme" and re-derives at publish time, so pre-filling would silently convert that to a pinned override on the next save. The description text under each field states the theme's color, and the picker's Default button applies it deliberately.

## Testing instructions:

No Bluesky connection is needed to verify the record shape.

1. On a stock Twenty Twenty-Five install, before this branch, confirm the bug: `wp eval 'var_dump( array_key_exists( "basicTheme", ( new \Atmosphere\Transformer\Publication( null ) )->transform() ) );'` prints `false`. On this branch it prints `true`.
2. Go to **Settings → ATmosphere → Theme**. Each field should render, state the color your theme provides, focus its input when you click the row label, and offer your theme's palette as picker swatches.
3. Leave all three blank and save, then inspect the derived record:
   ```
   wp eval 'print_r( ( new \Atmosphere\Transformer\Publication( null ) )->transform()["basicTheme"] );'
   ```
   The colors should match your theme.
4. Set just the **accent** color and save. Re-run: only `accent` changes, `background` and `foreground` stay derived, and `accentForeground` flips to black or white for contrast.
5. Set all three and save. Re-run: all three are yours.
6. Clear a field and save. Re-run: that color reverts to the derived value.
7. Paste something invalid such as `rgb(1,2,3)` or `javascript:alert(1)` and save. It stores empty and the derived color is used.
8. With a connection active, saving any of the three should queue a publication sync: `wp cron event list | grep atmosphere`.

### Changelog entry

<details>

<summary>Changelog Entry Details</summary>

Committed in `.github/changelog/add-publication-theme-colors`:

> Significance: minor
> Type: added
>
> Add color settings for your publication theme, so you can choose the background, text, and accent colors apps use when they display your site.

</details>
