### PR TITLE
Force https on the OAuth client_id

### DIFF
--- a/.github/changelog/fix-client-id-https
+++ b/.github/changelog/fix-client-id-https
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix sharing to Bluesky failing with an "Invalid client ID" error on sites served through a reverse proxy or CDN.

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -166,7 +166,18 @@ class Client {
 	 * @return string
 	 */
 	public static function client_id(): string {
-		return \rest_url( 'atmosphere/v1/client-metadata' );
+		/*
+		 * Force the `https` scheme, mirroring redirect_uri(). AT Protocol
+		 * requires the client_id to be an https URL. rest_url() inherits its
+		 * scheme from the request context, so on a site behind a
+		 * TLS-terminating proxy a CLI/cron request (where is_ssl() is false)
+		 * yields an http client_id — which the auth server rejects as
+		 * "Invalid client ID" during the pre-publish token refresh, even
+		 * though the browser-side authorize used https and succeeded.
+		 * Forcing the scheme keeps the client_id stable across contexts and
+		 * matching the value advertised in the client metadata document.
+		 */
+		return \set_url_scheme( \rest_url( 'atmosphere/v1/client-metadata' ), 'https' );
 	}
 
 	/**

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -175,7 +175,7 @@ class Client {
 		 * "Invalid client ID" during the pre-publish token refresh, even
 		 * though the browser-side authorize used https and succeeded.
 		 * Forcing the scheme keeps the client_id stable across contexts and
-		 * matching the value advertised in the client metadata document.
+		 * matches the value advertised in the client metadata document.
 		 */
 		return \set_url_scheme( \rest_url( 'atmosphere/v1/client-metadata' ), 'https' );
 	}

--- a/tests/phpunit/tests/oauth/class-test-client-id.php
+++ b/tests/phpunit/tests/oauth/class-test-client-id.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Tests for `Client::client_id()`.
+ *
+ * AT Protocol requires the client_id to be an https URL. `rest_url()`
+ * inherits its scheme from the request context, so on a site behind a
+ * TLS-terminating proxy a CLI/cron request produces an http client_id
+ * that the auth server rejects as "Invalid client ID". `client_id()`
+ * must force https regardless of context.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group oauth
+ */
+
+namespace Atmosphere\Tests\OAuth;
+
+use WP_UnitTestCase;
+use Atmosphere\OAuth\Client;
+
+/**
+ * `Client::client_id()` scheme tests.
+ */
+class Test_Client_Id extends WP_UnitTestCase {
+
+	/**
+	 * Remove the rest_url override between tests.
+	 */
+	public function tear_down(): void {
+		\remove_all_filters( 'rest_url' );
+		parent::tear_down();
+	}
+
+	/**
+	 * An http `rest_url()` (a CLI/cron request behind a TLS-terminating
+	 * proxy) is forced to https for the client_id.
+	 */
+	public function test_client_id_forces_https_on_http_rest_url() {
+		\add_filter(
+			'rest_url',
+			static fn() => 'http://proxied.example/wp-json/atmosphere/v1/client-metadata'
+		);
+
+		$this->assertSame(
+			'https://proxied.example/wp-json/atmosphere/v1/client-metadata',
+			Client::client_id()
+		);
+	}
+
+	/**
+	 * An https `rest_url()` is passed through unchanged.
+	 */
+	public function test_client_id_keeps_https_rest_url() {
+		\add_filter(
+			'rest_url',
+			static fn() => 'https://proxied.example/wp-json/atmosphere/v1/client-metadata'
+		);
+
+		$this->assertSame(
+			'https://proxied.example/wp-json/atmosphere/v1/client-metadata',
+			Client::client_id()
+		);
+	}
+}

--- a/tests/phpunit/tests/oauth/class-test-client-id.php
+++ b/tests/phpunit/tests/oauth/class-test-client-id.php
@@ -48,6 +48,22 @@ class Test_Client_Id extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The scheme is forced regardless of permalink structure — a plain
+	 * `?rest_route=` URL is handled the same as a pretty `/wp-json/` one.
+	 */
+	public function test_client_id_forces_https_on_plain_permalink_url() {
+		\add_filter(
+			'rest_url',
+			static fn() => 'http://proxied.example/index.php?rest_route=/atmosphere/v1/client-metadata'
+		);
+
+		$this->assertSame(
+			'https://proxied.example/index.php?rest_route=/atmosphere/v1/client-metadata',
+			Client::client_id()
+		);
+	}
+
+	/**
 	 * An https `rest_url()` is passed through unchanged.
 	 */
 	public function test_client_id_keeps_https_rest_url() {


### PR DESCRIPTION
Fixes #225

## Proposed changes:

`Client::client_id()` returned `rest_url( 'atmosphere/v1/client-metadata' )` verbatim, so its scheme followed the request context. On a site behind a TLS-terminating proxy or CDN, a request with no HTTPS context, the WP-CLI backfill and the token refresh that runs before each publish, resolves that URL as `http://`. AT Protocol requires the `client_id` to be an https URL, so Bluesky's auth server rejects the http one with `Invalid client ID` even though the browser-driven authorize (a real https request) succeeded.

This forces the https scheme, the same way `Client::redirect_uri()` already does. The client-metadata document is built from the same method, so the advertised `client_id` and the one sent in the token request now match and are both https.

* `includes/oauth/class-client.php` — force https on `client_id()`.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

Hard to reproduce without a proxy, so the test drives it directly:

* `vendor/bin/phpunit --filter=Test_Client_Id` (or `npm run env-test -- --filter=Test_Client_Id`).
* The tests filter `rest_url` to return an `http://` URL (standing in for the proxied CLI/cron context) and assert `Client::client_id()` returns the same URL with `https`, and that an already-https URL is passed through unchanged.

To sanity-check by hand: on any site, `wp eval 'echo Atmosphere\OAuth\Client::client_id();'` should print an `https://` URL regardless of how the site URL is stored.

### Changelog entry

Committed at `.github/changelog/fix-client-id-https` (patch / fixed).
