### PR TITLE
Request review from the Automattic/atmosphere team on release PRs

### DIFF
--- a/bin/release.js
+++ b/bin/release.js
@@ -283,7 +283,7 @@ async function createRelease() {
 	// Create PR using GitHub CLI and capture the URL
 	console.log( '\nCreating PR...' );
 	const prUrl = execWithOutput(
-		`gh pr create --title "Release ${ version }" --body "Release version ${ version }" --base trunk --head ${ branchName } --reviewer "Automattic/fediverse" --assignee "${ currentUser }" --label "Release"`
+		`gh pr create --title "Release ${ version }" --body "Release version ${ version }" --base trunk --head ${ branchName } --reviewer "Automattic/atmosphere" --assignee "${ currentUser }" --label "Release"`
 	);
 
 	// Open PR in browser if a URL was returned

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -33,7 +33,7 @@ Major and minor releases share the same workflow. They are cut off `trunk` by th
    4. Mirrors the new changelog block into `readme.txt`'s `== Changelog ==` section (same-major-version history, with a trailing link to the full GitHub `CHANGELOG.md`).
    5. Replaces `@since unreleased` / `@deprecated unreleased` and the equivalent `_deprecated_*` / `_doing_it_wrong` / `apply_filters_deprecated` literals across all `*.php` files (excluding `vendor/`).
    6. Prompts for an optional `== Upgrade Notice ==` entry.
-   7. Commits, pushes the branch, and opens a `Release X.Y.Z` PR against `trunk` (reviewer: `Automattic/fediverse`).
+   7. Commits, pushes the branch, and opens a `Release X.Y.Z` PR against `trunk` (reviewer: `Automattic/atmosphere`).
 
 2. **Review and merge the PR.**
 


### PR DESCRIPTION
## Proposed changes:

The release script (`npm run release`) still requested review from `Automattic/fediverse` when opening the `Release X.Y.Z` PR — a leftover from before the repo standardized on the `Automattic/atmosphere` team. Every other place that names a reviewer (`docs/pull-request.md`, the PR workflow) already uses `Automattic/atmosphere`, so release PRs were going to a different team than everything else.

* `bin/release.js` — the `gh pr create` call now passes `--reviewer "Automattic/atmosphere"`.
* `docs/release-process.md` — the documented reviewer updated to match.

No behavior change beyond which team is requested for review; nothing user-facing.

## Testing instructions:

* `node --check bin/release.js` passes.
* `grep -rn "Automattic/fediverse" bin/ docs/ .github/` returns nothing.
* On the next `npm run release`, the opened PR requests `Automattic/atmosphere` as reviewer.

### Changelog entry

Tooling and documentation only — no user-facing change. Requesting the **Skip Changelog** label.
