### PR TITLE
Treat imported reply text as plain text when building comment HTML

### DIFF
--- a/.github/changelog/fix-imported-reply-text-markup
+++ b/.github/changelog/fix-imported-reply-text-markup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Treat the text of imported Bluesky replies as plain text, so markup in a reply can no longer alter the look of your site.

--- a/includes/transformer/class-facet.php
+++ b/includes/transformer/class-facet.php
@@ -174,10 +174,15 @@ class Facet {
 	 * comment keeps only the lossy display string.
 	 *
 	 * Link and mention features become anchors; tags become hashtag-search
-	 * links; the byte ranges between facets are copied through untouched.
-	 * The result is an HTML fragment intended to be passed through
-	 * `wp_kses_post()` by the caller (as the reaction-sync path does), so
-	 * only the generated `href` attributes are escaped here.
+	 * links. A record's `text` is plain text per the Lexicon, so every
+	 * slice of it is escaped on the way into the fragment, whether or not
+	 * a facet covers it. The only markup in the result is generated here.
+	 *
+	 * That escaping is `esc_html()`, which encodes quotes as well, so an
+	 * ordinary `It's fine` comes back as `It&#039;s fine`. Core's own
+	 * comment pipeline would have kept the apostrophe. The divergence is
+	 * deliberate: this is a fragment we assemble ourselves rather than a
+	 * value core re-encodes on the way out, and it renders identically.
 	 *
 	 * @since 2.0.0
 	 *
@@ -194,7 +199,7 @@ class Facet {
 		$facets = \array_filter( $facets, '\is_array' );
 
 		if ( empty( $facets ) ) {
-			return $text;
+			return \esc_html( $text );
 		}
 
 		\usort(
@@ -228,6 +233,21 @@ class Facet {
 			}
 
 			/*
+			 * An offset landing inside a multi-byte character would hand
+			 * `esc_html()` a slice that isn't valid UTF-8, and
+			 * `wp_check_invalid_utf8()` answers that with an empty string:
+			 * the neighbouring slice would disappear outright rather than
+			 * just lose its anchor. The record's `text` is always valid
+			 * UTF-8 (it reached us through `json_decode()`, which rejects
+			 * anything else), but the offsets are the reply author's to
+			 * choose, so a facet cutting a character in half is theirs to
+			 * arrange. Drop the facet and the line survives as text.
+			 */
+			if ( self::splits_character( $text, $start ) || self::splits_character( $text, $end ) ) {
+				continue;
+			}
+
+			/*
 			 * A facet may carry several features; in practice Bluesky emits
 			 * one, and a non-array `features` (again, untrusted JSON) must
 			 * not reach the array-typed renderer.
@@ -235,12 +255,12 @@ class Facet {
 			$features = $facet['features'] ?? null;
 			$feature  = \is_array( $features ) && \is_array( $features[0] ?? null ) ? $features[0] : array();
 
-			$result .= \substr( $text, $cursor, $start - $cursor );
+			$result .= \esc_html( \substr( $text, $cursor, $start - $cursor ) );
 			$result .= self::render_feature( $feature, \substr( $text, $start, $end - $start ) );
 			$cursor  = $end;
 		}
 
-		return $result . \substr( $text, $cursor );
+		return $result . \esc_html( \substr( $text, $cursor ) );
 	}
 
 	/**
@@ -256,6 +276,25 @@ class Facet {
 		$index = $facet['index'] ?? null;
 
 		return \is_array( $index ) && \is_int( $index['byteStart'] ?? null ) ? $index['byteStart'] : 0;
+	}
+
+	/**
+	 * Whether a byte offset falls inside a multi-byte UTF-8 character.
+	 *
+	 * True when the byte at `$offset` is a continuation byte (`10xxxxxx`),
+	 * which means a slice starting or ending there splits a character in
+	 * half. The end of the string is a boundary like any other.
+	 *
+	 * @param string $text   Text the offset indexes into.
+	 * @param int    $offset Byte offset.
+	 * @return bool Whether the offset splits a character.
+	 */
+	private static function splits_character( string $text, int $offset ): bool {
+		if ( $offset >= \strlen( $text ) ) {
+			return false;
+		}
+
+		return 0x80 === ( \ord( $text[ $offset ] ) & 0xC0 );
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-reaction-sync.php
+++ b/tests/phpunit/tests/class-test-reaction-sync.php
@@ -838,6 +838,72 @@ class Test_Reaction_Sync extends WP_UnitTestCase {
 	}
 
 	/**
+	 * An imported reply's text must not reach `comment_content` as live
+	 * markup. The only gate on it is `wp_kses_post()` — the *post*
+	 * allowlist — which passes `style` and `<img src>` straight through,
+	 * so a reply can otherwise lay a fixed-position overlay over the page
+	 * and beacon every visitor's IP to a host of the author's choosing.
+	 */
+	public function test_process_reply_escapes_markup_in_reply_text() {
+		$post_id  = self::factory()->post->create();
+		$post_uri = 'at://did:plc:me/app.bsky.feed.post/defacepost';
+
+		\update_post_meta( $post_id, BskyPost::META_URI, $post_uri );
+
+		$profile_key = 'atmosphere_profile_' . \md5( 'did:plc:mallory' );
+
+		\set_transient(
+			$profile_key,
+			array(
+				'name'   => 'Mallory',
+				'handle' => 'mallory.test',
+			),
+			\HOUR_IN_SECONDS
+		);
+
+		$payload = '<span style="position:fixed;top:0;left:0;width:100vw;height:100vh;background:#000;z-index:99999">SITE DEFACED</span><img src="https://tracker.example/pixel.gif">';
+
+		$method = new \ReflectionMethod( Reaction_Sync::class, 'process_reply' );
+
+		try {
+			$comment_id = $method->invoke(
+				null,
+				array(
+					'uri'    => 'at://did:plc:mallory/app.bsky.feed.post/defacereply',
+					'cid'    => 'bafyreideface',
+					'record' => array(
+						'text'      => $payload,
+						'createdAt' => '2026-08-21T12:00:00.000Z',
+						'reply'     => array(
+							'parent' => array( 'uri' => $post_uri ),
+							'root'   => array( 'uri' => $post_uri ),
+						),
+					),
+					'author' => array(
+						'did'    => 'did:plc:mallory',
+						'handle' => 'mallory.test',
+					),
+				)
+			);
+		} finally {
+			\delete_transient( $profile_key );
+		}
+
+		$this->assertIsInt( $comment_id );
+
+		$stored = \get_comment( $comment_id )->comment_content;
+
+		// No live element survives: the style and the beacon are inert text.
+		$this->assertStringNotContainsString( '<span', $stored );
+		$this->assertStringNotContainsString( '<img', $stored );
+		$this->assertStringContainsString( '&lt;span style=', $stored );
+
+		// Nothing is dropped either — the reply still reads as written.
+		$this->assertStringContainsString( 'SITE DEFACED', $stored );
+		$this->assertSame( $payload, \html_entity_decode( $stored, \ENT_QUOTES, 'UTF-8' ) );
+	}
+
+	/**
 	 * Test that process_reply drops a reply when get_comment() returns
 	 * null for the resolved parent comment ID (race: comment deleted
 	 * between the meta lookup and the get_comment call). The previous

--- a/tests/phpunit/tests/transformer/class-test-facet.php
+++ b/tests/phpunit/tests/transformer/class-test-facet.php
@@ -521,11 +521,125 @@ class Test_Facet extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Text with no facets must come back byte-for-byte identical.
+	 * Plain text with no facets comes back unchanged.
 	 */
-	public function test_apply_without_facets_is_identity() {
+	public function test_apply_without_facets_leaves_plain_text_alone() {
 		$text = 'Plain reply, no links here.';
 		$this->assertSame( $text, Facet::apply( $text, array() ) );
+	}
+
+	/**
+	 * A record's `text` is plain text per the Lexicon, so markup in it is
+	 * content, not markup. The facet-less path has to escape it: the result
+	 * is only gated by `wp_kses_post()` downstream, which is the *post*
+	 * allowlist and passes `style` and `<img src>` straight through.
+	 */
+	public function test_apply_without_facets_escapes_markup() {
+		$text = '<span style="position:fixed">DEFACED</span><img src="https://tracker.example/p.gif">';
+
+		$result = Facet::apply( $text, array() );
+
+		$this->assertStringNotContainsString( '<span', $result );
+		$this->assertStringNotContainsString( '<img', $result );
+		$this->assertStringContainsString( '&lt;span style=', $result );
+		$this->assertSame( $text, \html_entity_decode( $result, \ENT_QUOTES, 'UTF-8' ) );
+	}
+
+	/**
+	 * The slices *between* facets need the same escaping the facet-covered
+	 * slice already gets, while the generated anchor survives intact.
+	 */
+	public function test_apply_escapes_text_between_facets() {
+		$text   = '<b>bad</b> https://example.com tail<i>';
+		$facets = array(
+			array(
+				'index'    => array(
+					'byteStart' => 11,
+					'byteEnd'   => 30,
+				),
+				'features' => array(
+					array(
+						'$type' => 'app.bsky.richtext.facet#link',
+						'uri'   => 'https://example.com',
+					),
+				),
+			),
+		);
+
+		$result = Facet::apply( $text, $facets );
+
+		// Leading slice, before the facet.
+		$this->assertStringContainsString( '&lt;b&gt;bad&lt;/b&gt;', $result );
+		// Trailing slice, after the facet.
+		$this->assertStringContainsString( 'tail&lt;i&gt;', $result );
+		// No raw markup anywhere from the record text.
+		$this->assertStringNotContainsString( '<b>', $result );
+		$this->assertStringNotContainsString( '<i>', $result );
+		// The anchor we generate is still there.
+		$this->assertStringContainsString( 'href="https://example.com"', $result );
+	}
+
+	/**
+	 * Facet offsets are the reply author's to choose, and nothing says they
+	 * have to line up with the text's character boundaries. A range that cuts
+	 * a multi-byte character in half hands `esc_html()` a slice that isn't
+	 * valid UTF-8, and `wp_check_invalid_utf8()` answers that with an empty
+	 * string — so the neighbouring text would vanish on import while the
+	 * reply still reads in full on Bluesky. Drop the facet, keep the text.
+	 *
+	 * @dataProvider data_apply_character_splitting_facets
+	 *
+	 * @param int $byte_start Start offset of the malformed facet.
+	 * @param int $byte_end   End offset of the malformed facet.
+	 */
+	public function test_apply_skips_facet_splitting_a_character( int $byte_start, int $byte_end ) {
+		// The `é` occupies bytes 1 and 2; the URL runs from byte 7 to byte 26.
+		$text = 'héllo https://example.com';
+
+		$facets = array(
+			array(
+				'index'    => array(
+					'byteStart' => $byte_start,
+					'byteEnd'   => $byte_end,
+				),
+				'features' => array(
+					array(
+						'$type' => 'app.bsky.richtext.facet#link',
+						'uri'   => 'https://malicious.example',
+					),
+				),
+			),
+			array(
+				'index'    => array(
+					'byteStart' => 7,
+					'byteEnd'   => 26,
+				),
+				'features' => array(
+					array(
+						'$type' => 'app.bsky.richtext.facet#link',
+						'uri'   => 'https://example.com',
+					),
+				),
+			),
+		);
+
+		$this->assertSame(
+			'héllo <a href="https://example.com">https://example.com</a>',
+			Facet::apply( $text, $facets ),
+			'A facet range splitting a character must be dropped without taking any of the text with it.'
+		);
+	}
+
+	/**
+	 * Facet ranges that split the `é` in `héllo`, at either end.
+	 *
+	 * @return array<string,array{int,int}>
+	 */
+	public function data_apply_character_splitting_facets(): array {
+		return array(
+			'byteStart mid-character' => array( 2, 3 ),
+			'byteEnd mid-character'   => array( 0, 2 ),
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes CMA-48

## Proposed changes:

* When we import a reply from Bluesky, we build the comment HTML ourselves out of the reply's `text` and its facets. The slices of text between facets used to be copied through as-is. They're now escaped, so the only markup left in the comment is the links / mentions / hashtags we generate.
* Facets whose byte offsets fall in the middle of a multi-byte character are skipped. Escaping half a character gives you an empty string back, which would have dropped the surrounding text instead of just losing the link.

One deliberate difference: the escaping encodes quotes too, so `It's fine` is stored as `It&#039;s fine`. Core's comment pipeline would have kept the apostrophe. This is a fragment we assemble ourselves rather than a value core re-encodes on output, and it renders the same either way.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Connect a site to Bluesky, and share a post to it.
* From Bluesky, reply to that post with some markup in the text, e.g. `<strong>hi</strong>` or an `<img>` tag.
* Run the reaction sync (or wait for the cron).
* The reply lands as a comment with the markup showing as plain text, not rendered.
* Reply again with a link, a mention and a hashtag, plus a few emoji before them. Those should still come through as real links, and the emoji shouldn't shift anything.
