### PR TITLE
Add atmosphere_record_tags to filter the tags written into records

### DIFF
--- a/.agents/skills/code-style/SKILL.md
+++ b/.agents/skills/code-style/SKILL.md
@@ -58,6 +58,8 @@ Always reserve the rkey via meta in `get_rkey()` — that meta key is the marker
 
 **Transform filters:** `atmosphere_transform_bsky_post`, `atmosphere_transform_comment`, `atmosphere_transform_document`, `atmosphere_transform_publication`.
 
+**Records:** `atmosphere_record_tags` (tag/keyword list for both record types; runs before the 8-tag cap, so prefer it over the record-level transform filters for tag changes).
+
 **Content / composition:** `atmosphere_content_parser` (deprecated; use `Content_Parser\Registry::register()`), `atmosphere_document_content`, `atmosphere_long_form_composition`, `atmosphere_teaser_thread_posts`.
 
 **Gating:** `atmosphere_syncable_post_types`, `atmosphere_should_publish_comment`, `atmosphere_should_publish_bluesky_post` (return `false` for document-only publishing — no `app.bsky.feed.post` companion; pure filter, forward-only), `atmosphere_should_sync_reply`, `atmosphere_backfill_query_chunk_size`, `atmosphere_oauth_redirect_uri`, `atmosphere_client_metadata`, `atmosphere_publish_retry_delays` (backoff ladder for failed publish/update cron workers; length = retry budget; empty array disables retries).

--- a/.github/changelog/add-record-tags-filter
+++ b/.github/changelog/add-record-tags-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a way for sites to change the tags and keywords sent to Bluesky and standard.site, so leftover terms from an import stay out of the records.

--- a/docs/developer-docs.md
+++ b/docs/developer-docs.md
@@ -230,7 +230,9 @@ add_filter(
 );
 ```
 
-Prefer this over `atmosphere_transform_document` / `atmosphere_transform_bsky_post` for tag changes. Those run after the cap, so removing a tag there shortens the list rather than making room for the next one. Non-string entries are dropped from the return value, and the result is de-duplicated and capped again, so a filter cannot push a record past what the lexicons accept.
+Prefer this over `atmosphere_transform_document` / `atmosphere_transform_bsky_post` for tag changes. Those run after the cap, so removing a tag there shortens the list rather than making room for the next one.
+
+Non-string entries are dropped from the return value, and the result is de-duplicated and capped again, so a filter cannot write more than 8 tags into a record. The per-tag length limit (64 graphemes for `app.bsky.feed.post`) is not enforced, the same way it is not enforced for an over-long WordPress tag name, so a filter that builds tag names rather than picking from existing terms should keep them short itself.
 
 ATmosphere models one root publication per WordPress site. It verifies that publication at `/.well-known/site.standard.publication` and does not currently implement Standard.site's non-root publication verification path (`/.well-known/site.standard.publication/path/to/publication`). Social Standard.site lexicons such as `site.standard.graph.subscription` and `site.standard.graph.recommend` are also out of scope for the plugin's publishing flow; ATmosphere requests explicit `repo:` scopes only for `app.bsky.feed.post`, `site.standard.document`, and `site.standard.publication`, and intentionally keeps the documented `include:site.standard.authFull` permission set for Standard.site compatibility even though it does not publish or manage social records itself.
 

--- a/docs/developer-docs.md
+++ b/docs/developer-docs.md
@@ -44,6 +44,7 @@ ATmosphere exposes a small set of filters and actions for plugins to extend beha
 | `atmosphere_document_contributors` | filter | Add contributor metadata to `site.standard.document` records. |
 | `atmosphere_publication_labels` | filter | Add standard self-labels to `site.standard.publication` records. |
 | `atmosphere_publication_show_in_discover` | filter | Override `preferences.showInDiscover` (defaults to the site's `blog_public` option) for `site.standard.publication` records. |
+| `atmosphere_record_tags` | filter | Add, change, or remove the tags/keywords written into a post's records. Runs before the 8-tag cap and covers both the Bluesky post and the document. |
 | `atmosphere_syncable_post_types` | filter | Add or remove post types eligible for cross-posting. |
 | `atmosphere_connection_only_mode` | filter | Return `true` to embed ATmosphere purely as a connection layer: auto cross-posting, reaction/reply import, and comment publishing all default off, and the Settings → ATmosphere screen is hidden. |
 | `atmosphere_should_auto_publish` | filter | Effective on/off for automatic post cross-posting; runs after the stored setting and connection-only mode, and has the final say. |
@@ -214,6 +215,22 @@ add_filter( 'atmosphere_publication_show_in_discover', '__return_false' );
 ```
 
 The field-specific filters run before `atmosphere_transform_document` and `atmosphere_transform_publication`, so a final record-level filter can still inspect or override the complete record.
