### PR TITLE
Handle Bluesky rate limits when sharing and backfilling

### DIFF
--- a/.github/changelog/add-rate-limit-awareness
+++ b/.github/changelog/add-rate-limit-awareness
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Handle Bluesky rate limits when sharing: a share that hits the limit now waits for it to lift before retrying, and bulk syncs can be paced so they stay under it.

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -136,7 +136,7 @@ class API {
 			$body = array();
 		}
 
-		self::capture_rate_limit( $response );
+		$rate_limit = self::capture_rate_limit( $response );
 
 		// Persist any nonce the server sends back.
 		$response_nonce = \wp_remote_retrieve_header( $response, 'dpop-nonce' );
@@ -242,7 +242,7 @@ class API {
 		 * Waiting is the caller's decision.
 		 */
 		if ( 429 === $status ) {
-			return self::rate_limited_error( $body );
+			return self::rate_limited_error( $body, $rate_limit );
 		}
 
 		if ( ! is_success_status( $status ) ) {
@@ -263,13 +263,17 @@ class API {
 	 * A response without any of the headers leaves the previous reading
 	 * in place rather than clearing it: an intermediary that strips them
 	 * on one call should not erase what the last real answer told us.
+	 * The return value is still null in that case, so a caller reasoning
+	 * about *this* response cannot mistake a stale reading for a fresh
+	 * one.
 	 *
 	 * @since unreleased
 	 *
 	 * @param array $response Raw `wp_remote_*` response.
-	 * @return void
+	 * @return array|null Snapshot for this response, or null when it
+	 *                    carried no rate-limit headers.
 	 */
-	private static function capture_rate_limit( array $response ): void {
+	private static function capture_rate_limit( array $response ): ?array {
 		/*
 		 * `wp_remote_retrieve_header()` returns an array when a header
 		 * repeats, so each read is guarded by a type check rather than a
@@ -288,10 +292,12 @@ class API {
 		);
 
 		if ( null === $snapshot['limit'] && null === $snapshot['remaining'] && null === $snapshot['reset'] ) {
-			return;
+			return null;
 		}
 
 		self::$last_rate_limit = $snapshot;
+
+		return $snapshot;
 	}
 
 	/**
@@ -333,13 +339,19 @@ class API {
 	 * neither, both are null and the caller falls back to its own
 	 * backoff — the error code alone is still the useful signal.
 	 *
+	 * Reads only the snapshot from the 429 itself, never the stored
+	 * one. Reporting an earlier request's reset time here would send a
+	 * caller back at a moment that has nothing to do with the window it
+	 * actually hit.
+	 *
 	 * @since unreleased
 	 *
-	 * @param array $body Decoded response body.
+	 * @param array      $body     Decoded response body.
+	 * @param array|null $snapshot Rate-limit headers on this response.
 	 * @return \WP_Error
 	 */
-	private static function rate_limited_error( array $body ): \WP_Error {
-		$snapshot = self::$last_rate_limit ?? array();
+	private static function rate_limited_error( array $body, ?array $snapshot ): \WP_Error {
+		$snapshot = $snapshot ?? array();
 		$reset    = $snapshot['reset'] ?? null;
 
 		$message = $body['message'] ?? ( $body['error'] ?? \__( 'The PDS rate limit was reached.', 'atmosphere' ) );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -21,6 +21,36 @@ use Atmosphere\OAuth\DPoP;
 class API {
 
 	/**
+	 * Latest rate-limit snapshot the PDS reported.
+	 *
+	 * Shape: `[ 'limit' => ?int, 'remaining' => ?int, 'reset' => ?int,
+	 * 'policy' => ?string ]`, where `reset` is a Unix timestamp. Null
+	 * until a response in this process has carried the headers.
+	 *
+	 * Process-local on purpose. A long-running `wp atmosphere backfill`
+	 * wants to know what the last write cost it; an ordinary web request
+	 * does not, and persisting the reading would mean an option write on
+	 * every single PDS call.
+	 *
+	 * @since unreleased
+	 *
+	 * @var array|null
+	 */
+	private static ?array $last_rate_limit = null;
+
+	/**
+	 * Read the most recent rate-limit snapshot reported by the PDS.
+	 *
+	 * @since unreleased
+	 *
+	 * @return array|null Snapshot, or null when no response in this
+	 *                    process carried the `ratelimit-*` headers.
+	 */
+	public static function last_rate_limit(): ?array {
+		return self::$last_rate_limit;
+	}
+
+	/**
 	 * Send a DPoP-authenticated request to the connected PDS.
 	 *
 	 * @param string      $method       HTTP method.
@@ -105,6 +135,8 @@ class API {
 		if ( ! \is_array( $body ) ) {
 			$body = array();
 		}
+
+		self::capture_rate_limit( $response );
 
 		// Persist any nonce the server sends back.
 		$response_nonce = \wp_remote_retrieve_header( $response, 'dpop-nonce' );
@@ -195,12 +227,134 @@ class API {
 			return self::request( $method, $endpoint, $original_args, null, true );
 		}
 
+		/*
+		 * A 429 is not a generic PDS failure. It is temporary, the server
+		 * tells us exactly when it clears, and callers can do something
+		 * useful with that: the publish retry ladder can wait for the
+		 * window instead of guessing, and `wp atmosphere backfill` can
+		 * stop cleanly instead of grinding the rest of the queue into
+		 * identical 429s. So it gets its own error code, with the reset
+		 * time in the error data.
+		 *
+		 * Deliberately no sleeping here. This method also runs inside
+		 * ordinary web requests (an editor publish, a REST call), where
+		 * blocking the response for minutes is worse than failing fast.
+		 * Waiting is the caller's decision.
+		 */
+		if ( 429 === $status ) {
+			return self::rate_limited_error( $body );
+		}
+
 		if ( ! is_success_status( $status ) ) {
 			$msg = $body['message'] ?? ( $body['error'] ?? \__( 'PDS request failed.', 'atmosphere' ) );
 			return new \WP_Error( 'atmosphere_pds', $msg, array( 'status' => $status ) );
 		}
 
 		return \is_array( $body ) ? $body : array();
+	}
+
+	/**
+	 * Store the rate-limit headers from a PDS response.
+	 *
+	 * Every PDS response carries these, not just the 429s, so the
+	 * snapshot doubles as a "how much budget is left" reading that a
+	 * long backfill can pace itself against.
+	 *
+	 * A response without any of the headers leaves the previous reading
+	 * in place rather than clearing it: an intermediary that strips them
+	 * on one call should not erase what the last real answer told us.
+	 *
+	 * @since unreleased
+	 *
+	 * @param array $response Raw `wp_remote_*` response.
+	 * @return void
+	 */
+	private static function capture_rate_limit( array $response ): void {
+		/*
+		 * `wp_remote_retrieve_header()` returns an array when a header
+		 * repeats, so each read is guarded by a type check rather than a
+		 * bare cast: `(int) array()` would be a fatal in PHP 8.
+		 */
+		$limit     = \wp_remote_retrieve_header( $response, 'ratelimit-limit' );
+		$remaining = \wp_remote_retrieve_header( $response, 'ratelimit-remaining' );
+		$reset     = \wp_remote_retrieve_header( $response, 'ratelimit-reset' );
+		$policy    = \wp_remote_retrieve_header( $response, 'ratelimit-policy' );
+
+		$snapshot = array(
+			'limit'     => \is_numeric( $limit ) ? (int) $limit : null,
+			'remaining' => \is_numeric( $remaining ) ? (int) $remaining : null,
+			'reset'     => self::reset_timestamp( $reset ),
+			'policy'    => \is_string( $policy ) && '' !== $policy ? $policy : null,
+		);
+
+		if ( null === $snapshot['limit'] && null === $snapshot['remaining'] && null === $snapshot['reset'] ) {
+			return;
+		}
+
+		self::$last_rate_limit = $snapshot;
+	}
+
+	/**
+	 * Normalize a `ratelimit-reset` header into a Unix timestamp.
+	 *
+	 * Bluesky's PDS sends an absolute Unix timestamp. The IETF
+	 * RateLimit header draft allows delta-seconds instead, and a
+	 * self-hosted PDS sitting behind a different proxy may well send
+	 * that, so small values are read as "seconds from now". The cutoff
+	 * is arbitrary but safe in both directions: no plausible delta
+	 * reaches three decades in seconds, and no timestamp we care about
+	 * predates 2001.
+	 *
+	 * @since unreleased
+	 *
+	 * @param mixed $raw Raw header value.
+	 * @return int|null Unix timestamp, or null when unreadable.
+	 */
+	private static function reset_timestamp( $raw ): ?int {
+		if ( ! \is_numeric( $raw ) ) {
+			return null;
+		}
+
+		$value = (int) $raw;
+
+		if ( $value <= 0 ) {
+			return null;
+		}
+
+		return $value > 1000000000 ? $value : \time() + $value;
+	}
+
+	/**
+	 * Build the error returned for an HTTP 429 from the PDS.
+	 *
+	 * `retry_after` is the derived "wait this many seconds" value
+	 * callers actually want; `reset` is carried alongside it so a
+	 * message can name the wall-clock moment. When the PDS sends
+	 * neither, both are null and the caller falls back to its own
+	 * backoff — the error code alone is still the useful signal.
+	 *
+	 * @since unreleased
+	 *
+	 * @param array $body Decoded response body.
+	 * @return \WP_Error
+	 */
+	private static function rate_limited_error( array $body ): \WP_Error {
+		$snapshot = self::$last_rate_limit ?? array();
+		$reset    = $snapshot['reset'] ?? null;
+
+		$message = $body['message'] ?? ( $body['error'] ?? \__( 'The PDS rate limit was reached.', 'atmosphere' ) );
+
+		return new \WP_Error(
+			'atmosphere_rate_limited',
+			$message,
+			array(
+				'status'      => 429,
+				'reset'       => $reset,
+				'retry_after' => null === $reset ? null : \max( 0, $reset - \time() ),
+				'limit'       => $snapshot['limit'] ?? null,
+				'remaining'   => $snapshot['remaining'] ?? null,
+			)
+		);
 	}
 
 	/**

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -23,9 +23,9 @@ class API {
 	/**
 	 * Latest rate-limit snapshot the PDS reported.
 	 *
-	 * Shape: `[ 'limit' => ?int, 'remaining' => ?int, 'reset' => ?int,
-	 * 'policy' => ?string ]`, where `reset` is a Unix timestamp. Null
-	 * until a response in this process has carried the headers.
+	 * Shape: `[ 'limit' => ?int, 'remaining' => ?int, 'reset' => ?int ]`,
+	 * where `reset` is a Unix timestamp. Null until a response in this
+	 * process has carried the headers.
 	 *
 	 * Process-local on purpose. A long-running `wp atmosphere backfill`
 	 * wants to know what the last write cost it; an ordinary web request
@@ -48,6 +48,32 @@ class API {
 	 */
 	public static function last_rate_limit(): ?array {
 		return self::$last_rate_limit;
+	}
+
+	/**
+	 * Error code minted for a PDS rate limit (HTTP 429).
+	 *
+	 * Declared next to the method that mints it so consumers classify a
+	 * failure through {@see API::is_rate_limit_error()} instead of
+	 * typing the string at every call site, the same convention
+	 * {@see Client::is_reconnect_error()} follows.
+	 *
+	 * @since unreleased
+	 *
+	 * @var string
+	 */
+	public const RATE_LIMITED = 'atmosphere_rate_limited';
+
+	/**
+	 * Whether a failure is a rate limit reported by the PDS.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_Error $error Failure to classify.
+	 * @return bool
+	 */
+	public static function is_rate_limit_error( \WP_Error $error ): bool {
+		return self::RATE_LIMITED === $error->get_error_code();
 	}
 
 	/**
@@ -246,11 +272,28 @@ class API {
 		}
 
 		if ( ! is_success_status( $status ) ) {
-			$msg = $body['message'] ?? ( $body['error'] ?? \__( 'PDS request failed.', 'atmosphere' ) );
+			$msg = self::error_message( $body, \__( 'PDS request failed.', 'atmosphere' ) );
 			return new \WP_Error( 'atmosphere_pds', $msg, array( 'status' => $status ) );
 		}
 
 		return \is_array( $body ) ? $body : array();
+	}
+
+	/**
+	 * Pull the human-readable failure text out of a PDS error body.
+	 *
+	 * The PDS uses `message` for the prose and `error` for the machine
+	 * name, but not every failure carries both, so the caller supplies
+	 * the wording for the case where neither is there.
+	 *
+	 * @since unreleased
+	 *
+	 * @param array  $body     Decoded response body.
+	 * @param string $fallback Message to use when the body says nothing.
+	 * @return string
+	 */
+	private static function error_message( array $body, string $fallback ): string {
+		return $body['message'] ?? ( $body['error'] ?? $fallback );
 	}
 
 	/**
@@ -282,13 +325,11 @@ class API {
 		$limit     = \wp_remote_retrieve_header( $response, 'ratelimit-limit' );
 		$remaining = \wp_remote_retrieve_header( $response, 'ratelimit-remaining' );
 		$reset     = \wp_remote_retrieve_header( $response, 'ratelimit-reset' );
-		$policy    = \wp_remote_retrieve_header( $response, 'ratelimit-policy' );
 
 		$snapshot = array(
 			'limit'     => \is_numeric( $limit ) ? (int) $limit : null,
 			'remaining' => \is_numeric( $remaining ) ? (int) $remaining : null,
 			'reset'     => self::reset_timestamp( $reset ),
-			'policy'    => \is_string( $policy ) && '' !== $policy ? $policy : null,
 		);
 
 		if ( null === $snapshot['limit'] && null === $snapshot['remaining'] && null === $snapshot['reset'] ) {
@@ -351,14 +392,11 @@ class API {
 	 * @return \WP_Error
 	 */
 	private static function rate_limited_error( array $body, ?array $snapshot ): \WP_Error {
-		$snapshot = $snapshot ?? array();
-		$reset    = $snapshot['reset'] ?? null;
-
-		$message = $body['message'] ?? ( $body['error'] ?? \__( 'The PDS rate limit was reached.', 'atmosphere' ) );
+		$reset = $snapshot['reset'] ?? null;
 
 		return new \WP_Error(
-			'atmosphere_rate_limited',
-			$message,
+			self::RATE_LIMITED,
+			self::error_message( $body, \__( 'The PDS rate limit was reached.', 'atmosphere' ) ),
 			array(
 				'status'      => 429,
 				'reset'       => $reset,

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -2589,10 +2589,14 @@ class Atmosphere {
 	 * retrying before then is guaranteed to burn a rung of the ladder on
 	 * an identical 429. So the longer of the two wins.
 	 *
-	 * The result is capped at an hour. A malformed or hostile
-	 * `ratelimit-reset` should not be able to park a queued publish days
-	 * into the future — at that point the ladder has effectively been
-	 * disabled by a header we do not control.
+	 * Only the PDS-supplied wait is capped, and at a day rather than an
+	 * hour: Bluesky budgets repo writes per day as well as per hour, so
+	 * a daily-limit 429 legitimately reports a reset most of a day out,
+	 * and an hour-capped wait would spend every rung of the ladder
+	 * inside a window that is still closed. The cap is there so a
+	 * malformed or hostile `ratelimit-reset` cannot park a queued
+	 * publish weeks into the future; it must never shorten the ladder's
+	 * own step, which is why it applies to the header value alone.
 	 *
 	 * @since unreleased
 	 *
@@ -2612,7 +2616,7 @@ class Atmosphere {
 		 * Pad by a second so the retry lands just after the window
 		 * rolls over rather than exactly on the boundary.
 		 */
-		return \min( \max( $delay, $retry_after + 1 ), HOUR_IN_SECONDS );
+		return \max( $delay, \min( $retry_after + 1, DAY_IN_SECONDS ) );
 	}
 
 	/**

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -2574,10 +2574,45 @@ class Atmosphere {
 		self::record_publish_error( $post_id, $result, true );
 		\update_post_meta( $post_id, self::META_PUBLISH_RETRIES, $attempts + 1 );
 		\wp_schedule_single_event(
-			\time() + $delays[ $attempts ],
+			\time() + self::publish_retry_delay( $delays[ $attempts ], $result ),
 			$hook,
 			array( $post_id )
 		);
+	}
+
+	/**
+	 * Resolve how long to wait before the next publish attempt.
+	 *
+	 * Normally this is just the ladder's own step. The exception is a
+	 * rate-limited PDS: it tells us exactly when the window rolls over
+	 * (`API::rate_limited_error()` carries that as `retry_after`), and
+	 * retrying before then is guaranteed to burn a rung of the ladder on
+	 * an identical 429. So the longer of the two wins.
+	 *
+	 * The result is capped at an hour. A malformed or hostile
+	 * `ratelimit-reset` should not be able to park a queued publish days
+	 * into the future — at that point the ladder has effectively been
+	 * disabled by a header we do not control.
+	 *
+	 * @since unreleased
+	 *
+	 * @param int       $delay Ladder delay for this attempt, in seconds.
+	 * @param \WP_Error $error The failure being retried.
+	 * @return int Seconds to wait.
+	 */
+	private static function publish_retry_delay( int $delay, \WP_Error $error ): int {
+		$data        = $error->get_error_data();
+		$retry_after = \is_array( $data ) && isset( $data['retry_after'] ) ? (int) $data['retry_after'] : 0;
+
+		if ( $retry_after <= 0 ) {
+			return $delay;
+		}
+
+		/*
+		 * Pad by a second so the retry lands just after the window
+		 * rolls over rather than exactly on the boundary.
+		 */
+		return \min( \max( $delay, $retry_after + 1 ), HOUR_IN_SECONDS );
 	}
 
 	/**

--- a/includes/class-publisher.php
+++ b/includes/class-publisher.php
@@ -735,6 +735,62 @@ class Publisher {
 	}
 
 	/**
+	 * Error-data key carrying the failure that triggered a rollback.
+	 *
+	 * @since unreleased
+	 *
+	 * @var string
+	 */
+	private const ERROR_KEY_ORIGINAL = 'original_error';
+
+	/**
+	 * Error-data key carrying the failure the rollback itself hit.
+	 *
+	 * @since unreleased
+	 *
+	 * @var string
+	 */
+	private const ERROR_KEY_ROLLBACK = 'rollback_error';
+
+	/**
+	 * Unwrap the failures a Publisher error was built from.
+	 *
+	 * `atmosphere_thread_rollback_failed` is the one error the Publisher
+	 * nests inside another (see {@see Publisher::rollback_thread()}),
+	 * and a caller that classifies failures has to be able to see
+	 * through it: a rate limit that lands on a thread reply reaches the
+	 * caller wrapped in a rollback failure rather than as itself. The
+	 * keys live here, next to the method that writes them, so a rename
+	 * cannot silently break a consumer.
+	 *
+	 * An ordinary unwrapped failure returns an empty array, so a caller
+	 * can classify the error itself and then walk this without
+	 * special-casing the shape.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_Error $error Failure returned by the Publisher.
+	 * @return \WP_Error[] The nested failures, in declaration order.
+	 */
+	public static function underlying_errors( \WP_Error $error ): array {
+		$data = $error->get_error_data();
+
+		if ( ! \is_array( $data ) ) {
+			return array();
+		}
+
+		$nested = array();
+
+		foreach ( array( self::ERROR_KEY_ORIGINAL, self::ERROR_KEY_ROLLBACK ) as $key ) {
+			if ( ( $data[ $key ] ?? null ) instanceof \WP_Error ) {
+				$nested[] = $data[ $key ];
+			}
+		}
+
+		return $nested;
+	}
+
+	/**
 	 * Delete every already-written record in a partially-published thread.
 	 *
 	 * Posts are deleted tail-first so the root survives until last —
@@ -799,9 +855,9 @@ class Publisher {
 					$original_error->get_error_message()
 				),
 				array(
-					'original_error'  => $original_error,
-					'rollback_error'  => $rollback_result,
-					'partial_records' => $thread_records,
+					self::ERROR_KEY_ORIGINAL => $original_error,
+					self::ERROR_KEY_ROLLBACK => $rollback_result,
+					'partial_records'        => $thread_records,
 				)
 			);
 		}

--- a/includes/cli/class-backfill-command.php
+++ b/includes/cli/class-backfill-command.php
@@ -351,7 +351,7 @@ class Backfill_Command extends \WP_CLI_Command {
 						: Publisher::publish_post( $post, $original_time );
 
 					if ( \is_wp_error( $result ) ) {
-						$reached_pds = true;
+						$reached_pds = self::spent_write_budget( $result );
 
 						\WP_CLI::warning(
 							\sprintf(
@@ -584,15 +584,51 @@ class Backfill_Command extends \WP_CLI_Command {
 			return \__( 'Connection to AT Protocol was lost; aborting the remaining posts.', 'atmosphere' );
 		}
 
-		$candidates = \array_merge( array( $error ), Publisher::underlying_errors( $error ) );
-
-		foreach ( $candidates as $candidate ) {
+		foreach ( self::failure_chain( $error ) as $candidate ) {
 			if ( API::is_rate_limit_error( $candidate ) ) {
 				return self::rate_limit_message( $candidate );
 			}
 		}
 
 		return null;
+	}
+
+	/**
+	 * A publish failure plus whatever failures it wraps.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_Error $error Failure returned by the Publisher.
+	 * @return \WP_Error[] The failure itself first, then its causes.
+	 */
+	private static function failure_chain( \WP_Error $error ): array {
+		return \array_merge( array( $error ), Publisher::underlying_errors( $error ) );
+	}
+
+	/**
+	 * Whether a failed post still cost the account rate-limit budget.
+	 *
+	 * Only a failure the PDS actually answered carries an HTTP status.
+	 * A locally-generated one (a missing TID, a filter short-circuiting
+	 * the write, a lost connection) never left the site, so throttling
+	 * after it would sleep for nothing. A failed thread rollback keeps
+	 * its status one level down, hence the walk.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_Error $error Failure returned by the Publisher.
+	 * @return bool
+	 */
+	private static function spent_write_budget( \WP_Error $error ): bool {
+		foreach ( self::failure_chain( $error ) as $candidate ) {
+			$data = $candidate->get_error_data();
+
+			if ( \is_array( $data ) && isset( $data['status'] ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/cli/class-backfill-command.php
+++ b/includes/cli/class-backfill-command.php
@@ -9,6 +9,7 @@ namespace Atmosphere\Cli;
 
 \defined( 'ABSPATH' ) || exit;
 
+use Atmosphere\API;
 use Atmosphere\Backfill;
 use Atmosphere\Publisher;
 use Atmosphere\Transformer\Document;
@@ -147,8 +148,8 @@ class Backfill_Command extends \WP_CLI_Command {
 		 * absent --throttle both mean "no wait". See
 		 * self::whole_number_flag() for why the validation is this strict.
 		 */
-		$limit    = self::whole_number_flag( $assoc_args, 'limit', 0 );
-		$throttle = self::whole_number_flag( $assoc_args, 'throttle', 0 );
+		$limit    = self::whole_number_flag( $assoc_args, 'limit' );
+		$throttle = self::whole_number_flag( $assoc_args, 'throttle' );
 
 		$batch         = isset( $assoc_args['batch'] ) ? \max( 1, (int) $assoc_args['batch'] ) : self::DEFAULT_BATCH;
 		$dry_run       = ! empty( $assoc_args['dry-run'] );
@@ -349,9 +350,9 @@ class Backfill_Command extends \WP_CLI_Command {
 						? Publisher::update_post( $post )
 						: Publisher::publish_post( $post, $original_time );
 
-					$reached_pds = true;
-
 					if ( \is_wp_error( $result ) ) {
+						$reached_pds = true;
+
 						\WP_CLI::warning(
 							\sprintf(
 								/* translators: 1: post ID, 2: error message. */
@@ -362,38 +363,10 @@ class Backfill_Command extends \WP_CLI_Command {
 						);
 						++$errors;
 
-						/*
-						 * A lost connection will fail identically for every
-						 * remaining post. Stop now instead of grinding
-						 * through the rest of the queue (a query each) only
-						 * to report the same error N times. $errors > 0
-						 * already guarantees a non-zero exit below.
-						 */
-						if ( 'atmosphere_not_connected' === $result->get_error_code() ) {
-							\WP_CLI::warning( \__( 'Connection to AT Protocol was lost; aborting the remaining posts.', 'atmosphere' ) );
-							break;
-						}
+						$abort = self::abort_reason( $result );
 
-						/*
-						 * The PDS budgets writes per account, so once the
-						 * window is spent every remaining post in the queue
-						 * gets the same 429. Grinding through them would
-						 * only bury the real cause under N identical
-						 * warnings. Stop and say when the window reopens.
-						 *
-						 * Safe to stop mid-queue: a post that failed to
-						 * publish never gets `Document::META_URI`, so it
-						 * stays in the unsynced set and the next run picks
-						 * up exactly where this one left off.
-						 *
-						 * The 429 does not always arrive as the top-level
-						 * code, hence `find_rate_limit_error()` rather than
-						 * a bare code comparison.
-						 */
-						$rate_limit_error = self::find_rate_limit_error( $result );
-
-						if ( $rate_limit_error instanceof \WP_Error ) {
-							\WP_CLI::warning( self::rate_limit_message( $rate_limit_error ) );
+						if ( null !== $abort ) {
+							\WP_CLI::warning( $abort );
 							break;
 						}
 					} elseif ( $already_synced && \is_array( $result ) && empty( $result ) ) {
@@ -401,9 +374,10 @@ class Backfill_Command extends \WP_CLI_Command {
 						 * `update_post()` returns an empty array when the
 						 * post carries a document URI but has no Bluesky
 						 * publication history to update (a half-synced
-						 * state) — nothing was sent to the PDS. Reporting
-						 * "Updated" here would inflate $synced and hide that
-						 * no record was written.
+						 * state) — nothing was sent to the PDS, so this post
+						 * costs no rate-limit budget and is not throttled.
+						 * Reporting "Updated" here would inflate $synced and
+						 * hide that no record was written.
 						 */
 						\WP_CLI::warning(
 							\sprintf(
@@ -414,6 +388,8 @@ class Backfill_Command extends \WP_CLI_Command {
 						);
 						++$skipped;
 					} else {
+						$reached_pds = true;
+
 						/*
 						 * Both branches pass the same placeholders so PHPCS's
 						 * translators-comment sniff is satisfied by attaching
@@ -545,19 +521,18 @@ class Backfill_Command extends \WP_CLI_Command {
 	 * and `(int)` would truncate to a number the operator never typed.
 	 *
 	 * Failure exits through `WP_CLI::error()` rather than falling back to
-	 * the default. A publish-to-the-internet command must refuse to run
-	 * on a value it had to guess at.
+	 * zero. A publish-to-the-internet command must refuse to run on a
+	 * value it had to guess at.
 	 *
 	 * @since unreleased
 	 *
-	 * @param array  $assoc_args    Flag arguments.
-	 * @param string $flag          Flag name, without the leading dashes.
-	 * @param int    $default_value Value used when the flag is absent.
-	 * @return int
+	 * @param array  $assoc_args Flag arguments.
+	 * @param string $flag       Flag name, without the leading dashes.
+	 * @return int The flag value, or 0 when it was not supplied.
 	 */
-	private static function whole_number_flag( array $assoc_args, string $flag, int $default_value ): int {
+	private static function whole_number_flag( array $assoc_args, string $flag ): int {
 		if ( ! isset( $assoc_args[ $flag ] ) ) {
-			return $default_value;
+			return 0;
 		}
 
 		$raw = $assoc_args[ $flag ];
@@ -577,39 +552,43 @@ class Backfill_Command extends \WP_CLI_Command {
 	}
 
 	/**
-	 * Find the rate-limit failure inside a publish error, if there is one.
+	 * Whether a publish failure dooms the rest of the queue, and what to
+	 * tell the operator when it does.
 	 *
-	 * A 429 does not always surface as the top-level error code. A long
-	 * post publishes as a thread, and when a reply create is the write
-	 * that exhausts the budget, the compensating rollback draws on that
-	 * same spent budget and gets a 429 of its own — so the Publisher
-	 * returns `atmosphere_thread_rollback_failed`, carrying the original
-	 * and the rollback failure as data rather than the rate-limit code.
-	 * The rest of the queue is just as rate-limited either way, so the
-	 * abort has to look one level down.
+	 * Two failures repeat identically for every remaining post: a lost
+	 * connection, and a spent write budget. Grinding through the queue
+	 * (a query each) would only bury the cause under N identical
+	 * warnings, so the run stops. `$errors > 0` already guarantees a
+	 * non-zero exit.
+	 *
+	 * Nothing is lost by stopping mid-queue: a post that failed to
+	 * publish never gets `Document::META_URI`, so it stays in the
+	 * unsynced set and the next run picks up exactly where this one
+	 * left off.
+	 *
+	 * A rate limit does not always arrive as the top-level failure. A
+	 * long post publishes as a thread, and when a reply create spends
+	 * the last of the budget the compensating rollback draws on that
+	 * same spent budget and gets a 429 of its own, so the Publisher
+	 * returns a rollback failure with the 429 nested inside. The rest
+	 * of the queue is just as rate-limited either way, hence the walk
+	 * through the wrapped failures.
 	 *
 	 * @since unreleased
 	 *
 	 * @param \WP_Error $error Failure returned by the Publisher.
-	 * @return \WP_Error|null The rate-limit failure, or null when this
-	 *                       error is not one.
+	 * @return string|null Message to warn with, or null to keep going.
 	 */
-	private static function find_rate_limit_error( \WP_Error $error ): ?\WP_Error {
-		if ( 'atmosphere_rate_limited' === $error->get_error_code() ) {
-			return $error;
+	private static function abort_reason( \WP_Error $error ): ?string {
+		if ( 'atmosphere_not_connected' === $error->get_error_code() ) {
+			return \__( 'Connection to AT Protocol was lost; aborting the remaining posts.', 'atmosphere' );
 		}
 
-		$data = $error->get_error_data();
+		$candidates = \array_merge( array( $error ), Publisher::underlying_errors( $error ) );
 
-		if ( ! \is_array( $data ) ) {
-			return null;
-		}
-
-		foreach ( array( 'original_error', 'rollback_error' ) as $key ) {
-			$nested = $data[ $key ] ?? null;
-
-			if ( $nested instanceof \WP_Error && 'atmosphere_rate_limited' === $nested->get_error_code() ) {
-				return $nested;
+		foreach ( $candidates as $candidate ) {
+			if ( API::is_rate_limit_error( $candidate ) ) {
+				return self::rate_limit_message( $candidate );
 			}
 		}
 

--- a/includes/cli/class-backfill-command.php
+++ b/includes/cli/class-backfill-command.php
@@ -385,9 +385,15 @@ class Backfill_Command extends \WP_CLI_Command {
 						 * publish never gets `Document::META_URI`, so it
 						 * stays in the unsynced set and the next run picks
 						 * up exactly where this one left off.
+						 *
+						 * The 429 does not always arrive as the top-level
+						 * code, hence `find_rate_limit_error()` rather than
+						 * a bare code comparison.
 						 */
-						if ( 'atmosphere_rate_limited' === $result->get_error_code() ) {
-							\WP_CLI::warning( self::rate_limit_message( $result ) );
+						$rate_limit_error = self::find_rate_limit_error( $result );
+
+						if ( $rate_limit_error instanceof \WP_Error ) {
+							\WP_CLI::warning( self::rate_limit_message( $rate_limit_error ) );
 							break;
 						}
 					} elseif ( $already_synced && \is_array( $result ) && empty( $result ) ) {
@@ -568,6 +574,46 @@ class Backfill_Command extends \WP_CLI_Command {
 		}
 
 		return (int) $raw;
+	}
+
+	/**
+	 * Find the rate-limit failure inside a publish error, if there is one.
+	 *
+	 * A 429 does not always surface as the top-level error code. A long
+	 * post publishes as a thread, and when a reply create is the write
+	 * that exhausts the budget, the compensating rollback draws on that
+	 * same spent budget and gets a 429 of its own — so the Publisher
+	 * returns `atmosphere_thread_rollback_failed`, carrying the original
+	 * and the rollback failure as data rather than the rate-limit code.
+	 * The rest of the queue is just as rate-limited either way, so the
+	 * abort has to look one level down.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_Error $error Failure returned by the Publisher.
+	 * @return \WP_Error|null The rate-limit failure, or null when this
+	 *                       error is not one.
+	 */
+	private static function find_rate_limit_error( \WP_Error $error ): ?\WP_Error {
+		if ( 'atmosphere_rate_limited' === $error->get_error_code() ) {
+			return $error;
+		}
+
+		$data = $error->get_error_data();
+
+		if ( ! \is_array( $data ) ) {
+			return null;
+		}
+
+		foreach ( array( 'original_error', 'rollback_error' ) as $key ) {
+			$nested = $data[ $key ] ?? null;
+
+			if ( $nested instanceof \WP_Error && 'atmosphere_rate_limited' === $nested->get_error_code() ) {
+				return $nested;
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/includes/cli/class-backfill-command.php
+++ b/includes/cli/class-backfill-command.php
@@ -67,6 +67,16 @@ class Backfill_Command extends \WP_CLI_Command {
 	 * progress ticks and how often per-post caches are dropped to keep
 	 * long runs from growing memory unboundedly.
 	 *
+	 * [--throttle=<seconds>]
+	 * : Seconds to wait between posts that actually reach the PDS. Default:
+	 * 0 (no wait). Bluesky budgets repo writes at 5,000 points per hour and
+	 * 35,000 per day, and one publish costs 6 (two record creates), so an
+	 * unthrottled run of a large archive exhausts the hourly budget inside
+	 * the first ~830 posts and every post after that is rejected until the
+	 * window rolls over. `--throttle=5` holds a run just under that
+	 * ceiling. Skipped and dry-run posts are never waited on, they cost no
+	 * budget.
+	 *
 	 * [--dry-run]
 	 * : List the posts that would be published. Does NOT call the
 	 * publisher.
@@ -99,6 +109,9 @@ class Backfill_Command extends \WP_CLI_Command {
 	 *     # Restrict to a single post type.
 	 *     $ wp atmosphere backfill --post-type=article
 	 *
+	 *     # Backfill a large archive at a pace the Bluesky rate limit allows.
+	 *     $ wp atmosphere backfill --throttle=5
+	 *
 	 * @when after_wp_load
 	 *
 	 * @param array $args       Positional arguments (unused).
@@ -130,31 +143,12 @@ class Backfill_Command extends \WP_CLI_Command {
 		$ids_arg = isset( $assoc_args['ids'] ) ? (string) $assoc_args['ids'] : '';
 
 		/*
-		 * Validate --limit with a strict whole-number check before
-		 * coercion. `ctype_digit` accepts only digit strings, so it
-		 * rejects every silent-coercion trap at once: a bare `--limit`
-		 * (boolean true, not a string), negatives (`-1`), and decimals or
-		 * exponents (`5.5`, `1e3`) that `is_numeric()` would pass and
-		 * `(int)` would truncate to an unintended value. Literal `0` and
-		 * an absent flag still mean "no cap".
+		 * Literal `0` and an absent --limit both mean "no cap"; `0` and an
+		 * absent --throttle both mean "no wait". See
+		 * self::whole_number_flag() for why the validation is this strict.
 		 */
-		if ( isset( $assoc_args['limit'] ) ) {
-			$raw_limit = $assoc_args['limit'];
-
-			if ( ! \is_string( $raw_limit ) || ! \ctype_digit( $raw_limit ) ) {
-				\WP_CLI::error(
-					\sprintf(
-						/* translators: %s: the rejected --limit value. */
-						\__( 'Invalid --limit value "%s": expected 0 (no cap) or a positive whole number.', 'atmosphere' ),
-						\is_scalar( $raw_limit ) ? (string) $raw_limit : \gettype( $raw_limit )
-					)
-				);
-			}
-
-			$limit = (int) $raw_limit;
-		} else {
-			$limit = 0;
-		}
+		$limit    = self::whole_number_flag( $assoc_args, 'limit', 0 );
+		$throttle = self::whole_number_flag( $assoc_args, 'throttle', 0 );
 
 		$batch         = isset( $assoc_args['batch'] ) ? \max( 1, (int) $assoc_args['batch'] ) : self::DEFAULT_BATCH;
 		$dry_run       = ! empty( $assoc_args['dry-run'] );
@@ -291,6 +285,12 @@ class Backfill_Command extends \WP_CLI_Command {
 		}
 
 		foreach ( $post_ids as $post_id ) {
+			/*
+			 * Only a post that actually reached the PDS spends rate-limit
+			 * budget, so only those are worth throttling on.
+			 */
+			$reached_pds = false;
+
 			$post = \get_post( $post_id );
 
 			if ( ! $post instanceof \WP_Post ) {
@@ -349,6 +349,8 @@ class Backfill_Command extends \WP_CLI_Command {
 						? Publisher::update_post( $post )
 						: Publisher::publish_post( $post, $original_time );
 
+					$reached_pds = true;
+
 					if ( \is_wp_error( $result ) ) {
 						\WP_CLI::warning(
 							\sprintf(
@@ -369,6 +371,23 @@ class Backfill_Command extends \WP_CLI_Command {
 						 */
 						if ( 'atmosphere_not_connected' === $result->get_error_code() ) {
 							\WP_CLI::warning( \__( 'Connection to AT Protocol was lost; aborting the remaining posts.', 'atmosphere' ) );
+							break;
+						}
+
+						/*
+						 * The PDS budgets writes per account, so once the
+						 * window is spent every remaining post in the queue
+						 * gets the same 429. Grinding through them would
+						 * only bury the real cause under N identical
+						 * warnings. Stop and say when the window reopens.
+						 *
+						 * Safe to stop mid-queue: a post that failed to
+						 * publish never gets `Document::META_URI`, so it
+						 * stays in the unsynced set and the next run picks
+						 * up exactly where this one left off.
+						 */
+						if ( 'atmosphere_rate_limited' === $result->get_error_code() ) {
+							\WP_CLI::warning( self::rate_limit_message( $result ) );
 							break;
 						}
 					} elseif ( $already_synced && \is_array( $result ) && empty( $result ) ) {
@@ -447,6 +466,14 @@ class Backfill_Command extends \WP_CLI_Command {
 					);
 				}
 			}
+
+			/*
+			 * Pace the run. After the last post there is nothing left to
+			 * pace, so the wait would only delay the summary.
+			 */
+			if ( $throttle > 0 && $reached_pds && $ticks < $total ) {
+				\sleep( $throttle );
+			}
 		}
 
 		// Final-batch sweep so the trailing posts under one full $batch are not left cached.
@@ -500,6 +527,75 @@ class Backfill_Command extends \WP_CLI_Command {
 		}
 
 		\WP_CLI::success( $summary );
+	}
+
+	/**
+	 * Read a flag that must be a whole number, or exit.
+	 *
+	 * `ctype_digit` accepts only digit strings, so one check rejects
+	 * every silent-coercion trap at once: a valueless flag (WP-CLI hands
+	 * those over as boolean `true`, not a string), negatives (`-1`), and
+	 * decimals or exponents (`5.5`, `1e3`) that `is_numeric()` would pass
+	 * and `(int)` would truncate to a number the operator never typed.
+	 *
+	 * Failure exits through `WP_CLI::error()` rather than falling back to
+	 * the default. A publish-to-the-internet command must refuse to run
+	 * on a value it had to guess at.
+	 *
+	 * @since unreleased
+	 *
+	 * @param array  $assoc_args    Flag arguments.
+	 * @param string $flag          Flag name, without the leading dashes.
+	 * @param int    $default_value Value used when the flag is absent.
+	 * @return int
+	 */
+	private static function whole_number_flag( array $assoc_args, string $flag, int $default_value ): int {
+		if ( ! isset( $assoc_args[ $flag ] ) ) {
+			return $default_value;
+		}
+
+		$raw = $assoc_args[ $flag ];
+
+		if ( ! \is_string( $raw ) || ! \ctype_digit( $raw ) ) {
+			\WP_CLI::error(
+				\sprintf(
+					/* translators: 1: flag name, e.g. "limit". 2: the rejected value. */
+					\__( 'Invalid --%1$s value "%2$s": expected 0 or a positive whole number.', 'atmosphere' ),
+					$flag,
+					\is_scalar( $raw ) ? (string) $raw : \gettype( $raw )
+				)
+			);
+		}
+
+		return (int) $raw;
+	}
+
+	/**
+	 * Build the abort message for a rate-limited run.
+	 *
+	 * The PDS reports when the window rolls over, so the operator gets a
+	 * "come back at" rather than a bare failure. When the header was
+	 * missing or unreadable the error carries no reset and the message
+	 * drops that sentence instead of guessing at a number.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_Error $error Rate-limit error from the publisher.
+	 * @return string
+	 */
+	private static function rate_limit_message( \WP_Error $error ): string {
+		$data  = $error->get_error_data();
+		$reset = \is_array( $data ) && ! empty( $data['reset'] ) ? (int) $data['reset'] : 0;
+
+		if ( $reset <= \time() ) {
+			return \__( 'Bluesky rate limit reached; aborting the remaining posts. Re-run the same command later and it will continue where this run stopped.', 'atmosphere' );
+		}
+
+		return \sprintf(
+			/* translators: %s: human-readable duration, e.g. "34 mins". */
+			\__( 'Bluesky rate limit reached; aborting the remaining posts. The limit resets in about %s. Re-run the same command then and it will continue where this run stopped.', 'atmosphere' ),
+			\human_time_diff( \time(), $reset )
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-api.php
+++ b/tests/phpunit/tests/class-test-api.php
@@ -138,12 +138,29 @@ class Test_API extends \WP_UnitTestCase {
 	 * The rate-limit branches must not look like an auth problem, so
 	 * none of them may trigger a refresh.
 	 *
+	 * @param string $reason Failure message, when the default is not
+	 *                       specific enough for the caller.
 	 * @return callable
 	 */
-	private function no_token_calls(): callable {
-		return function () {
-			$this->fail( 'Token endpoint should not be called.' );
+	private function no_token_calls( string $reason = 'Token endpoint should not be called.' ): callable {
+		return function () use ( $reason ) {
+			$this->fail( $reason );
 		};
+	}
+
+	/**
+	 * Stub a single fixed PDS response, with the token endpoint off
+	 * limits.
+	 *
+	 * @param int   $status  HTTP status code.
+	 * @param array $body    Response body to JSON-encode.
+	 * @param array $headers Response headers.
+	 */
+	private function stub_pds( int $status, array $body, array $headers = array() ): void {
+		$this->stub_http(
+			$this->no_token_calls(),
+			fn() => $this->http_response( $status, $body, $headers )
+		);
 	}
 
 	/**
@@ -154,20 +171,16 @@ class Test_API extends \WP_UnitTestCase {
 	public function test_rate_limited_response_returns_dedicated_error() {
 		$reset = \time() + 900;
 
-		$this->stub_http(
-			$this->no_token_calls(),
-			fn() => $this->http_response(
-				429,
-				array(
-					'error'   => 'RateLimitExceeded',
-					'message' => 'Rate Limit Exceeded',
-				),
-				array(
-					'ratelimit-limit'     => '5000',
-					'ratelimit-remaining' => '0',
-					'ratelimit-reset'     => (string) $reset,
-					'ratelimit-policy'    => '5000;w=3600',
-				)
+		$this->stub_pds(
+			429,
+			array(
+				'error'   => 'RateLimitExceeded',
+				'message' => 'Rate Limit Exceeded',
+			),
+			array(
+				'ratelimit-limit'     => '5000',
+				'ratelimit-remaining' => '0',
+				'ratelimit-reset'     => (string) $reset,
 			)
 		);
 
@@ -193,17 +206,13 @@ class Test_API extends \WP_UnitTestCase {
 	public function test_rate_limit_headers_are_captured_on_success() {
 		$reset = \time() + 300;
 
-		$this->stub_http(
-			$this->no_token_calls(),
-			fn() => $this->http_response(
-				200,
-				array( 'ok' => true ),
-				array(
-					'ratelimit-limit'     => '3000',
-					'ratelimit-remaining' => '2999',
-					'ratelimit-reset'     => (string) $reset,
-					'ratelimit-policy'    => '3000;w=300',
-				)
+		$this->stub_pds(
+			200,
+			array( 'ok' => true ),
+			array(
+				'ratelimit-limit'     => '3000',
+				'ratelimit-remaining' => '2999',
+				'ratelimit-reset'     => (string) $reset,
 			)
 		);
 
@@ -216,7 +225,6 @@ class Test_API extends \WP_UnitTestCase {
 		$this->assertSame( 3000, $snapshot['limit'] );
 		$this->assertSame( 2999, $snapshot['remaining'] );
 		$this->assertSame( $reset, $snapshot['reset'] );
-		$this->assertSame( '3000;w=300', $snapshot['policy'] );
 	}
 
 	/**
@@ -225,14 +233,7 @@ class Test_API extends \WP_UnitTestCase {
 	 * Small values are read as "seconds from now".
 	 */
 	public function test_rate_limit_reset_accepts_delta_seconds() {
-		$this->stub_http(
-			$this->no_token_calls(),
-			fn() => $this->http_response(
-				200,
-				array( 'ok' => true ),
-				array( 'ratelimit-reset' => '60' )
-			)
-		);
+		$this->stub_pds( 200, array( 'ok' => true ), array( 'ratelimit-reset' => '60' ) );
 
 		API::get( '/xrpc/com.atproto.repo.getRecord' );
 
@@ -313,9 +314,7 @@ class Test_API extends \WP_UnitTestCase {
 	 */
 	public function test_request_rejects_redirect_response() {
 		$this->stub_http(
-			function () {
-				$this->fail( 'Token endpoint should not be called for a PDS redirect response.' );
-			},
+			$this->no_token_calls( 'Token endpoint should not be called for a PDS redirect response.' ),
 			function () {
 				return $this->http_response( 307, array() );
 			}
@@ -438,9 +437,7 @@ class Test_API extends \WP_UnitTestCase {
 		$pds_calls = 0;
 
 		$this->stub_http(
-			function () {
-				$this->fail( 'Token endpoint must not be called when there is no refresh token.' );
-			},
+			$this->no_token_calls( 'Token endpoint must not be called when there is no refresh token.' ),
 			function () use ( &$pds_calls ) {
 				++$pds_calls;
 				return $this->http_response(

--- a/tests/phpunit/tests/class-test-api.php
+++ b/tests/phpunit/tests/class-test-api.php
@@ -119,16 +119,163 @@ class Test_API extends \WP_UnitTestCase {
 	/**
 	 * Build a synthetic `pre_http_request` response payload.
 	 *
-	 * @param int   $status HTTP status code.
-	 * @param array $body   Response body to JSON-encode.
+	 * @param int   $status  HTTP status code.
+	 * @param array $body    Response body to JSON-encode.
+	 * @param array $headers Response headers.
 	 * @return array
 	 */
-	private function http_response( int $status, array $body ): array {
+	private function http_response( int $status, array $body, array $headers = array() ): array {
 		return array(
 			'response' => array( 'code' => $status ),
-			'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+			'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( $headers ),
 			'body'     => (string) \wp_json_encode( $body ),
 		);
+	}
+
+	/**
+	 * Fail the test if the token endpoint is touched.
+	 *
+	 * The rate-limit branches must not look like an auth problem, so
+	 * none of them may trigger a refresh.
+	 *
+	 * @return callable
+	 */
+	private function no_token_calls(): callable {
+		return function () {
+			$this->fail( 'Token endpoint should not be called.' );
+		};
+	}
+
+	/**
+	 * A 429 gets its own error code rather than the generic
+	 * `atmosphere_pds`, and carries the window the PDS reported so a
+	 * caller can wait for it instead of guessing at a backoff.
+	 */
+	public function test_rate_limited_response_returns_dedicated_error() {
+		$reset = \time() + 900;
+
+		$this->stub_http(
+			$this->no_token_calls(),
+			fn() => $this->http_response(
+				429,
+				array(
+					'error'   => 'RateLimitExceeded',
+					'message' => 'Rate Limit Exceeded',
+				),
+				array(
+					'ratelimit-limit'     => '5000',
+					'ratelimit-remaining' => '0',
+					'ratelimit-reset'     => (string) $reset,
+					'ratelimit-policy'    => '5000;w=3600',
+				)
+			)
+		);
+
+		$result = API::get( '/xrpc/com.atproto.repo.getRecord' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'atmosphere_rate_limited', $result->get_error_code() );
+		$this->assertSame( 'Rate Limit Exceeded', $result->get_error_message() );
+
+		$data = $result->get_error_data();
+
+		$this->assertSame( 429, $data['status'] );
+		$this->assertSame( $reset, $data['reset'] );
+		$this->assertSame( 5000, $data['limit'] );
+		$this->assertSame( 0, $data['remaining'] );
+		$this->assertEqualsWithDelta( 900, $data['retry_after'], 5 );
+	}
+
+	/**
+	 * Headers are read off every response, not just the 429s, so a long
+	 * run can watch its remaining budget before it runs out.
+	 */
+	public function test_rate_limit_headers_are_captured_on_success() {
+		$reset = \time() + 300;
+
+		$this->stub_http(
+			$this->no_token_calls(),
+			fn() => $this->http_response(
+				200,
+				array( 'ok' => true ),
+				array(
+					'ratelimit-limit'     => '3000',
+					'ratelimit-remaining' => '2999',
+					'ratelimit-reset'     => (string) $reset,
+					'ratelimit-policy'    => '3000;w=300',
+				)
+			)
+		);
+
+		$result = API::get( '/xrpc/com.atproto.repo.getRecord' );
+
+		$this->assertIsArray( $result );
+
+		$snapshot = API::last_rate_limit();
+
+		$this->assertSame( 3000, $snapshot['limit'] );
+		$this->assertSame( 2999, $snapshot['remaining'] );
+		$this->assertSame( $reset, $snapshot['reset'] );
+		$this->assertSame( '3000;w=300', $snapshot['policy'] );
+	}
+
+	/**
+	 * Bluesky sends `ratelimit-reset` as an absolute timestamp, but the
+	 * IETF draft allows delta-seconds and another PDS may send that.
+	 * Small values are read as "seconds from now".
+	 */
+	public function test_rate_limit_reset_accepts_delta_seconds() {
+		$this->stub_http(
+			$this->no_token_calls(),
+			fn() => $this->http_response(
+				200,
+				array( 'ok' => true ),
+				array( 'ratelimit-reset' => '60' )
+			)
+		);
+
+		API::get( '/xrpc/com.atproto.repo.getRecord' );
+
+		$this->assertEqualsWithDelta( \time() + 60, API::last_rate_limit()['reset'], 5 );
+	}
+
+	/**
+	 * A 429 with no headers still gets the dedicated code, but must not
+	 * borrow a reset time from an earlier request — that would send the
+	 * caller back at a moment unrelated to the window it actually hit.
+	 */
+	public function test_rate_limited_without_headers_reports_no_reset() {
+		$calls = 0;
+
+		$this->stub_http(
+			$this->no_token_calls(),
+			function () use ( &$calls ) {
+				++$calls;
+
+				if ( 1 === $calls ) {
+					return $this->http_response(
+						200,
+						array( 'ok' => true ),
+						array( 'ratelimit-reset' => (string) ( \time() + HOUR_IN_SECONDS ) )
+					);
+				}
+
+				return $this->http_response( 429, array( 'error' => 'RateLimitExceeded' ) );
+			}
+		);
+
+		API::get( '/xrpc/com.atproto.repo.getRecord' );
+		$result = API::get( '/xrpc/com.atproto.repo.getRecord' );
+
+		$this->assertSame( 'atmosphere_rate_limited', $result->get_error_code() );
+
+		$data = $result->get_error_data();
+
+		$this->assertNull( $data['reset'] );
+		$this->assertNull( $data['retry_after'] );
+
+		// The earlier reading survives for anything that still wants it.
+		$this->assertNotNull( API::last_rate_limit()['reset'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -3663,6 +3663,77 @@ class Test_Atmosphere extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Short-circuit applyWrites with a rate-limit rejection.
+	 *
+	 * @param int $retry_after Seconds the PDS says the window has left.
+	 */
+	private function force_apply_writes_rate_limited( int $retry_after ): void {
+		\add_filter(
+			'atmosphere_pre_apply_writes',
+			static fn() => new \WP_Error(
+				'atmosphere_rate_limited',
+				'Rate Limit Exceeded',
+				array(
+					'status'      => 429,
+					'reset'       => \time() + $retry_after,
+					'retry_after' => $retry_after,
+				)
+			)
+		);
+	}
+
+	/**
+	 * A rate-limited publish waits for the window the PDS reported.
+	 *
+	 * Retrying on the ladder's own first rung would spend a rung on a
+	 * request that is guaranteed to come back with the same 429.
+	 */
+	public function test_publish_worker_waits_for_the_rate_limit_window() {
+		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+
+		/*
+		 * WP-Cron unschedules an event before running its callback; mirror
+		 * that so the creation-time event doesn't mask the retry.
+		 */
+		\wp_clear_scheduled_hook( 'atmosphere_publish_post', array( $post->ID ) );
+		\wp_clear_scheduled_hook( 'atmosphere_update_post', array( $post->ID ) );
+
+		$this->force_apply_writes_rate_limited( 20 * MINUTE_IN_SECONDS );
+
+		\do_action( 'atmosphere_publish_post', $post->ID );
+
+		$next = \wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) );
+
+		$this->assertNotFalse( $next, 'A rate-limited publish is transient and must still be retried.' );
+		$this->assertGreaterThan(
+			\time() + 15 * MINUTE_IN_SECONDS,
+			$next,
+			'The retry must wait for the reported window, not the one-minute first rung.'
+		);
+	}
+
+	/**
+	 * A wildly out-of-range reset cannot park a queued publish days out.
+	 * Past an hour the header has effectively disabled the ladder, and
+	 * we do not control that header.
+	 */
+	public function test_rate_limit_retry_delay_is_capped_at_an_hour() {
+		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+
+		\wp_clear_scheduled_hook( 'atmosphere_publish_post', array( $post->ID ) );
+		\wp_clear_scheduled_hook( 'atmosphere_update_post', array( $post->ID ) );
+
+		$this->force_apply_writes_rate_limited( WEEK_IN_SECONDS );
+
+		\do_action( 'atmosphere_publish_post', $post->ID );
+
+		$next = \wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) );
+
+		$this->assertNotFalse( $next );
+		$this->assertLessThanOrEqual( \time() + HOUR_IN_SECONDS + 5, $next );
+	}
+
+	/**
 	 * Returning an empty ladder from the delays filter disables
 	 * retries entirely.
 	 */

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -3665,7 +3665,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 	/**
 	 * Short-circuit applyWrites with a rate-limit rejection.
 	 *
-	 * @param int $retry_after Seconds the PDS says the window has left.
+	 * @param int $retry_after Seconds until the rate-limit window resets.
 	 */
 	private function force_apply_writes_rate_limited( int $retry_after ): void {
 		\add_filter(
@@ -3690,7 +3690,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 	 * clears mirror that, so the creation-time event does not mask the
 	 * retry the worker schedules.
 	 *
-	 * @param int $retry_after Seconds the PDS says the window has left.
+	 * @param int $retry_after Seconds until the rate-limit window resets.
 	 * @return int|false Timestamp of the scheduled retry, or false when
 	 *                   none was scheduled.
 	 */

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -3683,26 +3683,38 @@ class Test_Atmosphere extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Publish a post against a rate-limited PDS and report when the
+	 * retry was scheduled for.
+	 *
+	 * WP-Cron unschedules an event before running its callback; the two
+	 * clears mirror that, so the creation-time event does not mask the
+	 * retry the worker schedules.
+	 *
+	 * @param int $retry_after Seconds the PDS says the window has left.
+	 * @return int|false Timestamp of the scheduled retry, or false when
+	 *                   none was scheduled.
+	 */
+	private function rate_limited_retry_time( int $retry_after ) {
+		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+
+		\wp_clear_scheduled_hook( 'atmosphere_publish_post', array( $post->ID ) );
+		\wp_clear_scheduled_hook( 'atmosphere_update_post', array( $post->ID ) );
+
+		$this->force_apply_writes_rate_limited( $retry_after );
+
+		\do_action( 'atmosphere_publish_post', $post->ID );
+
+		return \wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) );
+	}
+
+	/**
 	 * A rate-limited publish waits for the window the PDS reported.
 	 *
 	 * Retrying on the ladder's own first rung would spend a rung on a
 	 * request that is guaranteed to come back with the same 429.
 	 */
 	public function test_publish_worker_waits_for_the_rate_limit_window() {
-		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
-
-		/*
-		 * WP-Cron unschedules an event before running its callback; mirror
-		 * that so the creation-time event doesn't mask the retry.
-		 */
-		\wp_clear_scheduled_hook( 'atmosphere_publish_post', array( $post->ID ) );
-		\wp_clear_scheduled_hook( 'atmosphere_update_post', array( $post->ID ) );
-
-		$this->force_apply_writes_rate_limited( 20 * MINUTE_IN_SECONDS );
-
-		\do_action( 'atmosphere_publish_post', $post->ID );
-
-		$next = \wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) );
+		$next = $this->rate_limited_retry_time( 20 * MINUTE_IN_SECONDS );
 
 		$this->assertNotFalse( $next, 'A rate-limited publish is transient and must still be retried.' );
 		$this->assertGreaterThan(
@@ -3718,16 +3730,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 	 * and we do not control that header.
 	 */
 	public function test_rate_limit_retry_delay_is_capped_at_a_day() {
-		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
-
-		\wp_clear_scheduled_hook( 'atmosphere_publish_post', array( $post->ID ) );
-		\wp_clear_scheduled_hook( 'atmosphere_update_post', array( $post->ID ) );
-
-		$this->force_apply_writes_rate_limited( WEEK_IN_SECONDS );
-
-		\do_action( 'atmosphere_publish_post', $post->ID );
-
-		$next = \wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) );
+		$next = $this->rate_limited_retry_time( WEEK_IN_SECONDS );
 
 		$this->assertNotFalse( $next );
 		$this->assertLessThanOrEqual( \time() + DAY_IN_SECONDS + 5, $next );
@@ -3739,11 +3742,6 @@ class Test_Atmosphere extends WP_UnitTestCase {
 	 * *shorter* wait just because the failure happened to be a 429.
 	 */
 	public function test_rate_limit_retry_delay_never_shortens_the_ladder() {
-		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
-
-		\wp_clear_scheduled_hook( 'atmosphere_publish_post', array( $post->ID ) );
-		\wp_clear_scheduled_hook( 'atmosphere_update_post', array( $post->ID ) );
-
 		$ladder = function () {
 			return array( 6 * HOUR_IN_SECONDS );
 		};
@@ -3751,11 +3749,7 @@ class Test_Atmosphere extends WP_UnitTestCase {
 		\add_filter( 'atmosphere_publish_retry_delays', $ladder );
 
 		/* A short window; the ladder's own six hours has to win. */
-		$this->force_apply_writes_rate_limited( 5 * MINUTE_IN_SECONDS );
-
-		\do_action( 'atmosphere_publish_post', $post->ID );
-
-		$next = \wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) );
+		$next = $this->rate_limited_retry_time( 5 * MINUTE_IN_SECONDS );
 
 		\remove_filter( 'atmosphere_publish_retry_delays', $ladder );
 

--- a/tests/phpunit/tests/class-test-atmosphere.php
+++ b/tests/phpunit/tests/class-test-atmosphere.php
@@ -3713,11 +3713,11 @@ class Test_Atmosphere extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A wildly out-of-range reset cannot park a queued publish days out.
-	 * Past an hour the header has effectively disabled the ladder, and
-	 * we do not control that header.
+	 * A wildly out-of-range reset cannot park a queued publish weeks
+	 * out. Past a day the header has effectively disabled the ladder,
+	 * and we do not control that header.
 	 */
-	public function test_rate_limit_retry_delay_is_capped_at_an_hour() {
+	public function test_rate_limit_retry_delay_is_capped_at_a_day() {
 		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
 
 		\wp_clear_scheduled_hook( 'atmosphere_publish_post', array( $post->ID ) );
@@ -3730,7 +3730,41 @@ class Test_Atmosphere extends WP_UnitTestCase {
 		$next = \wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) );
 
 		$this->assertNotFalse( $next );
-		$this->assertLessThanOrEqual( \time() + HOUR_IN_SECONDS + 5, $next );
+		$this->assertLessThanOrEqual( \time() + DAY_IN_SECONDS + 5, $next );
+	}
+
+	/**
+	 * The cap applies to the PDS-supplied wait, never to the ladder's
+	 * own step: a site that filters in a longer ladder must not get a
+	 * *shorter* wait just because the failure happened to be a 429.
+	 */
+	public function test_rate_limit_retry_delay_never_shortens_the_ladder() {
+		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+
+		\wp_clear_scheduled_hook( 'atmosphere_publish_post', array( $post->ID ) );
+		\wp_clear_scheduled_hook( 'atmosphere_update_post', array( $post->ID ) );
+
+		$ladder = function () {
+			return array( 6 * HOUR_IN_SECONDS );
+		};
+
+		\add_filter( 'atmosphere_publish_retry_delays', $ladder );
+
+		/* A short window; the ladder's own six hours has to win. */
+		$this->force_apply_writes_rate_limited( 5 * MINUTE_IN_SECONDS );
+
+		\do_action( 'atmosphere_publish_post', $post->ID );
+
+		$next = \wp_next_scheduled( 'atmosphere_publish_post', array( $post->ID ) );
+
+		\remove_filter( 'atmosphere_publish_retry_delays', $ladder );
+
+		$this->assertNotFalse( $next );
+		$this->assertGreaterThan(
+			\time() + 5 * HOUR_IN_SECONDS,
+			$next,
+			'A 429 must not clamp a filtered ladder step down to the cap.'
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/cli/class-test-backfill-command-invoke.php
+++ b/tests/phpunit/tests/cli/class-test-backfill-command-invoke.php
@@ -174,11 +174,13 @@ class Test_Backfill_Command_Invoke extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider of `--limit` values the validator must reject.
+	 * Data provider of whole-number flag values the validator must
+	 * reject. Shared by every flag that goes through
+	 * `whole_number_flag()`.
 	 *
 	 * @return array<string, array{0: mixed}>
 	 */
-	public function data_invalid_limits(): array {
+	public function data_invalid_whole_number_flags(): array {
 		return array(
 			'decimal'     => array( '5.5' ),
 			'exponent'    => array( '1e3' ),
@@ -191,7 +193,7 @@ class Test_Backfill_Command_Invoke extends \WP_UnitTestCase {
 	/**
 	 * `--limit` rejects decimals, exponents, negatives, and bare flags.
 	 *
-	 * @dataProvider data_invalid_limits
+	 * @dataProvider data_invalid_whole_number_flags
 	 *
 	 * @param mixed $value Raw --limit value.
 	 */
@@ -209,7 +211,7 @@ class Test_Backfill_Command_Invoke extends \WP_UnitTestCase {
 	 * A bare `--throttle` would otherwise arrive as boolean true and
 	 * silently pace the whole run at one second.
 	 *
-	 * @dataProvider data_invalid_limits
+	 * @dataProvider data_invalid_whole_number_flags
 	 *
 	 * @param mixed $value Raw --throttle value.
 	 */
@@ -277,86 +279,82 @@ class Test_Backfill_Command_Invoke extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Shapes a rate limit can reach the backfill loop in.
+	 *
+	 * A long post publishes as a thread, and when a reply create spends
+	 * the last of the budget the compensating rollback draws on that
+	 * same spent budget and gets a 429 of its own, so the failure
+	 * arrives as `atmosphere_thread_rollback_failed` with the real 429
+	 * nested inside. Either shape has to stop the run.
+	 *
+	 * @return array<string, array{0: string, 1: array, 2: bool}>
+	 */
+	public function data_rate_limit_shapes(): array {
+		return array(
+			'top-level with reset'    => array(
+				'atmosphere_rate_limited',
+				array(
+					'status' => 429,
+					'reset'  => 0,
+				),
+				true,
+			),
+			'top-level, headers gone' => array(
+				'atmosphere_rate_limited',
+				array( 'status' => 429 ),
+				false,
+			),
+			'nested in the rollback'  => array(
+				'atmosphere_thread_rollback_failed',
+				array( 'original_error' => 'nest' ),
+				true,
+			),
+			'nested as the rollback'  => array(
+				'atmosphere_thread_rollback_failed',
+				array( 'rollback_error' => 'nest' ),
+				true,
+			),
+		);
+	}
+
+	/**
 	 * Once the write budget is spent every remaining post gets the same
 	 * 429, so the run stops and reports when the window reopens instead
 	 * of burying the cause under N identical warnings.
+	 *
+	 * @dataProvider data_rate_limit_shapes
+	 *
+	 * @param string $code          Error code the Publisher returns.
+	 * @param array  $data          Error data; `reset` of 0 and a 'nest'
+	 *                              placeholder are filled in here so the
+	 *                              provider stays free of wall-clock time.
+	 * @param bool   $expects_reset Whether the warning can name a reset.
 	 */
-	public function test_rate_limited_midrun_aborts_remaining() {
+	public function test_rate_limited_midrun_aborts_remaining( string $code, array $data, bool $expects_reset ) {
 		self::factory()->post->create( array( 'post_status' => 'publish' ) );
 		self::factory()->post->create( array( 'post_status' => 'publish' ) );
 		self::factory()->post->create( array( 'post_status' => 'publish' ) );
 
-		$this->mock_apply_writes_error(
-			'atmosphere_rate_limited',
-			array(
-				'status' => 429,
-				'reset'  => \time() + 30 * MINUTE_IN_SECONDS,
-			)
-		);
+		$reset = \time() + 30 * MINUTE_IN_SECONDS;
 
-		try {
-			$this->run_command( array() );
-			$this->fail( 'Expected WP_CLI_Halt after the rate-limit abort.' );
-		} catch ( \WP_CLI_Halt $e ) {
-			$warnings = \implode( "\n", \WP_CLI::messages( 'warning' ) );
-
-			$this->assertStringContainsString( 'Bluesky rate limit reached', $warnings );
-			$this->assertStringContainsString( 'resets in about', $warnings );
-			$this->assertSame(
-				1,
-				$this->publish_failure_count(),
-				'Only the first post may be attempted once the window is spent.'
-			);
+		if ( isset( $data['reset'] ) ) {
+			$data['reset'] = $reset;
 		}
-	}
 
-	/**
-	 * A 429 whose headers were stripped still aborts, just without a
-	 * "come back at" it cannot honestly supply.
-	 */
-	public function test_rate_limited_without_reset_still_aborts() {
-		self::factory()->post->create( array( 'post_status' => 'publish' ) );
-		self::factory()->post->create( array( 'post_status' => 'publish' ) );
-
-		$this->mock_apply_writes_error( 'atmosphere_rate_limited', array( 'status' => 429 ) );
-
-		try {
-			$this->run_command( array() );
-			$this->fail( 'Expected WP_CLI_Halt after the rate-limit abort.' );
-		} catch ( \WP_CLI_Halt $e ) {
-			$warnings = \implode( "\n", \WP_CLI::messages( 'warning' ) );
-
-			$this->assertStringContainsString( 'Bluesky rate limit reached', $warnings );
-			$this->assertStringNotContainsString( 'resets in about', $warnings );
-			$this->assertSame( 1, $this->publish_failure_count() );
-		}
-	}
-
-	/**
-	 * A long post publishes as a thread, and when a reply create spends
-	 * the last of the budget the compensating rollback gets a 429 of its
-	 * own — so the failure arrives as `atmosphere_thread_rollback_failed`
-	 * with the 429 nested inside. The rest of the queue is just as
-	 * rate-limited, so the run still has to stop.
-	 */
-	public function test_rate_limited_inside_a_thread_rollback_aborts_remaining() {
-		self::factory()->post->create( array( 'post_status' => 'publish' ) );
-		self::factory()->post->create( array( 'post_status' => 'publish' ) );
-		self::factory()->post->create( array( 'post_status' => 'publish' ) );
-
-		$this->mock_apply_writes_error(
-			'atmosphere_thread_rollback_failed',
-			array(
-				'original_error' => new \WP_Error(
+		foreach ( array( 'original_error', 'rollback_error' ) as $key ) {
+			if ( isset( $data[ $key ] ) ) {
+				$data[ $key ] = new \WP_Error(
 					'atmosphere_rate_limited',
 					'Rate limit exceeded.',
 					array(
 						'status' => 429,
-						'reset'  => \time() + 30 * MINUTE_IN_SECONDS,
+						'reset'  => $reset,
 					)
-				),
-			)
-		);
+				);
+			}
+		}
+
+		$this->mock_apply_writes_error( $code, $data );
 
 		try {
 			$this->run_command( array() );
@@ -365,11 +363,17 @@ class Test_Backfill_Command_Invoke extends \WP_UnitTestCase {
 			$warnings = \implode( "\n", \WP_CLI::messages( 'warning' ) );
 
 			$this->assertStringContainsString( 'Bluesky rate limit reached', $warnings );
-			$this->assertStringContainsString( 'resets in about', $warnings );
+
+			if ( $expects_reset ) {
+				$this->assertStringContainsString( 'resets in about', $warnings );
+			} else {
+				$this->assertStringNotContainsString( 'resets in about', $warnings );
+			}
+
 			$this->assertSame(
 				1,
 				$this->publish_failure_count(),
-				'A nested 429 must stop the queue like a top-level one.'
+				'Only the first post may be attempted once the window is spent.'
 			);
 		}
 	}
@@ -610,13 +614,7 @@ class Test_Backfill_Command_Invoke extends \WP_UnitTestCase {
 			$this->assertStringContainsString( 'aborting the remaining posts', $warnings );
 
 			// Only the first post should have been attempted.
-			$failures = 0;
-			foreach ( \WP_CLI::messages( 'warning' ) as $message ) {
-				if ( false !== \strpos( $message, 'Failed to publish' ) ) {
-					++$failures;
-				}
-			}
-			$this->assertSame( 1, $failures );
+			$this->assertSame( 1, $this->publish_failure_count() );
 		}
 	}
 

--- a/tests/phpunit/tests/cli/class-test-backfill-command-invoke.php
+++ b/tests/phpunit/tests/cli/class-test-backfill-command-invoke.php
@@ -119,17 +119,35 @@ class Test_Backfill_Command_Invoke extends \WP_UnitTestCase {
 	 * Register an error short-circuit for `applyWrites`.
 	 *
 	 * @param string $code Error code to return.
+	 * @param array  $data Error data to attach.
 	 * @return void
 	 */
-	private function mock_apply_writes_error( string $code ): void {
+	private function mock_apply_writes_error( string $code, array $data = array() ): void {
 		\add_filter(
 			'atmosphere_pre_apply_writes',
-			static function () use ( $code ) {
-				return new \WP_Error( $code, 'Simulated apply_writes failure.' );
+			static function () use ( $code, $data ) {
+				return new \WP_Error( $code, 'Simulated apply_writes failure.', $data );
 			},
 			10,
 			2
 		);
+	}
+
+	/**
+	 * Count the "Failed to publish" warnings in the captured log.
+	 *
+	 * @return int
+	 */
+	private function publish_failure_count(): int {
+		$failures = 0;
+
+		foreach ( \WP_CLI::messages( 'warning' ) as $message ) {
+			if ( false !== \strpos( $message, 'Failed to publish' ) ) {
+				++$failures;
+			}
+		}
+
+		return $failures;
 	}
 
 	/**
@@ -183,6 +201,134 @@ class Test_Backfill_Command_Invoke extends \WP_UnitTestCase {
 			$this->fail( 'Expected WP_CLI_Halt for an invalid --limit.' );
 		} catch ( \WP_CLI_Halt $e ) {
 			$this->assertStringContainsString( 'Invalid --limit', $e->getMessage() );
+		}
+	}
+
+	/**
+	 * `--throttle` gets the same strict whole-number check as `--limit`.
+	 * A bare `--throttle` would otherwise arrive as boolean true and
+	 * silently pace the whole run at one second.
+	 *
+	 * @dataProvider data_invalid_limits
+	 *
+	 * @param mixed $value Raw --throttle value.
+	 */
+	public function test_invalid_throttle_aborts( $value ) {
+		try {
+			$this->run_command( array( 'throttle' => $value ) );
+			$this->fail( 'Expected WP_CLI_Halt for an invalid --throttle.' );
+		} catch ( \WP_CLI_Halt $e ) {
+			$this->assertStringContainsString( 'Invalid --throttle', $e->getMessage() );
+		}
+	}
+
+	/**
+	 * `--throttle` waits between posts that reached the PDS.
+	 */
+	public function test_throttle_waits_between_posts() {
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$this->mock_apply_writes_success();
+
+		$started = \microtime( true );
+		$this->run_command( array( 'throttle' => '1' ) );
+		$elapsed = \microtime( true ) - $started;
+
+		$this->assertGreaterThanOrEqual(
+			1.0,
+			$elapsed,
+			'Two published posts with --throttle=1 must wait once between them.'
+		);
+	}
+
+	/**
+	 * Nothing is paced after the final post — the wait would only delay
+	 * the summary the operator is waiting for.
+	 */
+	public function test_throttle_does_not_wait_after_the_last_post() {
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$this->mock_apply_writes_success();
+
+		$started = \microtime( true );
+		$this->run_command( array( 'throttle' => '5' ) );
+		$elapsed = \microtime( true ) - $started;
+
+		$this->assertLessThan( 5.0, $elapsed );
+	}
+
+	/**
+	 * Skipped posts cost no rate-limit budget, so they are not paced
+	 * either. A dry run of a large archive must not take hours.
+	 */
+	public function test_throttle_does_not_wait_on_dry_run() {
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$started = \microtime( true );
+		$this->run_command(
+			array(
+				'throttle' => '5',
+				'dry-run'  => true,
+			)
+		);
+		$elapsed = \microtime( true ) - $started;
+
+		$this->assertLessThan( 5.0, $elapsed );
+	}
+
+	/**
+	 * Once the write budget is spent every remaining post gets the same
+	 * 429, so the run stops and reports when the window reopens instead
+	 * of burying the cause under N identical warnings.
+	 */
+	public function test_rate_limited_midrun_aborts_remaining() {
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$this->mock_apply_writes_error(
+			'atmosphere_rate_limited',
+			array(
+				'status' => 429,
+				'reset'  => \time() + 30 * MINUTE_IN_SECONDS,
+			)
+		);
+
+		try {
+			$this->run_command( array() );
+			$this->fail( 'Expected WP_CLI_Halt after the rate-limit abort.' );
+		} catch ( \WP_CLI_Halt $e ) {
+			$warnings = \implode( "\n", \WP_CLI::messages( 'warning' ) );
+
+			$this->assertStringContainsString( 'Bluesky rate limit reached', $warnings );
+			$this->assertStringContainsString( 'resets in about', $warnings );
+			$this->assertSame(
+				1,
+				$this->publish_failure_count(),
+				'Only the first post may be attempted once the window is spent.'
+			);
+		}
+	}
+
+	/**
+	 * A 429 whose headers were stripped still aborts, just without a
+	 * "come back at" it cannot honestly supply.
+	 */
+	public function test_rate_limited_without_reset_still_aborts() {
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$this->mock_apply_writes_error( 'atmosphere_rate_limited', array( 'status' => 429 ) );
+
+		try {
+			$this->run_command( array() );
+			$this->fail( 'Expected WP_CLI_Halt after the rate-limit abort.' );
+		} catch ( \WP_CLI_Halt $e ) {
+			$warnings = \implode( "\n", \WP_CLI::messages( 'warning' ) );
+
+			$this->assertStringContainsString( 'Bluesky rate limit reached', $warnings );
+			$this->assertStringNotContainsString( 'resets in about', $warnings );
+			$this->assertSame( 1, $this->publish_failure_count() );
 		}
 	}
 

--- a/tests/phpunit/tests/cli/class-test-backfill-command-invoke.php
+++ b/tests/phpunit/tests/cli/class-test-backfill-command-invoke.php
@@ -244,6 +244,28 @@ class Test_Backfill_Command_Invoke extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A failure that never left the site spends no rate-limit budget,
+	 * so there is nothing to pace against. Only a failure the PDS
+	 * answered carries an HTTP status.
+	 */
+	public function test_throttle_does_not_wait_on_a_local_failure() {
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$this->mock_apply_writes_error( 'atmosphere_missing_tid' );
+
+		$started = \microtime( true );
+
+		try {
+			$this->run_command( array( 'throttle' => '5' ) );
+		} catch ( \WP_CLI_Halt $e ) {
+			// Failures exit non-zero; the timing is what matters here.
+			unset( $e );
+		}
+
+		$this->assertLessThan( 5.0, \microtime( true ) - $started );
+	}
+
+	/**
 	 * Nothing is paced after the final post — the wait would only delay
 	 * the summary the operator is waiting for.
 	 */

--- a/tests/phpunit/tests/cli/class-test-backfill-command-invoke.php
+++ b/tests/phpunit/tests/cli/class-test-backfill-command-invoke.php
@@ -333,6 +333,48 @@ class Test_Backfill_Command_Invoke extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A long post publishes as a thread, and when a reply create spends
+	 * the last of the budget the compensating rollback gets a 429 of its
+	 * own — so the failure arrives as `atmosphere_thread_rollback_failed`
+	 * with the 429 nested inside. The rest of the queue is just as
+	 * rate-limited, so the run still has to stop.
+	 */
+	public function test_rate_limited_inside_a_thread_rollback_aborts_remaining() {
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$this->mock_apply_writes_error(
+			'atmosphere_thread_rollback_failed',
+			array(
+				'original_error' => new \WP_Error(
+					'atmosphere_rate_limited',
+					'Rate limit exceeded.',
+					array(
+						'status' => 429,
+						'reset'  => \time() + 30 * MINUTE_IN_SECONDS,
+					)
+				),
+			)
+		);
+
+		try {
+			$this->run_command( array() );
+			$this->fail( 'Expected WP_CLI_Halt after the rate-limit abort.' );
+		} catch ( \WP_CLI_Halt $e ) {
+			$warnings = \implode( "\n", \WP_CLI::messages( 'warning' ) );
+
+			$this->assertStringContainsString( 'Bluesky rate limit reached', $warnings );
+			$this->assertStringContainsString( 'resets in about', $warnings );
+			$this->assertSame(
+				1,
+				$this->publish_failure_count(),
+				'A nested 429 must stop the queue like a top-level one.'
+			);
+		}
+	}
+
+	/**
 	 * `--limit=0` is accepted as "no cap" and the run proceeds.
 	 */
 	public function test_limit_zero_is_no_cap() {


### PR DESCRIPTION
Fixes #241

## Proposed changes:

* `API::request()` now reads the `ratelimit-*` headers and returns a dedicated `atmosphere_rate_limited` error for a 429, with the reset timestamp in the error data. No sleeping in there, that code also runs during normal web requests.
* A rate-limited share waits for the window the PDS reported instead of the ladder's own 60/300/900 step. The header value is capped at a day, so a broken or hostile `ratelimit-reset` cannot park a queued share weeks out, but the cap only applies to the header, it never shortens the ladder.
* `wp atmosphere backfill` stops when it hits the limit, the same way it stops on a lost connection, and says roughly when the window reopens. Nothing is lost, a failed post never gets `Document::META_URI` so a re-run continues where it stopped.
* New `--throttle=<seconds>` flag to pace a long run. Skipped posts and dry runs cost no budget, so they are not paced.

One thing that was not obvious to me: a long post publishes as a thread, and there the 429 does not always arrive as the top level error code. If a reply create spends the last of the budget, the compensating rollback draws on the same spent budget and gets a 429 too, so the failure comes back as `atmosphere_thread_rollback_failed`. The abort looks one level down for that now.

What this does not solve:

* The throttle is reactive and dumb, a fixed sleep. It does not count points and it does not slow down as the budget runs low. `API::last_rate_limit()` keeps the last reading around so we could do that later, but nothing reads it yet. I went with this because proactive pacing means tracking spend across runs, which is the state I did not want to add (see the issue).
* A thread whose rollback was itself rate limited still leaves orphan records on the PDS and is still not retried automatically. A retry would mint fresh TIDs next to the live partial records and give you a duplicate post, so that case keeps needing a human.
* Only `ratelimit-*` is read, not `Retry-After`. A self hosted PDS behind Cloudflare or nginx would send the latter, and we would fall back to the plain ladder there. Probably worth adding, I just did not want to guess at the shape without a real response to look at.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

`npm run env-test` and `composer lint` both pass. New coverage is in `class-test-api.php`, `class-test-atmosphere.php` and `tests/phpunit/tests/cli/class-test-backfill-command-invoke.php`.

A real 429 is hard to trigger on purpose, so for a manual check drop this into a mu-plugin:

```php
add_filter( 'atmosphere_pre_apply_writes', function () {
	return new WP_Error(
		'atmosphere_rate_limited',
		'Rate limit exceeded.',
		array(
			'status' => 429,
			'reset'  => time() + 30 * MINUTE_IN_SECONDS,
		)
	);
} );
```

* With the filter active and a few unsynced posts on the site, run `wp atmosphere backfill`. It should try one post, warn that the limit resets in about 30 minutes, and stop, instead of walking the whole queue and printing the same warning for every post.
* Swap the error code in the filter for `atmosphere_thread_rollback_failed` and wrap the 429 above as `'original_error'` in the data array. Same result, the run still stops.
* Publish a post with the filter active, then check `wp cron event list | grep atmosphere_publish_post`. The retry should sit about 30 minutes out, not 60 seconds.
* Remove the filter. `wp atmosphere backfill --throttle=3 --dry-run` should finish right away, a dry run spends no budget. Without `--dry-run` it should pause about three seconds between posts.
