### PR TITLE
Pass the published post to atmosphere_should_publish_bluesky_post

### DIFF
--- a/.github/changelog/add-per-post-bluesky-companion
+++ b/.github/changelog/add-per-post-bluesky-companion
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Compatible plugins can now decide per post whether it is also shared to Bluesky.

--- a/docs/developer-docs.md
+++ b/docs/developer-docs.md
@@ -47,7 +47,7 @@ ATmosphere exposes a small set of filters and actions for plugins to extend beha
 | `atmosphere_syncable_post_types` | filter | Add or remove post types eligible for cross-posting. |
 | `atmosphere_connection_only_mode` | filter | Return `true` to embed ATmosphere purely as a connection layer: auto cross-posting, reaction/reply import, and comment publishing all default off, and the Settings → ATmosphere screen is hidden. |
 | `atmosphere_should_auto_publish` | filter | Effective on/off for automatic post cross-posting; runs after the stored setting and connection-only mode, and has the final say. |
-| `atmosphere_should_publish_bluesky_post` | filter | Return `false` to publish the `site.standard.document` record only, without a companion `app.bsky.feed.post`, across backfill, auto-publish, and edits. Shapes what a publish writes (not whether it runs), so it is a pure filter with no connection-only pass. Forward-only — leaves already-published Bluesky posts in place. |
+| `atmosphere_should_publish_bluesky_post` | filter | Return `false` to publish the `site.standard.document` record only, without a companion `app.bsky.feed.post`, across backfill, auto-publish, and edits. Receives the post being published as a second argument, so the answer can be made per post (by type, meta, or author). Shapes what a publish writes (not whether it runs), so it is a pure filter with no connection-only pass. Forward-only — leaves already-published Bluesky posts in place. |
 | `atmosphere_should_publish_comments` | filter | Effective on/off for publishing local comments as Bluesky replies; runs after the stored setting and connection-only mode, and has the final say. Re-enable this lane while in connection-only mode. Not the per-comment `_comment` filter below. |
 | `atmosphere_should_publish_comment` | filter | Customise which approved comments from users allowed to publish posts are mirrored as Bluesky replies. |
 | `atmosphere_should_sync_reactions` | filter | Effective on/off for importing Bluesky likes and reposts; runs after the stored setting and connection-only mode, and has the final say. |
@@ -405,6 +405,39 @@ The filter shapes *what* a publish writes, not *whether* the site publishes,
 so — unlike the connection-only lane switches — it has no connection-only pass
 and stays a pure filter. A host embedded as a connection layer can still choose
 document-only output when it runs a manual backfill.
