### PR TITLE
Fix the Plugin URI, the repo moved to Automattic

### DIFF
--- a/atmosphere.php
+++ b/atmosphere.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: ATmosphere
- * Plugin URI: https://github.com/pfefferle/atmosphere
+ * Plugin URI: https://github.com/Automattic/wordpress-atmosphere
  * Description: Publish WordPress posts to AT Protocol (Bluesky + standard.site) via native OAuth.
  * Version: 2.1.0
  * Author: Automattic


### PR DESCRIPTION
## Proposed changes:

* The `Plugin URI` header still pointed at `pfefferle/atmosphere`, which does not exist anymore. The repo is `Automattic/wordpress-atmosphere`, so the link on the plugins screen was dead. This just updates the header, nothing else.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Go to Plugins in wp-admin.
* The "Visit plugin site" link of ATmosphere should point to https://github.com/Automattic/wordpress-atmosphere.

### Changelog entry

Header metadata only, so I added the "Skip Changelog" label.