+
+### Tags and keywords
+
+A post's `tags` come from its post tags plus its categories (minus `uncategorized`), de-duplicated and capped at 8 by `Transformer\Base::collect_tags()`. The same list feeds the `app.bsky.feed.post` and the `site.standard.document`.
+
+`atmosphere_record_tags` filters that list before the cap:
+
+```php
+// Drop legacy terms a migration left behind.
+add_filter(
+	'atmosphere_record_tags',
+	static fn( array $tags ): array => array_values( array_diff( $tags, array( '1', 'imported' ) ) )
+);
+```
+
+Prefer this over `atmosphere_transform_document` / `atmosphere_transform_bsky_post` for tag changes. Those run after the cap, so removing a tag there shortens the list rather than making room for the next one. Non-string entries are dropped from the return value, and the result is de-duplicated and capped again, so a filter cannot push a record past what the lexicons accept.
 
 ATmosphere models one root publication per WordPress site. It verifies that publication at `/.well-known/site.standard.publication` and does not currently implement Standard.site's non-root publication verification path (`/.well-known/site.standard.publication/path/to/publication`). Social Standard.site lexicons such as `site.standard.graph.subscription` and `site.standard.graph.recommend` are also out of scope for the plugin's publishing flow; ATmosphere requests explicit `repo:` scopes only for `app.bsky.feed.post`, `site.standard.document`, and `site.standard.publication`, and intentionally keeps the documented `include:site.standard.authFull` permission set for Standard.site compatibility even though it does not publish or manage social records itself.
 

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -203,7 +203,7 @@ abstract class Base {
 	 *
 	 * @var int
 	 */
-	protected const MAX_TAGS = 8;
+	private const MAX_TAGS = 8;
 
 	/**
 	 * Collect tags from post taxonomies (max 8, no "uncategorized").
@@ -249,7 +249,13 @@ abstract class Base {
 		 * The return value is normalized before use. Entries that are
 		 * not strings are dropped, the rest are trimmed, empties are
 		 * removed, and the result is de-duplicated and capped again at
-		 * {@see self::MAX_TAGS}.
+		 * {@see self::MAX_TAGS}. That bounds how many tags a record
+		 * carries, not how long each one is: both lexicons also bound a
+		 * single tag (64 graphemes for `app.bsky.feed.post`), and an
+		 * over-long entry is passed through as-is, exactly as an
+		 * over-long WordPress tag name already is. A filter that builds
+		 * tag names rather than picking from existing terms should keep
+		 * them short itself.
 		 *
 		 * @since unreleased
 		 *
@@ -275,6 +281,13 @@ abstract class Base {
 		 * deliberate: `(string) $term` on a WP_Term would fatal, and
 		 * stringifying an integer would quietly write the junk keyword
 		 * this filter mostly exists to remove.
+		 *
+		 * Deliberately quieter than the non-array branch above, which
+		 * does call `_doing_it_wrong()`. A filter returning the wrong
+		 * type outright is a bug in that filter; a filter returning a
+		 * mixed list is usually a `get_terms()` result someone forgot to
+		 * pluck, and warning once per post across a backfill would be
+		 * noise rather than signal.
 		 */
 		$normalized = array();
 

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -191,6 +191,21 @@ abstract class Base {
 	}
 
 	/**
+	 * Maximum tags written into a record.
+	 *
+	 * Both `app.bsky.feed.post` and `site.standard.document` cap their
+	 * `tags` array at 8, so the limit is applied here rather than in
+	 * each transformer. It is enforced after
+	 * `atmosphere_record_tags` runs, so a filter cannot push a record
+	 * past what the lexicons accept.
+	 *
+	 * @since unreleased
+	 *
+	 * @var int
+	 */
+	protected const MAX_TAGS = 8;
+
+	/**
 	 * Collect tags from post taxonomies (max 8, no "uncategorized").
 	 *
 	 * @param \WP_Post $post Post object.
@@ -215,7 +230,67 @@ abstract class Base {
 			}
 		}
 
-		return \array_slice( \array_unique( $tags ), 0, 8 );
+		$tags = \array_values( \array_unique( $tags ) );
+
+		/**
+		 * Filters the tag list for a post's AT Protocol records.
+		 *
+		 * Runs before the 8-tag cap and before any record is built, so
+		 * the `app.bsky.feed.post` and the `site.standard.document` for
+		 * a post always see the same list. Use it to drop junk terms a
+		 * migration left behind, or to feed the records from a taxonomy
+		 * the plugin does not read.
+		 *
+		 * This is the filter to reach for rather than
+		 * `atmosphere_transform_document` / `atmosphere_transform_bsky_post`:
+		 * those run after the cap, so dropping a tag there shortens the
+		 * list instead of making room for the next one.
+		 *
+		 * The return value is normalized before use. Entries that are
+		 * not strings are dropped, the rest are trimmed, empties are
+		 * removed, and the result is de-duplicated and capped again at
+		 * {@see self::MAX_TAGS}.
+		 *
+		 * @since unreleased
+		 *
+		 * @param string[] $tags Tag names collected from the post's tags and categories.
+		 * @param \WP_Post $post WordPress post.
+		 */
+		$filtered = \apply_filters( 'atmosphere_record_tags', $tags, $post );
+
+		if ( ! \is_array( $filtered ) ) {
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'atmosphere_record_tags must return an array; falling back to the unfiltered tags.', 'atmosphere' ),
+				'unreleased'
+			);
+			$filtered = $tags;
+		}
+
+		/*
+		 * Normalize whatever came back. A record's `tags` entries have
+		 * to be strings, and this list is written to the PDS unescaped,
+		 * so a filter returning term objects or integers must not reach
+		 * the transformer. Dropping silently rather than casting is
+		 * deliberate: `(string) $term` on a WP_Term would fatal, and
+		 * stringifying an integer would quietly write the junk keyword
+		 * this filter mostly exists to remove.
+		 */
+		$normalized = array();
+
+		foreach ( $filtered as $tag ) {
+			if ( ! \is_string( $tag ) ) {
+				continue;
+			}
+
+			$tag = \trim( $tag );
+
+			if ( '' !== $tag ) {
+				$normalized[] = $tag;
+			}
+		}
+
+		return \array_slice( \array_values( \array_unique( $normalized ) ), 0, self::MAX_TAGS );
 	}
 
 	/**

--- a/tests/phpunit/tests/transformer/class-test-base.php
+++ b/tests/phpunit/tests/transformer/class-test-base.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * Tests for the shared transformer base class.
+ *
+ * `Transformer\Base::collect_tags()` collects the tag list once and
+ * feeds both the `app.bsky.feed.post` and the `site.standard.document`,
+ * so the records are asserted through the concrete transformers that
+ * extend it.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group transformer
+ */
+
+namespace Atmosphere\Tests\Transformer;
+
+use Atmosphere\Transformer\Document;
+use Atmosphere\Transformer\Post;
+
+/**
+ * Transformer base class tests.
+ */
+class Test_Base extends \WP_UnitTestCase {
+
+	/**
+	 * Drop anything a test hooked on, so ordering between tests in this
+	 * file (and the files after it) stays irrelevant.
+	 */
+	public function tear_down(): void {
+		\remove_all_filters( 'atmosphere_record_tags' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a published post carrying the given tags.
+	 *
+	 * @param string[] $tags Tag names.
+	 * @return \WP_Post
+	 */
+	private function post_with_tags( array $tags ): \WP_Post {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'Hello',
+				'post_content' => 'Body.',
+				'post_status'  => 'publish',
+			)
+		);
+
+		\wp_set_post_tags( $post->ID, $tags );
+
+		return \get_post( $post->ID );
+	}
+
+	/**
+	 * Baseline: tags are collected, "uncategorized" is left out, and the
+	 * list is capped at 8 when nothing filters it.
+	 */
+	public function test_unfiltered_tags_are_capped_at_eight() {
+		$post   = $this->post_with_tags( array( '1', 'a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8' ) );
+		$record = ( new Document( $post ) )->transform();
+
+		$this->assertCount( 8, $record['tags'] );
+		$this->assertContains( '1', $record['tags'] );
+		$this->assertNotContains( 'Uncategorized', $record['tags'] );
+	}
+
+	/**
+	 * The filter runs before the cap: dropping one of nine tags leaves a
+	 * full list of 8, not a short list of 7.
+	 *
+	 * This is the whole reason the hook exists. The record-level
+	 * `atmosphere_transform_*` filters can already remove a tag, but
+	 * they run after the slice.
+	 */
+	public function test_filter_runs_before_the_cap() {
+		$post = $this->post_with_tags( array( '1', 'a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8' ) );
+
+		\add_filter(
+			'atmosphere_record_tags',
+			static fn( array $tags ): array => \array_values( \array_diff( $tags, array( '1' ) ) )
+		);
+
+		$record = ( new Document( $post ) )->transform();
+
+		$this->assertCount( 8, $record['tags'] );
+		$this->assertNotContains( '1', $record['tags'] );
+	}
+
+	/**
+	 * Both record types read the same filtered list, so a site only has
+	 * to hook once.
+	 */
+	public function test_filter_applies_to_both_record_types() {
+		$post = $this->post_with_tags( array( '1', 'keep' ) );
+
+		\add_filter(
+			'atmosphere_record_tags',
+			static fn( array $tags ): array => \array_values( \array_diff( $tags, array( '1' ) ) )
+		);
+
+		$document = ( new Document( $post ) )->transform();
+		$bsky     = ( new Post( $post ) )->transform();
+
+		$this->assertSame( array( 'keep' ), $document['tags'] );
+		$this->assertSame( array( 'keep' ), $bsky['tags'] );
+	}
+
+	/**
+	 * The post is passed through, so a filter can scope itself to a
+	 * single post type, author, or date range.
+	 */
+	public function test_filter_receives_the_post() {
+		$post     = $this->post_with_tags( array( 'keep' ) );
+		$received = null;
+
+		\add_filter(
+			'atmosphere_record_tags',
+			static function ( array $tags, \WP_Post $filtered_post ) use ( &$received ): array {
+				$received = $filtered_post;
+
+				return $tags;
+			},
+			10,
+			2
+		);
+
+		( new Document( $post ) )->transform();
+
+		$this->assertInstanceOf( \WP_Post::class, $received );
+		$this->assertSame( $post->ID, $received->ID );
+	}
+
+	/**
+	 * Returning an empty list drops the field entirely rather than
+	 * writing an empty array into the record.
+	 */
+	public function test_filter_can_remove_every_tag() {
+		$post = $this->post_with_tags( array( '1' ) );
+
+		\add_filter( 'atmosphere_record_tags', '__return_empty_array' );
+
+		$record = ( new Document( $post ) )->transform();
+
+		$this->assertArrayNotHasKey( 'tags', $record );
+	}
+
+	/**
+	 * A filter that returns a non-array is reported and ignored, rather
+	 * than propagating into the record and fataling inside applyWrites.
+	 */
+	public function test_non_array_return_falls_back_to_the_unfiltered_tags() {
+		$this->setExpectedIncorrectUsage( 'Atmosphere\\Transformer\\Base::collect_tags' );
+
+		$post = $this->post_with_tags( array( 'keep' ) );
+
+		\add_filter( 'atmosphere_record_tags', static fn() => 'not-an-array' );
+
+		$record = ( new Document( $post ) )->transform();
+
+		$this->assertSame( array( 'keep' ), $record['tags'] );
+	}
+
+	/**
+	 * Whatever comes back is normalized before it reaches the record:
+	 * non-strings are dropped, entries are trimmed, blanks are removed,
+	 * and duplicates collapse.
+	 */
+	public function test_filter_return_value_is_normalized() {
+		$post = $this->post_with_tags( array( 'keep' ) );
+
+		\add_filter(
+			'atmosphere_record_tags',
+			static fn(): array => array(
+				'  padded  ',
+				'',
+				'   ',
+				42,
+				null,
+				array( 'nested' ),
+				'dupe',
+				'dupe',
+			)
+		);
+
+		$record = ( new Document( $post ) )->transform();
+
+		$this->assertSame( array( 'padded', 'dupe' ), $record['tags'] );
+	}
+
+	/**
+	 * A filter that adds tags cannot push a record past what the
+	 * lexicons accept.
+	 */
+	public function test_filter_cannot_exceed_the_cap() {
+		$post = $this->post_with_tags( array( 'keep' ) );
+
+		\add_filter(
+			'atmosphere_record_tags',
+			static fn(): array => array( 't1', 't2', 't3', 't4', 't5', 't6', 't7', 't8', 't9', 't10' )
+		);
+
+		$record = ( new Document( $post ) )->transform();
+
+		$this->assertCount( 8, $record['tags'] );
+	}
+}