+
+**Decide per post, not just site-wide.** The filter receives the post being
+published as a second argument, so a callback can route individual posts.
+A site-wide `__return_false` still works unchanged — it simply ignores the post.
+The post is always a real `WP_Post`, so no `null` check is needed.
+
+Route a whole post type document-only (e.g. short-form status updates or an
+activity-log CPT) while long-form posts keep their Bluesky companion:
+
+```php
+add_filter(
+	'atmosphere_should_publish_bluesky_post',
+	function ( $enabled, $post ) {
+		return 'status' === $post->post_type ? false : $enabled;
+	},
+	10,
+	2
+);
+```
+
+Or honor a per-post author choice stored in post meta ("publish this one
+quietly"):
+
+```php
+add_filter(
+	'atmosphere_should_publish_bluesky_post',
+	function ( $enabled, $post ) {
+		return get_post_meta( $post->ID, 'skip_bluesky', true ) ? false : $enabled;
+	},
+	10,
+	2
+);
+```
 
 **This is a one-way choice, on purpose.** A post first published as a
 document-only record does not retroactively gain a Bluesky companion if you

--- a/docs/php-coding-standards.md
+++ b/docs/php-coding-standards.md
@@ -226,7 +226,7 @@ use function Atmosphere\is_connected;
 \apply_filters( 'atmosphere_syncable_post_types',         array( 'post' ) );
 \apply_filters( 'atmosphere_connection_only_mode',        false ); // Return true to embed ATmosphere purely as a connection layer: auto cross-posting, reaction/reply import, comment publishing, and the settings screen all default off.
 \apply_filters( 'atmosphere_should_auto_publish',         $bool ); // Feature switch for automatic post cross-posting; runs after the stored setting and connection-only mode, final say.
-\apply_filters( 'atmosphere_should_publish_bluesky_post', true ); // Return false to write the site.standard.document record only, no app.bsky.feed.post companion; pure filter (no connection-only pass), forward-only.
+\apply_filters( 'atmosphere_should_publish_bluesky_post', true, $post ); // Return false to write the site.standard.document record only, no app.bsky.feed.post companion; `$post` is the post being published, so the answer can be per post. Pure filter (no connection-only pass), forward-only.
 \apply_filters( 'atmosphere_should_publish_comment',      $bool, $comment );
 \apply_filters( 'atmosphere_should_publish_comments',     $bool ); // Feature switch for publishing WP comments to Bluesky; runs after the stored setting and connection-only mode, final say. NOT the per-comment `_comment` filter above.
 \apply_filters( 'atmosphere_should_sync_reactions',       $bool ); // Feature switch for importing Bluesky likes/reposts; runs after the stored setting and connection-only mode, final say.

--- a/includes/class-publisher.php
+++ b/includes/class-publisher.php
@@ -114,7 +114,7 @@ class Publisher {
 		 * is cleaned up) and the result action (so metrics/notice subscribers
 		 * behave the same as any other publish).
 		 */
-		if ( ! is_bluesky_post_enabled() ) {
+		if ( ! is_bluesky_post_enabled( $post ) ) {
 			$result = self::publish_document_only( $post, $original_time );
 			$result = self::reconcile_post_after_write( $post, $result );
 
@@ -900,7 +900,7 @@ class Publisher {
 		 * Run the same reconcile race-guard the dual update paths end with, so
 		 * a document edit that races a visibility change is still cleaned up.
 		 */
-		if ( ! is_bluesky_post_enabled() ) {
+		if ( ! is_bluesky_post_enabled( $post ) ) {
 			return self::reconcile_post_after_write( $post, self::update_document_only( $post ) );
 		}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -976,11 +976,14 @@ function is_publication_sync_enabled(): bool {
  * choice away. It is therefore a pure filter, not the
  * "option → force off in connection-only → filter last" contract.
  *
+ * The post is passed to the filter so a callback can answer per post.
+ *
  * @since unreleased
  *
+ * @param \WP_Post $post The post being published.
  * @return bool True when the Bluesky companion post should be published. Default true.
  */
-function is_bluesky_post_enabled(): bool {
+function is_bluesky_post_enabled( \WP_Post $post ): bool {
 	/**
 	 * Filters whether a companion Bluesky feed post is published alongside the
 	 * site.standard.document record.
@@ -990,9 +993,10 @@ function is_bluesky_post_enabled(): bool {
 	 *
 	 * @since unreleased
 	 *
-	 * @param bool $enabled Whether to publish the Bluesky companion post. Default true.
+	 * @param bool     $enabled Whether to publish the Bluesky companion post. Default true.
+	 * @param \WP_Post $post    The post being published.
 	 */
-	return (bool) \apply_filters( 'atmosphere_should_publish_bluesky_post', true );
+	return (bool) \apply_filters( 'atmosphere_should_publish_bluesky_post', true, $post );
 }
 
 /**

--- a/tests/phpunit/tests/class-test-functions.php
+++ b/tests/phpunit/tests/class-test-functions.php
@@ -1075,17 +1075,46 @@ class Test_Functions extends \WP_UnitTestCase {
 	 * @group atmosphere
 	 */
 	public function test_is_bluesky_post_enabled_defaults_true() {
-		$this->assertTrue( is_bluesky_post_enabled() );
+		$post = self::factory()->post->create_and_get();
+		$this->assertTrue( is_bluesky_post_enabled( $post ) );
 	}
 
 	/**
-	 * The filter can disable the Bluesky companion post.
+	 * A site-wide (one-argument) callback still disables the companion post —
+	 * the added post parameter must not break callbacks that ignore it.
 	 *
 	 * @group atmosphere
 	 */
 	public function test_is_bluesky_post_enabled_filter_can_disable() {
+		$post = self::factory()->post->create_and_get();
+
 		\add_filter( 'atmosphere_should_publish_bluesky_post', '__return_false' );
-		$this->assertFalse( is_bluesky_post_enabled() );
+		$this->assertFalse( is_bluesky_post_enabled( $post ) );
 		\remove_filter( 'atmosphere_should_publish_bluesky_post', '__return_false' );
+	}
+
+	/**
+	 * The filter receives the post being published, so a callback can answer
+	 * per post — here, gating on the post type.
+	 *
+	 * @group atmosphere
+	 */
+	public function test_is_bluesky_post_enabled_filter_receives_post() {
+		$article = self::factory()->post->create_and_get( array( 'post_type' => 'post' ) );
+		$page    = self::factory()->post->create_and_get( array( 'post_type' => 'page' ) );
+
+		\add_filter(
+			'atmosphere_should_publish_bluesky_post',
+			static function ( $enabled, $post ) {
+				return 'page' === $post->post_type ? false : $enabled;
+			},
+			10,
+			2
+		);
+
+		$this->assertTrue( is_bluesky_post_enabled( $article ), 'Posts keep the Bluesky companion.' );
+		$this->assertFalse( is_bluesky_post_enabled( $page ), 'Pages are routed document-only.' );
+
+		\remove_all_filters( 'atmosphere_should_publish_bluesky_post' );
 	}
 }

--- a/tests/phpunit/tests/class-test-publisher.php
+++ b/tests/phpunit/tests/class-test-publisher.php
@@ -692,6 +692,47 @@ class Test_Publisher extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A per-post filter routes each post independently in a single run: a post
+	 * flagged "quiet" via post meta is written document-only while an ordinary
+	 * post keeps its Bluesky companion. Proves the post reaches the filter and
+	 * shapes that post's applyWrites batch.
+	 *
+	 * @group atmosphere
+	 * @group publisher
+	 */
+	public function test_publish_companion_decided_per_post() {
+		\add_filter(
+			'atmosphere_should_publish_bluesky_post',
+			static function ( $enabled, $post ) {
+				return \get_post_meta( $post->ID, 'quiet', true ) ? false : $enabled;
+			},
+			10,
+			2
+		);
+
+		$loud  = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+		$quiet = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+		\update_post_meta( $quiet->ID, 'quiet', '1' );
+
+		$this->register_capture( $loud->ID );
+
+		Publisher::publish_post( $loud );
+		Publisher::publish_post( $quiet );
+
+		$this->assertCount( 2, $this->captured_calls, 'Each post makes one applyWrites call.' );
+
+		$loud_writes = $this->captured_calls[0]['writes'];
+		$this->assertCount( 2, $loud_writes, 'The ordinary post keeps the Bluesky companion.' );
+		$loud_collections = \wp_list_pluck( $loud_writes, 'collection' );
+		$this->assertContains( 'app.bsky.feed.post', $loud_collections );
+		$this->assertContains( 'site.standard.document', $loud_collections );
+
+		$quiet_writes = $this->captured_calls[1]['writes'];
+		$this->assertCount( 1, $quiet_writes, 'The quiet post is written document-only.' );
+		$this->assertSame( 'site.standard.document', $quiet_writes[0]['collection'] );
+	}
+
+	/**
 	 * Doc-only update issues a single document #update against the stored TID.
 	 *
 	 * @group atmosphere


### PR DESCRIPTION
Fixes #239

## Proposed changes:

The `atmosphere_should_publish_bluesky_post` filter used to receive only the boolean, so a callback could answer for the whole site but never for the specific post being published. It now gets that post as a second argument, so an integration can route a status-update or activity-log post document-only while long-form posts keep their Bluesky companion, or honor a per-post "publish this one quietly" choice.

`is_bluesky_post_enabled()` now takes a required, non-nullable `WP_Post`, and both Publisher call sites pass it. I went with a required post rather than the issue's optional `?WP_Post $post = null`. Both (and the only) call sites always hold a real post, the filter is still unreleased so nothing depends on the old signature, and a guaranteed-real post means callbacks never need a `null` check. Site-wide callbacks like `__return_false` keep working unchanged, since WordPress only passes a filter the arguments it accepts.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

Add a per-post callback to a test site running the plugin, connected to an AT Protocol account:

```php
add_filter( 'atmosphere_should_publish_bluesky_post', function ( $enabled, $post ) {
	return get_post_meta( $post->ID, 'quiet', true ) ? false : $enabled;
}, 10, 2 );
```

* Publish an ordinary post. Both an `app.bsky.feed.post` and a `site.standard.document` record are written, and the post shows up on Bluesky.
* Publish a post with the `quiet` post meta set. Only the `site.standard.document` record is written, and nothing appears on Bluesky.
* Swap in a site-wide `add_filter( 'atmosphere_should_publish_bluesky_post', '__return_false' );` and confirm every post still goes document-only. The one-argument callback keeps working.
* `composer lint` and `npm run env-test` both pass (1121 tests).

### Changelog entry

The changelog entry is already committed on the branch (`.github/changelog/add-per-post-bluesky-companion`), so there's no need to auto-create one.

-   [ ] Automatically create a changelog entry from the details below.
