### PR TITLE
Emit AT Tags meta tags mapping pages to their AT Protocol records

### DIFF
--- a/.github/changelog/add-at-tags-meta-tags
+++ b/.github/changelog/add-at-tags-meta-tags
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add AT Tags meta tags to your posts and home page, so apps like Bluesky and Leaflet can tell which AT Protocol records a page came from.

--- a/.github/changelog/add-at-tags-meta-tags
+++ b/.github/changelog/add-at-tags-meta-tags
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add AT Tags meta tags to your posts and home page, so apps like Bluesky and Leaflet can tell which AT Protocol records a page came from.
+Your posts and home page now name the AT Protocol records they were published as, so other apps can tell which record a page came from.

--- a/docs/developer-docs.md
+++ b/docs/developer-docs.md
@@ -58,6 +58,7 @@ ATmosphere exposes a small set of filters and actions for plugins to extend beha
 | `atmosphere_transform_document` | filter | Mutate the document record before write. |
 | `atmosphere_transform_publication` | filter | Mutate the publication record before write. |
 | `atmosphere_atproto_preview_transformers` | filter | Add a transformer to the `?atproto={$type}` preview for posts and the front page. |
+| `atmosphere_at_tags` | filter | Add, change, or remove the AT Tags `<meta>` tags mapping a page to its AT Protocol records. |
 | `atmosphere_appview_host` | filter | Point Bluesky web links at an alternative AT Protocol appview (host or subpath). |
 | `atmosphere_appview_url` | filter | Rewrite the whole assembled appview link, including its route. |
 | `atmosphere_publish_post_result` | action | React to a post-publish outcome (success or `WP_Error`). |