### PR DESCRIPTION
Fixes #242

## Proposed changes:

Adds `atmosphere_record_tags`, a filter for the tag list a post writes into its AT Protocol records.

Techdirt carries a stray `1` tag on every post, a leftover from their Drupal migration. It is hidden on their own front end, but we write it into both the `site.standard.document` and the Bluesky post, where it shows up as a junk keyword. They are about to backfill their whole archive, so we would rather fix this at the plugin layer than touch the partner's post data.

There were already two ways to do it and neither is good:

* The record-level filters (`atmosphere_transform_document` / `atmosphere_transform_bsky_post`) run *after* `collect_tags()` has capped the list at 8, so removing a tag there leaves 7 instead of pulling the next one in.
* Core's `get_the_tags` does apply before the cap, but it is global, so it changes the site's own front end too.

So the new filter sits inside `Transformer\Base::collect_tags()`, after the de-duplication and before the slice. Both record types call that one method, so a site only has to hook once.

The return value is normalized before it reaches a record: non-string entries are dropped, the rest are trimmed, blanks are removed, and the result is de-duplicated and capped again at `Base::MAX_TAGS`. Dropping non-strings rather than casting them is deliberate. `(string)` on a `WP_Term` would fatal, and stringifying an integer would quietly write back the kind of junk keyword this filter mostly exists to remove. A non-array return triggers `_doing_it_wrong` and falls back to the unfiltered list, the same way the `atmosphere_transform_*` filters already behave.

Nothing changes when no one hooks it.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Add a few tags to a published post, one of them called `1`.
2. Open the post with `?atproto=all` while logged in. Both the `site.standard.document` and the `app.bsky.feed.post` should list `1` under `tags`.
3. Drop this into an mu-plugin:

```php
add_filter(
	'atmosphere_record_tags',
	static fn( array $tags ): array => array_values( array_diff( $tags, array( '1' ) ) )
);
```

4. Reload `?atproto=all`. The `1` should be gone from both records.
5. Now give the post 9 tags, still including `1`, and keep the filter active. The record should still carry 8 tags and none of them should be `1`. That is the part the record-level filters cannot do: without running before the cap you would end up with 7.
6. Remove the filter again and confirm the records look exactly as they did in step 2.

`npm run env-test -- --filter=Test_Base` covers all of the above, plus the malformed-return cases (non-array, non-string entries, blanks, duplicates, and a filter trying to exceed the cap).

### Changelog entry

The entry is already committed on the branch as `.github/changelog/add-record-tags-filter`, no need to tick the box below.