@@ -68,6 +69,34 @@ ATmosphere exposes a small set of filters and actions for plugins to extend beha
 | `atmosphere_reauth_required` | action | React when the connection first enters a reauth-required state after a permanent OAuth failure. Fires once per transition. |
 
 When adding a new public hook, mark its `@since` tag as `unreleased` — the release script rewrites it (see [Release Process → Marking Unreleased Code](release-process.md#marking-unreleased-code)).
+
+### Mapping pages back to AT Protocol records
+
+Every page that represents a record advertises it twice: through the `<link rel="site.standard.document">` / `<link rel="site.standard.publication">` tags standard.site expects, and through the [AT Tags](https://tangled.org/chrisshank.com/at-tags/) `<meta>` tags Bluesky and Leaflet emit. A dual-published post carries all five:
+
+```html
+<link rel="site.standard.document" href="at://did:plc:xxx/site.standard.document/3l…" />
+<link rel="site.standard.publication" href="at://did:plc:xxx/site.standard.publication/3l…" />
+<meta name="at:canonical" content="at://did:plc:xxx/site.standard.document/3l…" />
+<meta name="at:alternate" content="at://did:plc:xxx/site.standard.publication/3l…" />
+<meta name="at:alternate" content="at://did:plc:xxx/app.bsky.feed.post/3l…" />
+```
+
+`at:canonical` marks the records the page is a rendering of; `at:alternate` marks records it references. On the front page the publication is canonical instead, since that is the URL the publication record's `url` field points at.
+
+Two tags from the proposal are not emitted: `at:author`, because a site has exactly one connected account and it would attribute every post on a multi-author site to whoever connected it, and `at:me`, which has no clear use under the same constraint. Add either — or a namespaced `at:{namespace}:{property}` — with `atmosphere_at_tags`, which receives the assembled tags keyed by name, each holding a list of AT-URIs:
+
+```php
+add_filter(
+	'atmosphere_at_tags',
+	function ( $tags ) {
+		$tags['at:me'] = array( 'at://' . \Atmosphere\get_did() );
+		return $tags;
+	}
+);
+```
+
+Returning an empty array suppresses the meta tags entirely; the `<link rel>` tags are unaffected by this filter.
 
 ### Pointing Bluesky links at another appview
 

--- a/docs/php-class-structure.md
+++ b/docs/php-class-structure.md
@@ -91,7 +91,9 @@ Plugin orchestration class:
 
 Three `wp_head` emitters advertise which AT Protocol records a page maps to. All resolve their AT-URIs through the same private helpers (`current_document_uri()`, `publication_uri()`, `current_bsky_post_uri()`), so the gating — `has_identity()` rather than `is_connected()`, and a required stored record URI — lives in one place.
 
-Those helpers memoize through `head_memo()`, keyed by resolver, queried object, and connected DID. The emitters overlap heavily, and the shared `is_post_publishable()` check walks every registered post type and fires `atmosphere_syncable_post_types` on each call, so an unmemoized head render resolves it four times. `wp_head` fires once per request, which is what makes a plain memo safe. A test process is not a request, so tests call `Atmosphere::flush_head_record_cache()` between renders.
+Those helpers memoize through `head_memo()`, keyed by resolver, queried object, and connected DID. The emitters overlap heavily, and the shared `is_post_publishable()` check walks every registered post type and fires `atmosphere_syncable_post_types` on each call, so an unmemoized head render resolves it four times.
+
+The memo is scoped to the head render, not to the process: `flush_head_record_cache()` is hooked on `wp_head` at priority 0, ahead of the emitters at the default 10. A process static would live as long as the process, which is one request under mod_php or FPM but many under a persistent runtime (FrankenPHP worker mode, Swoole, RoadRunner) — there, a post whose document was re-minted to a new rkey would keep being advertised under the old AT-URI until the worker recycled. Tests call the same method directly, since a test process is not a request either.
 
 | Emitter | Output |
 |---------|--------|

--- a/docs/php-class-structure.md
+++ b/docs/php-class-structure.md
@@ -91,6 +91,8 @@ Plugin orchestration class:
 
 Three `wp_head` emitters advertise which AT Protocol records a page maps to. All resolve their AT-URIs through the same private helpers (`current_document_uri()`, `publication_uri()`, `current_bsky_post_uri()`), so the gating — `has_identity()` rather than `is_connected()`, and a required stored record URI — lives in one place.
 
+Those helpers memoize through `head_memo()`, keyed by resolver, queried object, and connected DID. The emitters overlap heavily, and the shared `is_post_publishable()` check walks every registered post type and fires `atmosphere_syncable_post_types` on each call, so an unmemoized head render resolves it four times. `wp_head` fires once per request, which is what makes a plain memo safe. A test process is not a request, so tests call `Atmosphere::flush_head_record_cache()` between renders.
+
 | Emitter | Output |
 |---------|--------|
 | `output_document_link()` | `<link rel="site.standard.document">` on a singular publishable post with a document record. |

--- a/docs/php-class-structure.md
+++ b/docs/php-class-structure.md
@@ -89,15 +89,19 @@ Plugin orchestration class:
 
 #### Front-end record mapping
 
-Three `wp_head` emitters advertise which AT Protocol records a page maps to. All resolve their AT-URIs through the same three private helpers (`current_document_uri()`, `publication_uri()`, `current_bsky_post_uri()`), so the gating — `has_identity()` rather than `is_connected()`, a required `Document::META_URI`, and the lazy TID mint routed through `Document::get_rkey()` — lives in one place.
+Three `wp_head` emitters advertise which AT Protocol records a page maps to. All resolve their AT-URIs through the same private helpers (`current_document_uri()`, `publication_uri()`, `current_bsky_post_uri()`), so the gating — `has_identity()` rather than `is_connected()`, and a required stored record URI — lives in one place.
 
 | Emitter | Output |
 |---------|--------|
 | `output_document_link()` | `<link rel="site.standard.document">` on a singular publishable post with a document record. |
 | `output_publication_link()` | `<link rel="site.standard.publication">` on the front page and on singular publishable posts. |
-| `output_at_tags()` | [AT Tags](https://tangled.org/chrisshank.com/at-tags/) `<meta>` tags, as emitted by Bluesky and Leaflet. |
+| `output_at_tags()` | [AT Tags](https://tangled.org/chrisshank.com/at-tags/) `<meta>` tags, as emitted by Leaflet and others. |
 
-The AT Tags mapping: `at:canonical` for records the page is a rendering of, `at:alternate` for records it merely references. A singular post marks its document canonical, with the parent publication and the companion `app.bsky.feed.post` as alternates; the front page marks the publication canonical. Repeated names are arrays, so a static front page that is also a publishable post emits two `at:canonical` lines.
+**Record URIs are read, never rebuilt.** Both per-post helpers return the URI the Publisher stored, validated through `verified_record_uri()` against the current DID, the expected collection, and a non-empty rkey. Reassembling a URI from `get_did()` plus the post's TID looks equivalent but retargets the record at whichever account is connected now: after a reconnect to a different account the TID still belongs to the old repo, so the page would advertise a record that exists nowhere. The publication URI is the exception — it is built from `get_did()` plus the site-level TID, both of which belong to the current connection by construction.
+
+This is also why the front end no longer calls `Document::get_rkey()`. That call refreshes `Document::META_DID` to the current DID, and the head emitters were its only render-time callers, so a pageview can no longer move a post's recorded origin out from under the cleanup guards.
+
+The AT Tags mapping: `at:canonical` for records the page is a rendering of, `at:alternate` for records it merely references. A singular post marks its document canonical, with the parent publication and the companion `app.bsky.feed.post` as alternates; the front page marks the publication canonical. Repeated names are arrays, so a static front page that is also a publishable post emits two `at:canonical` lines. Both alternates depend on the document being present — a page with no canonical record has nothing for an alternate to reference.
 
 `at:author` and `at:me` are not emitted — a site has one connected account, so `at:author` would attribute every post on a multi-author site to whoever connected it. Add them (or a namespaced `at:{namespace}:{property}`) through the `atmosphere_at_tags` filter, which receives the assembled `name => [uris]` array.
 

--- a/docs/php-class-structure.md
+++ b/docs/php-class-structure.md
@@ -83,8 +83,25 @@ The main file registers the autoloader, defines `ATMOSPHERE_VERSION` and path co
 Plugin orchestration class:
 
 - Registers rewrite rules + `template_redirect` handlers for `/.well-known/atproto-did` and `/.well-known/site.standard.publication`. All share the `atmosphere_wellknown` query var.
+- Emits the front-end record mapping on `wp_head` (see below).
 - Registers async cron hooks (`register_async_hooks()`) that delegate to the Publisher / Reaction_Sync.
 - Listens on `transition_post_status` and comment-status transitions to schedule cross-post / update / delete jobs.
+
+#### Front-end record mapping
+
+Three `wp_head` emitters advertise which AT Protocol records a page maps to. All resolve their AT-URIs through the same three private helpers (`current_document_uri()`, `publication_uri()`, `current_bsky_post_uri()`), so the gating — `has_identity()` rather than `is_connected()`, a required `Document::META_URI`, and the lazy TID mint routed through `Document::get_rkey()` — lives in one place.
+
+| Emitter | Output |
+|---------|--------|
+| `output_document_link()` | `<link rel="site.standard.document">` on a singular publishable post with a document record. |
+| `output_publication_link()` | `<link rel="site.standard.publication">` on the front page and on singular publishable posts. |
+| `output_at_tags()` | [AT Tags](https://tangled.org/chrisshank.com/at-tags/) `<meta>` tags, as emitted by Bluesky and Leaflet. |
+
+The AT Tags mapping: `at:canonical` for records the page is a rendering of, `at:alternate` for records it merely references. A singular post marks its document canonical, with the parent publication and the companion `app.bsky.feed.post` as alternates; the front page marks the publication canonical. Repeated names are arrays, so a static front page that is also a publishable post emits two `at:canonical` lines.
+
+`at:author` and `at:me` are not emitted — a site has one connected account, so `at:author` would attribute every post on a multi-author site to whoever connected it. Add them (or a namespaced `at:{namespace}:{property}`) through the `atmosphere_at_tags` filter, which receives the assembled `name => [uris]` array.
+
+The `<link rel>` tags and the meta tags ship together; the meta tags are additive.
 
 ### API (`includes/class-api.php`)
 

--- a/docs/php-coding-standards.md
+++ b/docs/php-coding-standards.md
@@ -238,6 +238,7 @@ use function Atmosphere\is_connected;
 \apply_filters( 'atmosphere_publish_retry_delays',        array( 60, 300, 900 ) ); // Backoff ladder for failed publish/update cron workers; length = retry budget; empty array disables retries.
 \apply_filters( 'atmosphere_oauth_redirect_uri',          $uri );
 \apply_filters( 'atmosphere_client_metadata',             $metadata );
+\apply_filters( 'atmosphere_at_tags',                     $tags ); // AT Tags <meta> mapping the page to its records; tag name => list of AT-URIs. Empty array suppresses them.
 \apply_filters( 'atmosphere_appview_host',                'bsky.app', $path, $context ); // Host/subpath for appview web links; normalized; $context keys: type|did|handle|rkey|tag.
 \apply_filters( 'atmosphere_appview_url',                 $url, $path, $context );        // Whole assembled appview link; rewrite the route from $context.
 ```

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -415,9 +415,9 @@ class Atmosphere {
 	 * its AT Protocol document record, as required by standard.site.
 	 *
 	 * Gated on `has_identity()` rather than `is_connected()` so the
-	 * verification link survives a temporary OAuth refresh failure —
-	 * the document AT-URI is computed from the DID, which is stable
-	 * across session expiry and `needs_reauth` states.
+	 * verification link survives a temporary OAuth refresh failure: the
+	 * DID it is checked against is stable across session expiry and
+	 * `needs_reauth` states.
 	 *
 	 * Also gated on the document record's own `Document::META_URI` so the
 	 * link is emitted only for posts the Publisher actually wrote a
@@ -454,7 +454,25 @@ class Atmosphere {
 	 * place. See {@see Atmosphere::output_document_link()} for why the
 	 * gates are what they are.
 	 *
-	 * @return string AT-URI, or '' when the page has no document record.
+	 * The stored URI is returned as-is rather than rebuilt from
+	 * `get_did()` plus the post's TID. Rebuilding looks equivalent and
+	 * is not: after a disconnect and reconnect to a different account,
+	 * `get_did()` is the new DID while the TID still belongs to the old
+	 * one, so every already-published post would advertise
+	 * `at://NEW_DID/site.standard.document/OLD_TID` — a record that
+	 * exists nowhere. The same mismatch would arise from a row whose
+	 * `META_TID` was lost while `META_URI` survived, where the lazy mint
+	 * would issue a fresh TID unrelated to the published record.
+	 *
+	 * Not calling `Document::get_rkey()` here also takes the front end
+	 * out of the write path entirely. That call refreshes
+	 * `Document::META_DID` to the current DID, and this was its only
+	 * render-time caller — every other one is in the Publisher at
+	 * publish time — so a pageview can no longer move a post's recorded
+	 * origin DID out from under the cleanup guards (see #217).
+	 *
+	 * @return string AT-URI, or '' when the page has no document record
+	 *                belonging to the connected account.
 	 */
 	private static function current_document_uri(): string {
 		$post = self::current_publishable_post();
@@ -463,38 +481,58 @@ class Atmosphere {
 			return '';
 		}
 
-		$doc_uri = \get_post_meta( $post->ID, Document::META_URI, true );
-		if ( empty( $doc_uri ) ) {
+		$uri = \get_post_meta( $post->ID, Document::META_URI, true );
+
+		if ( ! \is_string( $uri ) || '' === $uri ) {
 			return '';
 		}
 
-		/*
-		 * Route the TID lookup through `Document::get_rkey()` so the
-		 * lazy mint here writes `META_DID` alongside `META_TID`. The
-		 * inlined fallback that used to live here would have left the
-		 * row in a "TID set, no DID" state, which the mismatch guard
-		 * in `Publisher::delete_post()` treats as "DID unknown, fall
-		 * through to `get_did()`" — re-opening the wrong-repo-delete
-		 * bypass after a reconnect-to-different-account.
-		 */
-		$doc_tid = ( new Document( $post ) )->get_rkey();
+		return self::verified_record_uri( $uri, ( new Document( $post ) )->get_collection() );
+	}
 
-		return build_at_uri( get_did(), 'site.standard.document', $doc_tid );
+	/**
+	 * A stored AT-URI, or an empty string when it is not a well-formed
+	 * URI for `$collection` in the connected account's repo.
+	 *
+	 * Records are advertised from the URI the Publisher stored, which is
+	 * the only record of the repo a write actually landed in. Every
+	 * component is checked rather than just the DID: `parse_at_uri()`
+	 * asserts only the `at://` prefix and a three-segment shape, so a
+	 * corrupted value holding another of our records would otherwise be
+	 * advertised as the wrong kind of record.
+	 *
+	 * @param string $uri        Stored AT-URI.
+	 * @param string $collection Collection NSID the URI must name.
+	 * @return string The URI when it checks out, '' otherwise.
+	 */
+	private static function verified_record_uri( string $uri, string $collection ): string {
+		$parsed = parse_at_uri( $uri );
+
+		if ( false === $parsed ) {
+			return '';
+		}
+
+		if (
+			get_did() !== $parsed['did']
+			|| $collection !== $parsed['collection']
+			|| '' === $parsed['rkey']
+		) {
+			return '';
+		}
+
+		return $uri;
 	}
 
 	/**
 	 * The companion `app.bsky.feed.post` AT-URI for the page being
 	 * rendered, or an empty string when there is none to advertise.
 	 *
-	 * Unlike the document URI this is read back verbatim from the meta
-	 * the Publisher wrote rather than rebuilt from the current DID —
-	 * the stored URI is the only record of which repo the post actually
-	 * landed in. After a disconnect and reconnect to a different
-	 * account, it points at the previous account's repo, and
-	 * advertising it would claim someone else's record as this page's.
+	 * Read back verbatim from the meta the Publisher wrote and validated
+	 * through {@see Atmosphere::verified_record_uri()}, on the same
+	 * terms as the document URI.
 	 *
-	 * The origin DID therefore comes out of the URI itself rather than
-	 * `Post::META_DID`. That meta is not a safe source here:
+	 * The origin DID deliberately comes out of the URI rather than
+	 * `Post::META_DID`. That meta is not a safe source:
 	 * {@see \Atmosphere\Transformer\Post::get_rkey()} refreshes it to
 	 * the current DID on every call, before any write to the PDS has
 	 * succeeded, so a failed republish after reconnecting leaves the row
@@ -506,11 +544,8 @@ class Atmosphere {
 	 * issue a delete against and has only the rkey meta to go on, while
 	 * here the full AT-URI is in hand.
 	 *
-	 * Having it in hand, the check uses all of it — collection and rkey
-	 * as well as DID — so a corrupted value can't be advertised as a
-	 * Bluesky post just because it happens to be one of our AT-URIs.
-	 *
-	 * @return string AT-URI, or '' when the page has no Bluesky record.
+	 * @return string AT-URI, or '' when the page has no Bluesky record
+	 *                belonging to the connected account.
 	 */
 	private static function current_bsky_post_uri(): string {
 		$post = self::current_publishable_post();
@@ -525,30 +560,7 @@ class Atmosphere {
 			return '';
 		}
 
-		$parsed = parse_at_uri( $uri );
-
-		if ( false === $parsed ) {
-			return '';
-		}
-
-		/*
-		 * Check all three components, not just the DID. `parse_at_uri()`
-		 * only asserts the `at://` prefix and a three-segment shape, so
-		 * a corrupted `META_URI` holding some other record of ours — a
-		 * `site.standard.document` URI, say — would otherwise pass the
-		 * DID comparison and be advertised as this page's Bluesky post.
-		 * The collection comes from the transformer rather than a
-		 * literal so the two can't drift apart.
-		 */
-		if (
-			get_did() !== $parsed['did']
-			|| ( new Post( $post ) )->get_collection() !== $parsed['collection']
-			|| '' === $parsed['rkey']
-		) {
-			return '';
-		}
-
-		return $uri;
+		return self::verified_record_uri( $uri, ( new Post( $post ) )->get_collection() );
 	}
 
 	/**
@@ -676,6 +688,15 @@ class Atmosphere {
 	 * exists to find, and the reason `has_post_records()` ORs the two
 	 * meta keys — stays silent here rather than advertising a lone
 	 * reference.
+	 *
+	 * The front-page test below is deliberately not routed through
+	 * `is_publication_url()`. The two answer different questions:
+	 * `is_publication_url()` asks whether the publication should be
+	 * named on this URL at all (front page *or* publishable singular),
+	 * while this asks where it is *canonical* (front page only), the
+	 * singular case being covered by the alternate branch. Collapsing
+	 * them would make every publishable post claim to be a rendering of
+	 * the publication record.
 	 *
 	 * These are additive. The `<link rel>` tags still ship, so consumers
 	 * that only read those keep working.

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -457,7 +457,7 @@ class Atmosphere {
 	 * @return string AT-URI, or '' when the page has no document record.
 	 */
 	private static function current_document_uri(): string {
-		$post = self::advertisable_post();
+		$post = self::current_publishable_post();
 
 		if ( null === $post ) {
 			return '';
@@ -506,10 +506,14 @@ class Atmosphere {
 	 * issue a delete against and has only the rkey meta to go on, while
 	 * here the full AT-URI is in hand.
 	 *
+	 * Having it in hand, the check uses all of it — collection and rkey
+	 * as well as DID — so a corrupted value can't be advertised as a
+	 * Bluesky post just because it happens to be one of our AT-URIs.
+	 *
 	 * @return string AT-URI, or '' when the page has no Bluesky record.
 	 */
 	private static function current_bsky_post_uri(): string {
-		$post = self::advertisable_post();
+		$post = self::current_publishable_post();
 
 		if ( null === $post ) {
 			return '';
@@ -523,7 +527,24 @@ class Atmosphere {
 
 		$parsed = parse_at_uri( $uri );
 
-		if ( false === $parsed || get_did() !== $parsed['did'] ) {
+		if ( false === $parsed ) {
+			return '';
+		}
+
+		/*
+		 * Check all three components, not just the DID. `parse_at_uri()`
+		 * only asserts the `at://` prefix and a three-segment shape, so
+		 * a corrupted `META_URI` holding some other record of ours — a
+		 * `site.standard.document` URI, say — would otherwise pass the
+		 * DID comparison and be advertised as this page's Bluesky post.
+		 * The collection comes from the transformer rather than a
+		 * literal so the two can't drift apart.
+		 */
+		if (
+			get_did() !== $parsed['did']
+			|| ( new Post( $post ) )->get_collection() !== $parsed['collection']
+			|| '' === $parsed['rkey']
+		) {
 			return '';
 		}
 
@@ -531,12 +552,18 @@ class Atmosphere {
 	}
 
 	/**
-	 * The post whose records the current request may advertise, or null
-	 * when the request is not a singular view of a publishable post.
+	 * The queried post when the current request is a singular view of a
+	 * post whose records may be named in the page head, or null when it
+	 * is not.
+	 *
+	 * Wraps {@see \Atmosphere\is_post_publishable()} with the two
+	 * request-shape conditions the head emitters share: a persisted
+	 * identity to name records under, and a singular view to name them
+	 * on.
 	 *
 	 * @return \WP_Post|null
 	 */
-	private static function advertisable_post(): ?\WP_Post {
+	private static function current_publishable_post(): ?\WP_Post {
 		if ( ! has_identity() || ! \is_singular() ) {
 			return null;
 		}

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -241,7 +241,13 @@ class Atmosphere {
 		// Read-only REST field exposing the published post's Bluesky URL.
 		\add_action( 'rest_api_init', array( $this, 'register_share_status_field' ) );
 
-		// Frontend verification headers.
+		/*
+		 * Frontend verification headers. The emitters memoize what they
+		 * resolve, so the head render opens by dropping anything left
+		 * over — see `flush_head_record_cache()` for why that matters
+		 * outside a request-per-process runtime.
+		 */
+		\add_action( 'wp_head', array( self::class, 'flush_head_record_cache' ), 0 );
 		\add_action( 'wp_head', array( $this, 'output_document_link' ) );
 		\add_action( 'wp_head', array( $this, 'output_publication_link' ) );
 		\add_action( 'wp_head', array( $this, 'output_at_tags' ) );
@@ -643,14 +649,23 @@ class Atmosphere {
 	}
 
 	/**
-	 * Clear the per-request head record cache.
+	 * Clear the head record cache.
 	 *
-	 * The cache assumes a page's records are stable for the life of a
-	 * request, which holds for a real pageview but not across tests that
-	 * render the same URL under different options. Tests should call
-	 * this between renders.
+	 * Hooked on `wp_head` at priority 0, so each head render starts from
+	 * nothing. A process static would otherwise be exactly as long-lived
+	 * as the process: under mod_php or FPM that is one request and the
+	 * distinction never shows, but under a persistent runtime — FrankenPHP
+	 * worker mode, Swoole, RoadRunner — a worker serves many requests, and
+	 * a post whose document was re-minted to a new rkey (delete then
+	 * republish, or a backfill) would keep being advertised under the old
+	 * AT-URI until that worker recycled. The memo only needs to survive
+	 * the head render, so scoping it there costs nothing and removes the
+	 * question.
 	 *
-	 * @internal
+	 * Tests call this directly too: a test process is not a request, so
+	 * two tests rendering the same URL under different options would
+	 * otherwise collide on one cache key.
+	 *
 	 * @return void
 	 */
 	public static function flush_head_record_cache(): void {

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -125,6 +125,23 @@ class Atmosphere {
 	private static array $publishing_post_ids = array();
 
 	/**
+	 * Per-request cache of what the `wp_head` emitters resolve, keyed by
+	 * resolver, queried object ID, and connected DID.
+	 *
+	 * The three emitters ask overlapping questions — which post may name
+	 * records, which document URI, which publication URI — so without
+	 * this the same work runs up to three times per pageview. The part
+	 * that costs is `is_post_publishable()`, which walks every
+	 * registered post type and fires the `atmosphere_syncable_post_types`
+	 * filter on each call, so a site hooking that filter pays for it
+	 * repeatedly. `wp_head` fires once per request, which is what makes
+	 * a plain memo sufficient here.
+	 *
+	 * @var array<string,mixed>
+	 */
+	private static array $head_record_cache = array();
+
+	/**
 	 * Maximum re-schedule hops for a child comment waiting on a
 	 * not-yet-published parent. After this many deferrals the child
 	 * is skipped if the parent still lacks a threadable strongRef so a
@@ -475,19 +492,24 @@ class Atmosphere {
 	 *                belonging to the connected account.
 	 */
 	private static function current_document_uri(): string {
-		$post = self::current_publishable_post();
+		return self::head_memo(
+			'document',
+			static function () {
+				$post = self::current_publishable_post();
 
-		if ( null === $post ) {
-			return '';
-		}
+				if ( null === $post ) {
+					return '';
+				}
 
-		$uri = \get_post_meta( $post->ID, Document::META_URI, true );
+				$uri = \get_post_meta( $post->ID, Document::META_URI, true );
 
-		if ( ! \is_string( $uri ) || '' === $uri ) {
-			return '';
-		}
+				if ( ! \is_string( $uri ) || '' === $uri ) {
+					return '';
+				}
 
-		return self::verified_record_uri( $uri, ( new Document( $post ) )->get_collection() );
+				return self::verified_record_uri( $uri, 'site.standard.document' );
+			}
+		);
 	}
 
 	/**
@@ -548,19 +570,24 @@ class Atmosphere {
 	 *                belonging to the connected account.
 	 */
 	private static function current_bsky_post_uri(): string {
-		$post = self::current_publishable_post();
+		return self::head_memo(
+			'bsky',
+			static function () {
+				$post = self::current_publishable_post();
 
-		if ( null === $post ) {
-			return '';
-		}
+				if ( null === $post ) {
+					return '';
+				}
 
-		$uri = \get_post_meta( $post->ID, Post::META_URI, true );
+				$uri = \get_post_meta( $post->ID, Post::META_URI, true );
 
-		if ( ! \is_string( $uri ) || '' === $uri ) {
-			return '';
-		}
+				if ( ! \is_string( $uri ) || '' === $uri ) {
+					return '';
+				}
 
-		return self::verified_record_uri( $uri, ( new Post( $post ) )->get_collection() );
+				return self::verified_record_uri( $uri, 'app.bsky.feed.post' );
+			}
+		);
 	}
 
 	/**
@@ -576,17 +603,58 @@ class Atmosphere {
 	 * @return \WP_Post|null
 	 */
 	private static function current_publishable_post(): ?\WP_Post {
-		if ( ! has_identity() || ! \is_singular() ) {
-			return null;
+		return self::head_memo(
+			'post',
+			static function () {
+				if ( ! has_identity() || ! \is_singular() ) {
+					return null;
+				}
+
+				$post = \get_queried_object();
+
+				if ( ! $post instanceof \WP_Post || ! is_post_publishable( $post ) ) {
+					return null;
+				}
+
+				return $post;
+			}
+		);
+	}
+
+	/**
+	 * Resolve a head-emitter value once per request.
+	 *
+	 * The queried object and the connected DID are folded into the key
+	 * so a cached answer can never outlive the request state it was
+	 * computed from.
+	 *
+	 * @param string   $key     Resolver identifier.
+	 * @param callable $resolve Produces the value on a miss.
+	 * @return mixed The resolved value.
+	 */
+	private static function head_memo( string $key, callable $resolve ): mixed {
+		$key .= '|' . \get_queried_object_id() . '|' . get_did();
+
+		if ( ! \array_key_exists( $key, self::$head_record_cache ) ) {
+			self::$head_record_cache[ $key ] = $resolve();
 		}
 
-		$post = \get_queried_object();
+		return self::$head_record_cache[ $key ];
+	}
 
-		if ( ! $post instanceof \WP_Post || ! is_post_publishable( $post ) ) {
-			return null;
-		}
-
-		return $post;
+	/**
+	 * Clear the per-request head record cache.
+	 *
+	 * The cache assumes a page's records are stable for the life of a
+	 * request, which holds for a real pageview but not across tests that
+	 * render the same URL under different options. Tests should call
+	 * this between renders.
+	 *
+	 * @internal
+	 * @return void
+	 */
+	public static function flush_head_record_cache(): void {
+		self::$head_record_cache = array();
 	}
 
 	/**
@@ -637,23 +705,28 @@ class Atmosphere {
 	 * @return string AT-URI, or '' when there is no publication record.
 	 */
 	private static function publication_uri(): string {
-		if ( ! has_identity() ) {
-			return '';
-		}
+		return self::head_memo(
+			'publication',
+			static function () {
+				if ( ! has_identity() ) {
+					return '';
+				}
 
-		$pub_tid = \get_option( Publication::OPTION_TID );
+				$pub_tid = \get_option( Publication::OPTION_TID );
 
-		/*
-		 * Type-check rather than cast: a corrupted option holding an
-		 * array would raise an "Array to string conversion" notice on
-		 * the front end, and `build_at_uri()` would splice the word
-		 * "Array" into a published AT-URI.
-		 */
-		if ( ! \is_string( $pub_tid ) || '' === $pub_tid ) {
-			return '';
-		}
+				/*
+				 * Type-check rather than cast: a corrupted option holding
+				 * an array would raise an "Array to string conversion"
+				 * notice on the front end, and `build_at_uri()` would
+				 * splice the word "Array" into a published AT-URI.
+				 */
+				if ( ! \is_string( $pub_tid ) || '' === $pub_tid ) {
+					return '';
+				}
 
-		return build_at_uri( get_did(), 'site.standard.publication', $pub_tid );
+				return build_at_uri( get_did(), 'site.standard.publication', $pub_tid );
+			}
+		);
 	}
 
 	/**
@@ -807,19 +880,19 @@ class Atmosphere {
 	 *   tag emitting in that configuration).
 	 * - A publishable singular post qualifies because its document
 	 *   record carries a reference back to the publication.
+	 *
+	 * The singular arm defers to {@see Atmosphere::current_publishable_post()}
+	 * so the publishability check is resolved once per request rather
+	 * than repeated here. That helper additionally requires an identity,
+	 * which changes nothing: the only caller pairs this with
+	 * {@see Atmosphere::publication_uri()}, which returns '' without one.
 	 */
 	private static function is_publication_url(): bool {
 		if ( \is_front_page() ) {
 			return true;
 		}
 
-		if ( ! \is_singular() ) {
-			return false;
-		}
-
-		$post = \get_queried_object();
-
-		return $post instanceof \WP_Post && is_post_publishable( $post );
+		return null !== self::current_publishable_post();
 	}
 
 	/**

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -227,6 +227,7 @@ class Atmosphere {
 		// Frontend verification headers.
 		\add_action( 'wp_head', array( $this, 'output_document_link' ) );
 		\add_action( 'wp_head', array( $this, 'output_publication_link' ) );
+		\add_action( 'wp_head', array( $this, 'output_at_tags' ) );
 
 		// Well-known endpoints and front-end query vars.
 		\add_action( 'init', array( $this, 'register_wellknown_rewrite' ) );
@@ -432,23 +433,39 @@ class Atmosphere {
 	 * stay silent until reconnect + publish lands a real record.
 	 */
 	public function output_document_link(): void {
-		if ( ! has_identity() || ! \is_singular() ) {
+		$uri = self::current_document_uri();
+
+		if ( '' === $uri ) {
 			return;
 		}
 
-		$post = \get_queried_object();
+		\printf(
+			'<link rel="site.standard.document" href="%s" />' . "\n",
+			\esc_attr( $uri )
+		);
+	}
 
-		if ( ! $post instanceof \WP_Post ) {
-			return;
-		}
+	/**
+	 * The `site.standard.document` AT-URI advertised by the page being
+	 * rendered, or an empty string when the page advertises none.
+	 *
+	 * Shared by the `<link rel="site.standard.document">` tag and the
+	 * `at:canonical` meta tag so the gating below lives in exactly one
+	 * place. See {@see Atmosphere::output_document_link()} for why the
+	 * gates are what they are.
+	 *
+	 * @return string AT-URI, or '' when the page has no document record.
+	 */
+	private static function current_document_uri(): string {
+		$post = self::advertisable_post();
 
-		if ( ! is_post_publishable( $post ) ) {
-			return;
+		if ( null === $post ) {
+			return '';
 		}
 
 		$doc_uri = \get_post_meta( $post->ID, Document::META_URI, true );
 		if ( empty( $doc_uri ) ) {
-			return;
+			return '';
 		}
 
 		/*
@@ -462,12 +479,75 @@ class Atmosphere {
 		 */
 		$doc_tid = ( new Document( $post ) )->get_rkey();
 
-		$uri = build_at_uri( get_did(), 'site.standard.document', $doc_tid );
+		return build_at_uri( get_did(), 'site.standard.document', $doc_tid );
+	}
 
-		\printf(
-			'<link rel="site.standard.document" href="%s" />' . "\n",
-			\esc_attr( $uri )
-		);
+	/**
+	 * The companion `app.bsky.feed.post` AT-URI for the page being
+	 * rendered, or an empty string when there is none to advertise.
+	 *
+	 * Unlike the document URI this is read back verbatim from the meta
+	 * the Publisher wrote rather than rebuilt from the current DID —
+	 * the stored URI is the only record of which repo the post actually
+	 * landed in. After a disconnect and reconnect to a different
+	 * account, it points at the previous account's repo, and
+	 * advertising it would claim someone else's record as this page's.
+	 *
+	 * The origin DID therefore comes out of the URI itself rather than
+	 * `Post::META_DID`. That meta is not a safe source here:
+	 * {@see \Atmosphere\Transformer\Post::get_rkey()} refreshes it to
+	 * the current DID on every call, before any write to the PDS has
+	 * succeeded, so a failed republish after reconnecting leaves the row
+	 * claiming the current account while `META_URI` still points at the
+	 * old one. Parsing the URI also covers pre-`META_DID` rows, which a
+	 * meta comparison has to wave through for lack of anything to
+	 * compare. This is why the check does not mirror the mismatch guard
+	 * in `Publisher::delete_post()`: that one decides which repo to
+	 * issue a delete against and has only the rkey meta to go on, while
+	 * here the full AT-URI is in hand.
+	 *
+	 * @return string AT-URI, or '' when the page has no Bluesky record.
+	 */
+	private static function current_bsky_post_uri(): string {
+		$post = self::advertisable_post();
+
+		if ( null === $post ) {
+			return '';
+		}
+
+		$uri = \get_post_meta( $post->ID, Post::META_URI, true );
+
+		if ( ! \is_string( $uri ) || '' === $uri ) {
+			return '';
+		}
+
+		$parsed = parse_at_uri( $uri );
+
+		if ( false === $parsed || get_did() !== $parsed['did'] ) {
+			return '';
+		}
+
+		return $uri;
+	}
+
+	/**
+	 * The post whose records the current request may advertise, or null
+	 * when the request is not a singular view of a publishable post.
+	 *
+	 * @return \WP_Post|null
+	 */
+	private static function advertisable_post(): ?\WP_Post {
+		if ( ! has_identity() || ! \is_singular() ) {
+			return null;
+		}
+
+		$post = \get_queried_object();
+
+		if ( ! $post instanceof \WP_Post || ! is_post_publishable( $post ) ) {
+			return null;
+		}
+
+		return $post;
 	}
 
 	/**
@@ -489,26 +569,182 @@ class Atmosphere {
 	 * lockstep with {@see Atmosphere::output_document_link()}.
 	 */
 	public function output_publication_link(): void {
-		if ( ! has_identity() ) {
-			return;
-		}
-
-		$pub_tid = \get_option( Publication::OPTION_TID );
-
-		if ( ! $pub_tid ) {
-			return;
-		}
-
 		if ( ! self::is_publication_url() ) {
 			return;
 		}
 
-		$uri = build_at_uri( get_did(), 'site.standard.publication', $pub_tid );
+		$uri = self::publication_uri();
+
+		if ( '' === $uri ) {
+			return;
+		}
 
 		\printf(
 			'<link rel="site.standard.publication" href="%s" />' . "\n",
 			\esc_attr( $uri )
 		);
+	}
+
+	/**
+	 * The site's `site.standard.publication` AT-URI, or an empty string
+	 * when the site has no identity or has not minted a publication TID
+	 * yet (fresh install, pre-sync).
+	 *
+	 * Says nothing about whether the current URL is one the publication
+	 * should be advertised on — that's {@see Atmosphere::is_publication_url()}
+	 * for the link tag, and the front-page test in
+	 * {@see Atmosphere::output_at_tags()} for the meta tags.
+	 *
+	 * @return string AT-URI, or '' when there is no publication record.
+	 */
+	private static function publication_uri(): string {
+		if ( ! has_identity() ) {
+			return '';
+		}
+
+		$pub_tid = \get_option( Publication::OPTION_TID );
+
+		/*
+		 * Type-check rather than cast: a corrupted option holding an
+		 * array would raise an "Array to string conversion" notice on
+		 * the front end, and `build_at_uri()` would splice the word
+		 * "Array" into a published AT-URI.
+		 */
+		if ( ! \is_string( $pub_tid ) || '' === $pub_tid ) {
+			return '';
+		}
+
+		return build_at_uri( get_did(), 'site.standard.publication', $pub_tid );
+	}
+
+	/**
+	 * Output the AT Tags `<meta>` mapping from this page to the AT
+	 * Protocol records behind it.
+	 *
+	 * Implements the community AT Tags proposal
+	 * (https://tangled.org/chrisshank.com/at-tags/), which Bluesky and
+	 * Leaflet both emit. `at:canonical` marks the records the page is a
+	 * rendering of — delete them and the page has nothing left to
+	 * represent — while `at:alternate` marks records the page merely
+	 * references. Repeated names are read as arrays, which is how a post
+	 * advertises both its publication and its Bluesky post as alternates.
+	 *
+	 * The mapping:
+	 *
+	 * - Singular publishable post with a document record: the document
+	 *   is canonical; the parent publication and the companion Bluesky
+	 *   post (which backs the reactions and synced comments displayed on
+	 *   the page) are alternates.
+	 * - Front page: the publication is canonical, since the front page
+	 *   is the local page the publication record's `url` points at.
+	 * - A static front page that is also a publishable post with a
+	 *   document record emits both as canonical, per the array
+	 *   semantics — the URL genuinely maps to both records.
+	 *
+	 * Both alternates are tied to the document's presence, rather than
+	 * the publication following `is_publication_url()` and the Bluesky
+	 * post standing on its own: a page with no canonical record has
+	 * nothing for an alternate to be an alternate *to*. So a post that
+	 * carries a Bluesky record but no document — the state `Backfill`
+	 * exists to find, and the reason `has_post_records()` ORs the two
+	 * meta keys — stays silent here rather than advertising a lone
+	 * reference.
+	 *
+	 * These are additive. The `<link rel>` tags still ship, so consumers
+	 * that only read those keep working.
+	 */
+	public function output_at_tags(): void {
+		$doc_uri = self::current_document_uri();
+		$pub_uri = self::publication_uri();
+
+		$tags = array(
+			'at:canonical' => array(),
+			'at:alternate' => array(),
+		);
+
+		if ( '' !== $doc_uri ) {
+			$tags['at:canonical'][] = $doc_uri;
+		}
+
+		if ( '' !== $pub_uri ) {
+			if ( \is_front_page() ) {
+				$tags['at:canonical'][] = $pub_uri;
+			} elseif ( '' !== $doc_uri ) {
+				$tags['at:alternate'][] = $pub_uri;
+			}
+		}
+
+		if ( '' !== $doc_uri ) {
+			$bsky_uri = self::current_bsky_post_uri();
+
+			if ( '' !== $bsky_uri ) {
+				$tags['at:alternate'][] = $bsky_uri;
+			}
+		}
+
+		/**
+		 * Filters the AT Tags emitted in the page head.
+		 *
+		 * Keyed by tag name, each holding a list of AT-URIs; a name with
+		 * an empty list prints nothing. This is the supported way to add
+		 * the tags the plugin does not emit itself — `at:me`, `at:author`,
+		 * or a namespaced `at:{namespace}:{property}` property. Neither
+		 * identity tag ships by default: a site has exactly one connected
+		 * account, so `at:author` would attribute every post on a
+		 * multi-author site to whoever connected it.
+		 *
+		 * @since unreleased
+		 *
+		 * @param array<string, string[]> $tags Tag name => list of AT-URIs.
+		 */
+		$tags = \apply_filters( 'atmosphere_at_tags', $tags );
+
+		if ( ! \is_array( $tags ) ) {
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'The atmosphere_at_tags filter must return an array keyed by tag name.', 'atmosphere' ),
+				'unreleased'
+			);
+			return;
+		}
+
+		$skipped = false;
+
+		foreach ( $tags as $name => $uris ) {
+			// A filter returning a plain list would otherwise print `name="0"`.
+			if ( ! \is_string( $name ) || '' === $name ) {
+				$skipped = true;
+				continue;
+			}
+
+			foreach ( (array) $uris as $uri ) {
+				if ( ! \is_string( $uri ) || '' === $uri ) {
+					$skipped = true;
+					continue;
+				}
+
+				\printf(
+					'<meta name="%s" content="%s" />' . "\n",
+					\esc_attr( $name ),
+					\esc_attr( $uri )
+				);
+			}
+		}
+
+		/*
+		 * Dropping malformed entries is the right behaviour — one bad
+		 * tag should not take the rest of the head with it — but doing
+		 * it silently leaves the filtering plugin with no way to see
+		 * why its tag never appeared. Reported once per request rather
+		 * than per entry so a badly-shaped array can't flood the log.
+		 */
+		if ( $skipped ) {
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'The atmosphere_at_tags filter produced entries that were not non-empty strings; those were skipped.', 'atmosphere' ),
+				'unreleased'
+			);
+		}
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -39,6 +39,14 @@ class Test_Atmosphere extends WP_UnitTestCase {
 
 		$this->atmosphere = new Atmosphere();
 
+		/*
+		 * The head emitters memoize per request. A test process is not a
+		 * request: without this, two tests rendering the same URL under
+		 * different options — the front page with and without a
+		 * publication TID, say — would collide on the same cache key.
+		 */
+		Atmosphere::flush_head_record_cache();
+
 		\update_option(
 			'atmosphere_connection',
 			array(
@@ -2624,6 +2632,57 @@ class Test_Atmosphere extends WP_UnitTestCase {
 			\get_post_meta( $post_id, Document::META_DID, true ),
 			'A front-end render must not rewrite the recorded origin DID.'
 		);
+	}
+
+	/**
+	 * A full head render resolves publishability once, not once per
+	 * emitter.
+	 *
+	 * `is_post_publishable()` walks every registered post type and fires
+	 * `atmosphere_syncable_post_types` on each call, so a site hooking
+	 * that filter pays for every repeat. Counting filter invocations
+	 * across all three emitters pins the memo: without it this is 4 —
+	 * one per emitter plus `is_publication_url()`'s own check.
+	 */
+	public function test_head_emitters_resolve_publishability_once_per_request() {
+		$this->set_identity();
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post_id, Document::META_URI, 'at://did:plc:test123/site.standard.document/3kdocrecord000' );
+		\update_post_meta( $post_id, Post::META_URI, 'at://did:plc:test123/app.bsky.feed.post/3kbskypost0000' );
+
+		$this->go_to_post( $post_id );
+		Atmosphere::flush_head_record_cache();
+
+		$calls = 0;
+		\add_filter(
+			'atmosphere_syncable_post_types',
+			static function ( $types ) use ( &$calls ) {
+				++$calls;
+				return $types;
+			}
+		);
+
+		\ob_start();
+		$this->atmosphere->output_document_link();
+		$this->atmosphere->output_publication_link();
+		$this->atmosphere->output_at_tags();
+		$output = (string) \ob_get_clean();
+
+		\remove_all_filters( 'atmosphere_syncable_post_types' );
+
+		$this->assertSame(
+			1,
+			$calls,
+			'Publishability must be resolved once for the whole head, not once per emitter.'
+		);
+
+		// The memo must not have cost us any output.
+		$this->assertStringContainsString( '<link rel="site.standard.document"', $output );
+		$this->assertStringContainsString( '<link rel="site.standard.publication"', $output );
+		$this->assertStringContainsString( '<meta name="at:canonical"', $output );
+		$this->assertSame( 2, \substr_count( $output, 'at:alternate' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -2538,6 +2538,95 @@ class Test_Atmosphere extends WP_UnitTestCase {
 	}
 
 	/**
+	 * After reconnecting to a different account, a post published under
+	 * the previous one advertises nothing.
+	 *
+	 * The URI used to be rebuilt as `get_did()` + the stored TID, which
+	 * silently retargets the record at the new account: the TID belongs
+	 * to the old repo, so `at://NEW_DID/site.standard.document/OLD_TID`
+	 * names a record that exists in neither. Both the meta tag and the
+	 * link tag are asserted here, since both read the same resolver.
+	 */
+	public function test_document_tags_silent_after_reconnect_to_another_account() {
+		$this->set_identity( 'did:plc:current' );
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post_id, Document::META_URI, 'at://did:plc:previous/site.standard.document/3kdocrecord000' );
+		\update_post_meta( $post_id, Document::META_TID, '3kdocrecord000' );
+
+		$this->go_to_post( $post_id );
+
+		$at_tags = $this->capture_at_tags();
+
+		$this->assertStringNotContainsString(
+			'at://did:plc:current/site.standard.document/3kdocrecord000',
+			$at_tags,
+			'A record minted under the previous account must not be re-pointed at the current one.'
+		);
+		$this->assertStringNotContainsString( 'at:canonical', $at_tags );
+		$this->assertSame(
+			'',
+			$this->capture_document_link(),
+			'The link tag reads the same resolver and must fall silent too.'
+		);
+	}
+
+	/**
+	 * The advertised document URI is the one the Publisher stored, not
+	 * one reassembled from the post's TID meta.
+	 *
+	 * Pinned with a deliberately divergent `META_TID`: if the URI were
+	 * rebuilt, the tag would carry the meta's TID instead of the
+	 * published record's.
+	 */
+	public function test_document_tags_use_stored_uri_not_rebuilt_tid() {
+		$this->set_identity();
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post_id, Document::META_URI, 'at://did:plc:test123/site.standard.document/3kpublished000' );
+		\update_post_meta( $post_id, Document::META_TID, '3kdivergent000' );
+
+		$this->go_to_post( $post_id );
+		$output = $this->capture_at_tags();
+
+		$this->assertStringContainsString(
+			'<meta name="at:canonical" content="at://did:plc:test123/site.standard.document/3kpublished000" />',
+			$output
+		);
+		$this->assertStringNotContainsString( '3kdivergent000', $output );
+	}
+
+	/**
+	 * Rendering a page never touches `Document::META_DID`.
+	 *
+	 * The head emitters were the only render-time callers of
+	 * `Document::get_rkey()`, which refreshes that meta to the current
+	 * DID. Leaving it alone keeps a pageview from moving a post's
+	 * recorded origin out from under the cleanup guards (#217).
+	 */
+	public function test_rendering_does_not_refresh_document_did_meta() {
+		$this->set_identity( 'did:plc:current' );
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post_id, Document::META_URI, 'at://did:plc:previous/site.standard.document/3kdocrecord000' );
+		\update_post_meta( $post_id, Document::META_TID, '3kdocrecord000' );
+		\update_post_meta( $post_id, Document::META_DID, 'did:plc:previous' );
+
+		$this->go_to_post( $post_id );
+		$this->capture_document_link();
+		$this->capture_at_tags();
+
+		$this->assertSame(
+			'did:plc:previous',
+			\get_post_meta( $post_id, Document::META_DID, true ),
+			'A front-end render must not rewrite the recorded origin DID.'
+		);
+	}
+
+	/**
 	 * A post carrying a Bluesky record but no document — the state
 	 * `Backfill` exists to find — advertises nothing. Both alternates
 	 * hang off the document's presence, because an alternate with no

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -2686,6 +2686,76 @@ class Test_Atmosphere extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The head render opens by dropping the memo, so a worker that
+	 * serves many requests cannot keep advertising a stale AT-URI.
+	 *
+	 * Priority 0 matters: the flush has to land before the emitters,
+	 * which sit at the default 10.
+	 */
+	public function test_init_flushes_head_record_cache_before_emitting() {
+		$this->atmosphere->init();
+
+		try {
+			$this->assertSame(
+				0,
+				\has_action( 'wp_head', array( Atmosphere::class, 'flush_head_record_cache' ) ),
+				'The flush must run before the emitters that populate the memo.'
+			);
+		} finally {
+			\remove_action( 'wp_head', array( Atmosphere::class, 'flush_head_record_cache' ), 0 );
+			foreach ( array( 'output_at_tags', 'output_document_link', 'output_publication_link' ) as $emitter ) {
+				\remove_action( 'wp_head', array( $this->atmosphere, $emitter ) );
+			}
+			\wp_clear_scheduled_hook( 'atmosphere_sync_publication' );
+			\wp_clear_scheduled_hook( 'atmosphere_refresh_token' );
+			\wp_clear_scheduled_hook( 'atmosphere_sync_reactions' );
+			\wp_clear_scheduled_hook( 'atmosphere_backfill_replies' );
+		}
+	}
+
+	/**
+	 * Re-minting a post's document record changes what the next head
+	 * render advertises.
+	 *
+	 * This is the persistent-runtime case in miniature: render, re-mint
+	 * the record as a delete-and-republish or a backfill would, then
+	 * render again in what a worker would treat as a fresh request. The
+	 * memo is keyed by post and DID rather than by the stored URI, so
+	 * without the flush the second render would still serve the first
+	 * URI.
+	 */
+	public function test_flush_head_record_cache_picks_up_a_reminted_record() {
+		$this->set_identity();
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post_id, Document::META_URI, 'at://did:plc:test123/site.standard.document/3koriginal0000' );
+
+		$this->go_to_post( $post_id );
+		Atmosphere::flush_head_record_cache();
+
+		$this->assertStringContainsString( '3koriginal0000', $this->capture_at_tags() );
+
+		// Delete + republish, or a backfill: same post, new record.
+		\update_post_meta( $post_id, Document::META_URI, 'at://did:plc:test123/site.standard.document/3kreminted0000' );
+
+		// What `wp_head` at priority 0 does at the top of the next render.
+		Atmosphere::flush_head_record_cache();
+
+		$output = $this->capture_at_tags();
+
+		$this->assertStringContainsString(
+			'<meta name="at:canonical" content="at://did:plc:test123/site.standard.document/3kreminted0000" />',
+			$output
+		);
+		$this->assertStringNotContainsString(
+			'3koriginal0000',
+			$output,
+			'A recycled worker must not keep serving the pre-remint AT-URI.'
+		);
+	}
+
+	/**
 	 * A post carrying a Bluesky record but no document — the state
 	 * `Backfill` exists to find — advertises nothing. Both alternates
 	 * hang off the document's presence, because an alternate with no

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -2471,23 +2471,70 @@ class Test_Atmosphere extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A malformed stored URI is not advertised — `parse_at_uri()`
-	 * returning false must fail closed rather than emit the raw value.
+	 * A stored value that isn't a well-formed `app.bsky.feed.post`
+	 * AT-URI under the current DID is not advertised.
+	 *
+	 * `parse_at_uri()` only asserts the `at://` prefix and a three-
+	 * segment shape, so checking the DID alone would let any other
+	 * record of ours through — a `site.standard.document` URI would be
+	 * published as this page's Bluesky post. Each case here fails a
+	 * different component while the document tag keeps emitting, which
+	 * is what proves the rejection is the Bluesky check and not a
+	 * wholesale bail.
+	 *
+	 * @dataProvider data_non_advertisable_bsky_uris
+	 *
+	 * @param string $uri     Value stored in `Post::META_URI`.
+	 * @param string $message Assertion message.
 	 */
-	public function test_output_at_tags_skips_unparseable_bluesky_uri() {
+	public function test_output_at_tags_skips_bluesky_uri_that_is_not_a_feed_post( string $uri, string $message ) {
 		$this->set_identity();
 		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
 
 		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
-		\update_post_meta( $post_id, Post::META_URI, 'https://bsky.app/not-an-at-uri' );
+		\update_post_meta( $post_id, Post::META_URI, $uri );
 		\update_post_meta( $post_id, Document::META_URI, 'at://did:plc:test123/site.standard.document/3kdocrecord000' );
 		\update_post_meta( $post_id, Document::META_TID, '3kdocrecord000' );
 
 		$this->go_to_post( $post_id );
 		$output = $this->capture_at_tags();
 
-		$this->assertStringNotContainsString( 'bsky.app', $output );
-		$this->assertStringContainsString( 'at:canonical', $output );
+		$this->assertStringNotContainsString(
+			'<meta name="at:alternate" content="' . $uri . '" />',
+			$output,
+			$message
+		);
+		$this->assertStringContainsString(
+			'<meta name="at:canonical" content="at://did:plc:test123/site.standard.document/3kdocrecord000" />',
+			$output,
+			'Rejecting the Bluesky URI must not suppress the document tag.'
+		);
+	}
+
+	/**
+	 * Stored values that must never be advertised as a Bluesky post.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function data_non_advertisable_bsky_uris(): array {
+		return array(
+			'not an AT-URI at all'           => array(
+				'https://bsky.app/not-an-at-uri',
+				'A value that does not parse must fail closed.',
+			),
+			'our own document record'        => array(
+				'at://did:plc:test123/site.standard.document/3kdocrecord000',
+				'Another of our records under the same DID is still not a Bluesky post.',
+			),
+			'right collection, empty rkey'   => array(
+				'at://did:plc:test123/app.bsky.feed.post/',
+				'An AT-URI with no rkey points at no record.',
+			),
+			'unrelated collection, same DID' => array(
+				'at://did:plc:test123/app.bsky.actor.profile/self',
+				'Only feed posts belong in the Bluesky alternate.',
+			),
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -76,6 +76,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 
 		\remove_all_filters( 'atmosphere_should_publish_comment' );
 		\remove_all_filters( 'atmosphere_pre_apply_writes' );
+		\remove_all_filters( 'atmosphere_at_tags' );
 		\delete_option( 'atmosphere_visibility_cleanup_migrated' );
 
 		parent::tear_down();
@@ -2023,6 +2024,34 @@ class Test_Atmosphere extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Capture what `output_at_tags()` prints to stdout.
+	 *
+	 * @return string Output (empty when the method emits no tags).
+	 */
+	private function capture_at_tags(): string {
+		\ob_start();
+		$this->atmosphere->output_at_tags();
+		return (string) \ob_get_clean();
+	}
+
+	/**
+	 * Set the persisted identity used by the tag-emission tests.
+	 *
+	 * @param string $did DID to store.
+	 */
+	private function set_identity( string $did = 'did:plc:test123' ): void {
+		\update_option(
+			'atmosphere_identity',
+			array(
+				'did'          => $did,
+				'handle'       => 'example.com',
+				'pds_endpoint' => 'https://pds.example.com',
+			),
+			true
+		);
+	}
+
+	/**
 	 * Front-end endpoint query vars are registered through WordPress.
 	 */
 	public function test_register_query_vars_adds_atproto_preview_var() {
@@ -2291,6 +2320,457 @@ class Test_Atmosphere extends WP_UnitTestCase {
 		$output = $this->capture_publication_link();
 
 		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * A dual-published post advertises all three of its records: the
+	 * document as the page's canonical AT record, and the publication
+	 * plus the companion Bluesky post as auxiliary references. Repeated
+	 * `at:alternate` names are the proposal's array form.
+	 */
+	public function test_output_at_tags_emits_full_set_on_dual_published_post() {
+		$this->set_identity();
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post_id, Post::META_URI, 'at://did:plc:test123/app.bsky.feed.post/3kbskypost0000' );
+		\update_post_meta( $post_id, Document::META_URI, 'at://did:plc:test123/site.standard.document/3kdocrecord000' );
+		\update_post_meta( $post_id, Document::META_TID, '3kdocrecord000' );
+
+		$this->go_to_post( $post_id );
+		$output = $this->capture_at_tags();
+
+		$this->assertStringContainsString(
+			'<meta name="at:canonical" content="at://did:plc:test123/site.standard.document/3kdocrecord000" />',
+			$output,
+			'The document record is what the page is a rendering of, so it is canonical.'
+		);
+		$this->assertStringContainsString(
+			'<meta name="at:alternate" content="at://did:plc:test123/site.standard.publication/3kpubtid000000" />',
+			$output,
+			'The parent publication is referenced by the page, not depended on by it.'
+		);
+		$this->assertStringContainsString(
+			'<meta name="at:alternate" content="at://did:plc:test123/app.bsky.feed.post/3kbskypost0000" />',
+			$output,
+			'The companion Bluesky post backs the reactions/comments shown on the page.'
+		);
+	}
+
+	/**
+	 * A document-only post — no companion `app.bsky.feed.post` — emits
+	 * the document and publication tags and nothing else. Guards against
+	 * an empty `at:alternate` being printed for the missing Bluesky post.
+	 */
+	public function test_output_at_tags_omits_bluesky_alternate_for_document_only_post() {
+		$this->set_identity();
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post_id, Document::META_URI, 'at://did:plc:test123/site.standard.document/3kdoconly00000' );
+		\update_post_meta( $post_id, Document::META_TID, '3kdoconly00000' );
+
+		$this->go_to_post( $post_id );
+		$output = $this->capture_at_tags();
+
+		$this->assertStringContainsString(
+			'<meta name="at:canonical" content="at://did:plc:test123/site.standard.document/3kdoconly00000" />',
+			$output
+		);
+		$this->assertStringContainsString(
+			'<meta name="at:alternate" content="at://did:plc:test123/site.standard.publication/3kpubtid000000" />',
+			$output
+		);
+		$this->assertStringNotContainsString(
+			'app.bsky.feed.post',
+			$output,
+			'A document-only post has no Bluesky record to advertise.'
+		);
+	}
+
+	/**
+	 * The Bluesky post URI is stored verbatim rather than rebuilt from
+	 * the current DID, so a post minted under a previous account would
+	 * otherwise advertise the old repo after a reconnect.
+	 */
+	public function test_output_at_tags_skips_bluesky_alternate_minted_under_another_did() {
+		$this->set_identity( 'did:plc:current' );
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post_id, Post::META_URI, 'at://did:plc:previous/app.bsky.feed.post/3kbskypost0000' );
+		\update_post_meta( $post_id, Post::META_DID, 'did:plc:previous' );
+		\update_post_meta( $post_id, Document::META_URI, 'at://did:plc:current/site.standard.document/3kdocrecord000' );
+		\update_post_meta( $post_id, Document::META_TID, '3kdocrecord000' );
+
+		$this->go_to_post( $post_id );
+		$output = $this->capture_at_tags();
+
+		$this->assertStringNotContainsString(
+			'app.bsky.feed.post',
+			$output,
+			'Records minted under a previous account must not be advertised as this page\'s.'
+		);
+		$this->assertStringContainsString(
+			'<meta name="at:canonical" content="at://did:plc:current/site.standard.document/3kdocrecord000" />',
+			$output,
+			'The document URI is rebuilt from the current DID, so it stays advertisable.'
+		);
+	}
+
+	/**
+	 * The origin DID comes out of the stored URI, not `Post::META_DID`.
+	 *
+	 * `Post::get_rkey()` refreshes `META_DID` to the current DID on
+	 * every call — before any PDS write has succeeded — so a failed
+	 * republish after reconnecting to a different account leaves the row
+	 * claiming the current DID while `META_URI` still points at the old
+	 * one. A meta-based guard passes there and advertises the previous
+	 * account's record; parsing the URI does not. Pre-`META_DID` rows
+	 * (no meta at all) are the same hole seen from the other side.
+	 *
+	 * @dataProvider data_stale_bsky_did_meta
+	 *
+	 * @param string $meta_did Value to store in `Post::META_DID`.
+	 * @param string $message  Assertion message.
+	 */
+	public function test_output_at_tags_skips_bluesky_alternate_when_uri_did_is_foreign( string $meta_did, string $message ) {
+		$this->set_identity( 'did:plc:current' );
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post_id, Post::META_URI, 'at://did:plc:previous/app.bsky.feed.post/3kbskypost0000' );
+		if ( '' !== $meta_did ) {
+			\update_post_meta( $post_id, Post::META_DID, $meta_did );
+		}
+		\update_post_meta( $post_id, Document::META_URI, 'at://did:plc:current/site.standard.document/3kdocrecord000' );
+		\update_post_meta( $post_id, Document::META_TID, '3kdocrecord000' );
+
+		$this->go_to_post( $post_id );
+		$output = $this->capture_at_tags();
+
+		$this->assertStringNotContainsString( 'app.bsky.feed.post', $output, $message );
+	}
+
+	/**
+	 * Rows where `Post::META_DID` does not reflect the URI's real origin.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function data_stale_bsky_did_meta(): array {
+		return array(
+			'META_DID refreshed to the current account by a failed republish' => array(
+				'did:plc:current',
+				'A META_DID refreshed ahead of a successful write must not vouch for a URI pointing elsewhere.',
+			),
+			'legacy row predating META_DID' => array(
+				'',
+				'A row with no META_DID must be judged on its URI, not waved through.',
+			),
+		);
+	}
+
+	/**
+	 * A malformed stored URI is not advertised — `parse_at_uri()`
+	 * returning false must fail closed rather than emit the raw value.
+	 */
+	public function test_output_at_tags_skips_unparseable_bluesky_uri() {
+		$this->set_identity();
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post_id, Post::META_URI, 'https://bsky.app/not-an-at-uri' );
+		\update_post_meta( $post_id, Document::META_URI, 'at://did:plc:test123/site.standard.document/3kdocrecord000' );
+		\update_post_meta( $post_id, Document::META_TID, '3kdocrecord000' );
+
+		$this->go_to_post( $post_id );
+		$output = $this->capture_at_tags();
+
+		$this->assertStringNotContainsString( 'bsky.app', $output );
+		$this->assertStringContainsString( 'at:canonical', $output );
+	}
+
+	/**
+	 * A post carrying a Bluesky record but no document — the state
+	 * `Backfill` exists to find — advertises nothing. Both alternates
+	 * hang off the document's presence, because an alternate with no
+	 * canonical record alongside it references nothing.
+	 */
+	public function test_output_at_tags_silent_for_bluesky_only_post() {
+		$this->set_identity();
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $post_id, Post::META_URI, 'at://did:plc:test123/app.bsky.feed.post/3kbskypost0000' );
+
+		$this->go_to_post( $post_id );
+
+		$this->assertSame( '', $this->capture_at_tags() );
+	}
+
+	/**
+	 * A static front page that is also a publishable post with a
+	 * document record maps to both records, so both are canonical —
+	 * the array semantics the proposal defines, and the one branch
+	 * where the meta mapping diverges from the link tags.
+	 */
+	public function test_output_at_tags_emits_both_canonicals_on_publishable_static_front_page() {
+		$this->set_identity();
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		// `page` is not syncable by default; opt it in so the static
+		// front page clears `is_post_publishable()`.
+		\add_filter(
+			'atmosphere_syncable_post_types',
+			static function ( $types ) {
+				$types[] = 'page';
+				return $types;
+			}
+		);
+
+		$page_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Home',
+			)
+		);
+		\update_post_meta( $page_id, Document::META_URI, 'at://did:plc:test123/site.standard.document/3kfrontdoc0000' );
+		\update_post_meta( $page_id, Document::META_TID, '3kfrontdoc0000' );
+
+		\update_option( 'show_on_front', 'page' );
+		\update_option( 'page_on_front', $page_id );
+
+		$this->go_to( '?page_id=' . $page_id );
+
+		$this->assertTrue( \is_front_page(), 'Sanity check: static page must be the front page.' );
+		$this->assertTrue( \is_singular(), 'Sanity check: the static front page is also singular.' );
+
+		$output = $this->capture_at_tags();
+
+		\delete_option( 'show_on_front' );
+		\delete_option( 'page_on_front' );
+		\remove_all_filters( 'atmosphere_syncable_post_types' );
+
+		$this->assertStringContainsString(
+			'<meta name="at:canonical" content="at://did:plc:test123/site.standard.document/3kfrontdoc0000" />',
+			$output
+		);
+		$this->assertStringContainsString(
+			'<meta name="at:canonical" content="at://did:plc:test123/site.standard.publication/3kpubtid000000" />',
+			$output
+		);
+		$this->assertStringNotContainsString(
+			'at:alternate',
+			$output,
+			'The publication is canonical here, so it must not also appear as an alternate.'
+		);
+	}
+
+	/**
+	 * A filter returning something other than an array is a contract
+	 * violation: drop the output, but say so rather than leaving the
+	 * filtering plugin to guess why its tags vanished.
+	 */
+	public function test_output_at_tags_flags_filter_returning_non_array() {
+		$this->setExpectedIncorrectUsage( 'Atmosphere\Atmosphere::output_at_tags' );
+
+		$this->set_identity();
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		\add_filter( 'atmosphere_at_tags', '__return_true' );
+
+		$this->go_to_front_page();
+		$output = $this->capture_at_tags();
+
+		\remove_all_filters( 'atmosphere_at_tags' );
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * Malformed entries are skipped rather than printed, and the skip
+	 * is reported. The valid entries around them still emit — one bad
+	 * tag must not take the rest of the head with it.
+	 */
+	public function test_output_at_tags_flags_and_skips_malformed_entries() {
+		$this->setExpectedIncorrectUsage( 'Atmosphere\Atmosphere::output_at_tags' );
+
+		$this->set_identity();
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		\add_filter(
+			'atmosphere_at_tags',
+			static function ( $tags ) {
+				$tags[]          = array( 'at://did:plc:test123' );      // Numeric key.
+				$tags['at:me']   = array( 'at://did:plc:test123', 42 );  // One good, one not.
+				$tags['at:junk'] = array( '' );                          // Empty string.
+				return $tags;
+			}
+		);
+
+		$this->go_to_front_page();
+		$output = $this->capture_at_tags();
+
+		\remove_all_filters( 'atmosphere_at_tags' );
+
+		$this->assertStringContainsString(
+			'<meta name="at:me" content="at://did:plc:test123" />',
+			$output,
+			'Valid entries must survive alongside malformed ones.'
+		);
+		$this->assertStringNotContainsString( 'name="0"', $output );
+		$this->assertStringNotContainsString( 'content="42"', $output );
+		$this->assertStringNotContainsString( 'at:junk', $output );
+		$this->assertStringContainsString(
+			'<meta name="at:canonical" content="at://did:plc:test123/site.standard.publication/3kpubtid000000" />',
+			$output,
+			'The plugin\'s own tags must be unaffected by a third party\'s bad entries.'
+		);
+	}
+
+	/**
+	 * On the front page the publication is the record the page renders,
+	 * so it is canonical there rather than alternate — the one place the
+	 * two mappings diverge.
+	 */
+	public function test_output_at_tags_marks_publication_canonical_on_front_page() {
+		$this->set_identity();
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		$this->go_to_front_page();
+		$output = $this->capture_at_tags();
+
+		$this->assertStringContainsString(
+			'<meta name="at:canonical" content="at://did:plc:test123/site.standard.publication/3kpubtid000000" />',
+			$output
+		);
+		$this->assertStringNotContainsString( 'at:alternate', $output );
+	}
+
+	/**
+	 * No document record means no tags at all, and — as with the link
+	 * tag — no lazy `META_TID` mint from a front-end render.
+	 */
+	public function test_output_at_tags_silent_for_post_without_document_record() {
+		$this->set_identity();
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$this->go_to_post( $post_id );
+		$output = $this->capture_at_tags();
+
+		$this->assertSame( '', $output );
+		$this->assertSame(
+			'',
+			\get_post_meta( $post_id, Document::META_TID, true ),
+			'Frontend render must not lazy-mint META_TID for an unpublished post.'
+		);
+	}
+
+	/**
+	 * Archives, search results and 404s map to no record.
+	 */
+	public function test_output_at_tags_silent_on_non_singular_non_front_page() {
+		$this->set_identity();
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		$this->go_to( \home_url( '/?s=anything' ) );
+
+		$this->assertSame( '', $this->capture_at_tags() );
+	}
+
+	/**
+	 * A disconnected site with no persisted identity advertises nothing,
+	 * in lockstep with the two link tags.
+	 */
+	public function test_output_at_tags_silent_without_identity() {
+		\delete_option( 'atmosphere_connection' );
+		\delete_option( 'atmosphere_identity' );
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		$this->go_to_front_page();
+
+		$this->assertSame( '', $this->capture_at_tags() );
+	}
+
+	/**
+	 * The filter is the supported way to add the tags the plugin does
+	 * not emit on its own — `at:me`, `at:author`, or a namespaced
+	 * community property — without patching the emitter.
+	 */
+	public function test_output_at_tags_filter_can_add_tags() {
+		$this->set_identity();
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		\add_filter(
+			'atmosphere_at_tags',
+			static function ( $tags ) {
+				$tags['at:me'] = array( 'at://did:plc:test123' );
+				return $tags;
+			}
+		);
+
+		$this->go_to_front_page();
+		$output = $this->capture_at_tags();
+
+		\remove_all_filters( 'atmosphere_at_tags' );
+
+		$this->assertStringContainsString(
+			'<meta name="at:me" content="at://did:plc:test123" />',
+			$output
+		);
+	}
+
+	/**
+	 * A filter that empties the tag list silences the output entirely,
+	 * rather than printing bare `<meta>` elements with empty content.
+	 */
+	public function test_output_at_tags_filter_can_suppress_all_tags() {
+		$this->set_identity();
+		\update_option( 'atmosphere_publication_tid', '3kpubtid000000' );
+
+		\add_filter( 'atmosphere_at_tags', '__return_empty_array' );
+
+		$this->go_to_front_page();
+		$output = $this->capture_at_tags();
+
+		\remove_all_filters( 'atmosphere_at_tags' );
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * Both emitters are wired to `wp_head` so the meta tags ship
+	 * alongside the link tags they complement.
+	 */
+	public function test_init_wires_at_tags_to_wp_head() {
+		$emitters = array( 'output_at_tags', 'output_document_link', 'output_publication_link' );
+
+		$this->atmosphere->init();
+
+		try {
+			foreach ( $emitters as $emitter ) {
+				$this->assertNotFalse(
+					\has_action( 'wp_head', array( $this->atmosphere, $emitter ) ),
+					"{$emitter} must be wired to wp_head."
+				);
+			}
+		} finally {
+			/*
+			 * `init()` mutates global hook + cron state the WP test
+			 * framework does not roll back; undo what this test caused,
+			 * mirroring `test_init_wires_publication_sync_triggers()`.
+			 */
+			foreach ( $emitters as $emitter ) {
+				\remove_action( 'wp_head', array( $this->atmosphere, $emitter ) );
+			}
+			\wp_clear_scheduled_hook( 'atmosphere_sync_publication' );
+			\wp_clear_scheduled_hook( 'atmosphere_refresh_token' );
+			\wp_clear_scheduled_hook( 'atmosphere_sync_reactions' );
+			\wp_clear_scheduled_hook( 'atmosphere_backfill_replies' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #219

## Proposed changes:

Our pages already advertise which AT Protocol records they came from, through `<link rel="site.standard.document">` and `<link rel="site.standard.publication">`. This adds the [AT Tags](https://tangled.org/chrisshank.com/at-tags/) `<meta>` equivalent alongside them. The link tags are untouched and still emitted, so nothing that reads them today breaks.

The mapping follows what [Leaflet ships](https://tangled.org/leaflet.pub/leaflet/commit/b4744504026ca285d545499f3ea4999263b29d60.patch), plus our Bluesky post:

| Page | Tags |
| --- | --- |
| Singular publishable post with a document record | `at:canonical` → document, `at:alternate` → publication, `at:alternate` → `app.bsky.feed.post` |
| Front page | `at:canonical` → publication |

`at:canonical` means the page is a rendering of that record; `at:alternate` means it only references one. The proposal reads repeated names as arrays, which is how a post advertises two alternates.

A handful of apps have shipped it in the last few days — mu.social, semble.so, aturi.to, leaflet.pub, and frontpage.fyi — per [the author's own tally](https://mu.social/profile/chrisshank.com/post/3mrg3zta5uc2h). There's [an open PR against bsky.app](https://github.com/bluesky-social/social-app/pull/11243) too, swapping `<link rel="alternate" href="at://…">` for `<meta name="at:canonical">` on post, profile, feed, and starter pack pages, though that one hasn't merged yet.

The reasoning in that PR is that a `<link rel>` with an unregistered rel value isn't valid HTML, which applies to our `rel="site.standard.document"` as well. Since the meta tags are purely additive here, we can follow the convention without betting on it.

Advertising the Bluesky post URI goes a step past Leaflet. The proposal's own example for `at:alternate` is embedding a Bluesky thread in a blog's comment section, which is what the reactions block and comment sync already do on these pages. We store that URI and have never surfaced it anywhere.

Two structural notes for review.

**The three emitters now share their URI resolution.** `output_document_link()` and `output_publication_link()` each resolved an AT-URI inline, with a fair bit of care behind it: gating on `has_identity()` rather than `is_connected()`, requiring `Document::META_URI` so a disconnected site doesn't advertise records that were never written, and routing the lazy TID mint through `Document::get_rkey()` so `META_DID` gets written alongside `META_TID`. Copying all of that into a third emitter would have left us with two copies to keep in sync, so it moved into private helpers that all three read from. One thing visibly changed: `output_publication_link()` now checks `is_publication_url()` before the identity and TID checks instead of after. Both are side-effect-free predicates, so the outcome is the same.

**`at:author` and `at:me` are deliberately absent.** A site has exactly one connected account, so `at:author` would attribute every post on a multi-author blog to whoever connected it. `at:me` doesn't have a clear use under the same constraint. Both stay reachable through a new `atmosphere_at_tags` filter, which also covers namespaced `at:{namespace}:{property}` properties:

```php
add_filter(
	'atmosphere_at_tags',
	function ( $tags ) {
		$tags['at:me'] = array( 'at://' . Atmosphere\get_did() );
		return $tags;
	}
);
```

Returning an empty array suppresses the meta tags; the link tags aren't affected by the filter. Returning a non-array, or entries that aren't non-empty strings, drops the offending output and reports it through `_doing_it_wrong()` so the filtering plugin can see why its tag never showed up.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Sixteen new tests cover the mapping on each page type, the document-only and Bluesky-only cases, the dual-canonical static front page, the origin-DID guard, the silent cases, and the filter's happy path plus both ways of misusing it.

Of note: the Bluesky post URI is the only one of the three read back verbatim from post meta instead of rebuilt from the current DID, since the stored URI is the only record of which repo the post actually landed in. After a disconnect and reconnect to a different account it would point at the previous account's repo, so it's guarded.

My first attempt read `Post::META_DID` for that, mirroring the mismatch guard in `Publisher::delete_post()`. Review caught that this doesn't hold: `Post::get_rkey()` refreshes `META_DID` to the current DID on every call, before any PDS write has succeeded, so a failed republish after reconnecting leaves the row claiming the current account while `META_URI` still points at the old one. The guard now parses the DID out of the stored URI instead, which closes that window and the pre-`META_DID` legacy rows in one go, and reads no meta at all. `Publisher::delete_post()` genuinely has no choice there, since rkey meta carries no DID; here the full AT-URI is already in hand.

Both alternates hang off the document's presence, so a post with a Bluesky record but no document (what `Backfill` exists to find) stays silent rather than advertising a lone `at:alternate` with no canonical record to reference from.

This doesn't change anything about #217. `Document::get_rkey()` still refreshes `META_DID` at `wp_head` time, and the second call this adds per pageview sees the value the first one already wrote, so it's a pure read.

## Testing instructions:

You don't need a real OAuth connection for this; seed the state directly.

* Check out this branch and run `npm run env-start`.
* Seed an identity and a post carrying both records:

```bash
npx wp-env run cli --env-cwd="wp-content/plugins/atmosphere" wp eval '
update_option( "atmosphere_identity", array( "did" => "did:plc:smoketest", "handle" => "example.com", "pds_endpoint" => "https://pds.example.com" ), true );
update_option( "atmosphere_publication_tid", "3kpubtid000000" );
$id = wp_insert_post( array( "post_title" => "AT tags test", "post_status" => "publish", "post_content" => "hello" ) );
update_post_meta( $id, "_atmosphere_doc_uri", "at://did:plc:smoketest/site.standard.document/3kdocsmoke0000" );
update_post_meta( $id, "_atmosphere_doc_tid", "3kdocsmoke0000" );
update_post_meta( $id, "_atmosphere_bsky_uri", "at://did:plc:smoketest/app.bsky.feed.post/3kbskysmoke000" );
update_post_meta( $id, "_atmosphere_bsky_did", "did:plc:smoketest" );
echo get_permalink( $id ) . "\n";
'
```

* View source on that permalink. You should get five tags, the two existing `<link rel>` ones plus:

```html
<meta name="at:canonical" content="at://did:plc:smoketest/site.standard.document/3kdocsmoke0000" />
<meta name="at:alternate" content="at://did:plc:smoketest/site.standard.publication/3kpubtid000000" />
<meta name="at:alternate" content="at://did:plc:smoketest/app.bsky.feed.post/3kbskysmoke000" />
```

* View source on the front page. The publication should be `at:canonical` this time, with no `at:alternate`.
* Search for anything (`/?s=hello`). No `at:` tags at all.
* Delete `_atmosphere_doc_uri` from the post and reload it. No `at:` tags either; a post with no document record advertises nothing.
* Set `_atmosphere_bsky_uri` to `at://did:plc:someoneelse/app.bsky.feed.post/3kbskysmoke000` and reload. The Bluesky `at:alternate` should disappear while the other two stay, whatever `_atmosphere_bsky_did` happens to say.
* Run the tests: `npm run env-test -- --filter=at_tags`.

To clean up afterwards: `wp_delete_post( $id, true )` and `delete_option( "atmosphere_identity" )`.

### Changelog entry

Added in `.github/changelog/add-at-tags-meta-tags`.
