### PR TITLE
Release 2.2.0

### DIFF
--- a/.github/changelog/add-at-tags-meta-tags
+++ b/.github/changelog/add-at-tags-meta-tags
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Your posts and home page now name the AT Protocol records they were published as, so other apps can tell which record a page came from.

--- a/.github/changelog/add-backfill-original-time
+++ b/.github/changelog/add-backfill-original-time
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-The backfill command can now preserve each post's original publish date so historical posts appear in the right chronological order in Bluesky and standard.site readers.

--- a/.github/changelog/add-bluesky-reply-restrictions
+++ b/.github/changelog/add-bluesky-reply-restrictions
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-You can now choose who is allowed to reply to a post on Bluesky: everyone, no one, people you mention, people you follow, or your followers. Sites that connected to Bluesky before this update need to reconnect once to turn it on.

--- a/.github/changelog/add-document-only-publishing
+++ b/.github/changelog/add-document-only-publishing
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Allow sites to publish posts as standard.site documents without also posting to Bluesky.

--- a/.github/changelog/add-editor-reauth-reminder
+++ b/.github/changelog/add-editor-reauth-reminder
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-The post editor now tells you when your Bluesky connection has expired so you can reconnect before publishing, and warns you in the editor before saving a change that removes a post from Bluesky.

--- a/.github/changelog/add-health-check-client-metadata
+++ b/.github/changelog/add-health-check-client-metadata
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add a Site Health check that tells you when Bluesky cannot reach your site, which is why connecting silently fails when a security plugin limits the REST API.

--- a/.github/changelog/add-icon-registration
+++ b/.github/changelog/add-icon-registration
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add the ATmosphere and Bluesky icons to the WordPress 7.1 icon library, so you can use them in the Icon block.

--- a/.github/changelog/add-per-post-bluesky-companion
+++ b/.github/changelog/add-per-post-bluesky-companion
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Compatible plugins can now decide per post whether it is also shared to Bluesky.

--- a/.github/changelog/add-posts-list-bluesky-column
+++ b/.github/changelog/add-posts-list-bluesky-column
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add a Bluesky column to the posts list showing whether a post was shared, with a link to it, plus a "Share to Bluesky" action to share a post that did not make it the first time.

--- a/.github/changelog/add-rate-limit-awareness
+++ b/.github/changelog/add-rate-limit-awareness
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Handle Bluesky rate limits when sharing: a share that hits the limit now waits for it to lift before retrying, and bulk syncs can be paced so they stay under it.

--- a/.github/changelog/add-record-tags-filter
+++ b/.github/changelog/add-record-tags-filter
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add a way for sites to change the tags and keywords sent to Bluesky and standard.site, so leftover terms from an import stay out of the records.

--- a/.github/changelog/change-mention-resolution-error-codes
+++ b/.github/changelog/change-mention-resolution-error-codes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Mention resolution now tells a temporarily unreachable handle host apart from a handle that has no verification set up.

--- a/.github/changelog/fix-client-id-https
+++ b/.github/changelog/fix-client-id-https
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix sharing to Bluesky failing with an "Invalid client ID" error on sites served through a reverse proxy or CDN.

--- a/.github/changelog/fix-did-guard-comment-hard-delete
+++ b/.github/changelog/fix-did-guard-comment-hard-delete
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed a case where deleting a post or comment after reconnecting to a different Bluesky account could quietly leave the original records stranded on the old account. Atmosphere now stops and reports the mismatch instead.

--- a/.github/changelog/fix-imported-reaction-author-markup
+++ b/.github/changelog/fix-imported-reaction-author-markup
@@ -1,4 +1,0 @@
-Significance: patch
-Type: security
-
-Strip HTML from the display names of Bluesky accounts whose replies, likes, and reposts are imported as comments, and keep names containing an ampersand from breaking the comment feeds.

--- a/.github/changelog/fix-imported-reply-text-markup
+++ b/.github/changelog/fix-imported-reply-text-markup
@@ -1,4 +1,0 @@
-Significance: patch
-Type: security
-
-Treat the text of imported Bluesky replies as plain text, so markup in a reply can no longer alter the look of your site.

--- a/.github/changelog/fix-pre-publish-error-handling
+++ b/.github/changelog/fix-pre-publish-error-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-The Bluesky pre-publish preview now shows a clear message when it can't be generated — including a distinct one for permission errors — instead of failing without explanation.

--- a/.github/changelog/fix-resolver-upstream-status
+++ b/.github/changelog/fix-resolver-upstream-status
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Show a clearer error when your own domain, Bluesky's directory, or a login server is temporarily unavailable, instead of reporting the account as invalid.

--- a/.github/changelog/fix-stale-featured-image-blob
+++ b/.github/changelog/fix-stale-featured-image-blob
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Posts with images no longer fail to share when a stored image reference is no longer available on the server; the images are automatically re-uploaded and the post is shared on a second attempt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-08-31
+### Security
+- Strip HTML from the display names of Bluesky accounts whose replies, likes, and reposts are imported as comments, and keep names containing an ampersand from breaking the comment feeds. [#255]
+- Treat the text of imported Bluesky replies as plain text, so markup in a reply can no longer alter the look of your site. [#256]
+
+### Added
+- Add a Bluesky column to the posts list showing whether a post was shared, with a link to it, plus a "Share to Bluesky" action to share a post that did not make it the first time. [#248]
+- Add a Site Health check that tells you when Bluesky cannot reach your site, which is why connecting silently fails when a security plugin limits the REST API. [#250]
+- Add a way for sites to change the tags and keywords sent to Bluesky and standard.site, so leftover terms from an import stay out of the records. [#243]
+- Add the ATmosphere and Bluesky icons to the WordPress 7.1 icon library, so you can use them in the Icon block. [#254]
+- Allow sites to publish posts as standard.site documents without also posting to Bluesky. [#211]
+- Compatible plugins can now decide per post whether it is also shared to Bluesky. [#240]
+- Handle Bluesky rate limits when sharing: a share that hits the limit now waits for it to lift before retrying, and bulk syncs can be paced so they stay under it. [#244]
+- The backfill command can now preserve each post's original publish date so historical posts appear in the right chronological order in Bluesky and standard.site readers. [#213]
+- The post editor now tells you when your Bluesky connection has expired so you can reconnect before publishing, and warns you in the editor before saving a change that removes a post from Bluesky. [#233]
+- You can now choose who is allowed to reply to a post on Bluesky: everyone, no one, people you mention, people you follow, or your followers. Sites that connected to Bluesky before this update need to reconnect once to turn it on. [#229]
+- Your posts and home page now name the AT Protocol records they were published as, so other apps can tell which record a page came from. [#220]
+
+### Changed
+- Mention resolution now tells a temporarily unreachable handle host apart from a handle that has no verification set up. [#214]
+
+### Fixed
+- Fixed a case where deleting a post or comment after reconnecting to a different Bluesky account could quietly leave the original records stranded on the old account. Atmosphere now stops and reports the mismatch instead. [#216]
+- Fix sharing to Bluesky failing with an "Invalid client ID" error on sites served through a reverse proxy or CDN. [#230]
+- Posts with images no longer fail to share when a stored image reference is no longer available on the server; the images are automatically re-uploaded and the post is shared on a second attempt. [#143]
+- Show a clearer error when your own domain, Bluesky's directory, or a login server is temporarily unavailable, instead of reporting the account as invalid. [#214]
+- The Bluesky pre-publish preview now shows a clear message when it can't be generated — including a distinct one for permission errors — instead of failing without explanation. [#149]
+
 ## [2.1.0] - 2026-07-22
 ### Added
 - Add a connection-only mode so another plugin can reuse just the Bluesky connection: automatic cross-posting, likes and reposts, and reply importing all stay off, and the ATmosphere settings screen is hidden. [#203]
@@ -162,6 +190,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove a comment reply from Bluesky if the comment was deleted or unapproved while it was being published, instead of leaving an orphan reply behind. [#32]
 - Short posts under the long-form teaser-thread strategy no longer ship a redundant "continue reading" reply when the entire body already fits in a single Bluesky post. The link-back is preserved as a card on the same post. [#51]
 
+[2.2.0]: https://github.com/Automattic/wordpress-atmosphere/compare/2.1.0...2.2.0
 [2.1.0]: https://github.com/Automattic/wordpress-atmosphere/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/Automattic/wordpress-atmosphere/compare/1.2.0...2.0.0
 [1.2.0]: https://github.com/Automattic/wordpress-atmosphere/compare/1.1.1...1.2.0

--- a/atmosphere.php
+++ b/atmosphere.php
@@ -3,7 +3,7 @@
  * Plugin Name: ATmosphere
  * Plugin URI: https://github.com/Automattic/wordpress-atmosphere
  * Description: Publish WordPress posts to AT Protocol (Bluesky + standard.site) via native OAuth.
- * Version: 2.1.0
+ * Version: 2.2.0
  * Author: Automattic
  * Author URI: https://automattic.com
  * License: GPL-2.0-or-later
@@ -19,7 +19,7 @@ namespace Atmosphere;
 
 \defined( 'ABSPATH' ) || exit;
 
-\define( 'ATMOSPHERE_VERSION', '2.1.0' );
+\define( 'ATMOSPHERE_VERSION', '2.2.0' );
 \define( 'ATMOSPHERE_PLUGIN_DIR', \plugin_dir_path( __FILE__ ) );
 \define( 'ATMOSPHERE_PLUGIN_URL', \plugin_dir_url( __FILE__ ) );
 \define( 'ATMOSPHERE_PLUGIN_FILE', __FILE__ );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -32,7 +32,7 @@ class API {
 	 * does not, and persisting the reading would mean an option write on
 	 * every single PDS call.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @var array|null
 	 */
@@ -41,7 +41,7 @@ class API {
 	/**
 	 * Read the most recent rate-limit snapshot reported by the PDS.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @return array|null Snapshot, or null when no response in this
 	 *                    process carried the `ratelimit-*` headers.
@@ -58,7 +58,7 @@ class API {
 	 * typing the string at every call site, the same convention
 	 * {@see Client::is_reconnect_error()} follows.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @var string
 	 */
@@ -67,7 +67,7 @@ class API {
 	/**
 	 * Whether a failure is a rate limit reported by the PDS.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param \WP_Error $error Failure to classify.
 	 * @return bool
@@ -295,7 +295,7 @@ class API {
 	 * name, but not every failure carries both, so the caller supplies
 	 * the wording for the case where neither is there.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param array  $body     Decoded response body.
 	 * @param string $fallback Message to use when the body says nothing.
@@ -319,7 +319,7 @@ class API {
 	 * about *this* response cannot mistake a stale reading for a fresh
 	 * one.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param array $response Raw `wp_remote_*` response.
 	 * @return array|null Snapshot for this response, or null when it
@@ -361,7 +361,7 @@ class API {
 	 * reaches three decades in seconds, and no timestamp we care about
 	 * predates 2001.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param mixed $raw Raw header value.
 	 * @return int|null Unix timestamp, or null when unreadable.
@@ -394,7 +394,7 @@ class API {
 	 * caller back at a moment that has nothing to do with the window it
 	 * actually hit.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param array      $body     Decoded response body.
 	 * @param array|null $snapshot Rate-limit headers on this response.
@@ -619,7 +619,7 @@ class API {
 		 * response) or a `WP_Error` to bypass the network; return null to run
 		 * the real request. Used by the Publisher test fixture.
 		 *
-		 * @since unreleased
+		 * @since 2.2.0
 		 *
 		 * @param array|\WP_Error|null $short_circuit Canned response, or null to proceed.
 		 * @param string               $collection    Collection NSID.

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -837,7 +837,7 @@ class Atmosphere {
 		 * account, so `at:author` would attribute every post on a
 		 * multi-author site to whoever connected it.
 		 *
-		 * @since unreleased
+		 * @since 2.2.0
 		 *
 		 * @param array<string, string[]> $tags Tag name => list of AT-URIs.
 		 */
@@ -2084,7 +2084,7 @@ class Atmosphere {
 	 * and beyond, and a second worker must not be queued alongside a retry
 	 * that is still pending.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param int $post_id Post to share.
 	 * @return bool True when a worker was queued, false when one was already pending.
@@ -2113,7 +2113,7 @@ class Atmosphere {
 	 * is suppressed on the same condition: the surface would otherwise say
 	 * "update the post to try again" and "reconnect your account" at once.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param int $post_id Post ID.
 	 * @return array|null Failure details, or null when the last attempt succeeded.
@@ -2694,7 +2694,7 @@ class Atmosphere {
 	 * publish weeks into the future; it must never shorten the ladder's
 	 * own step, which is why it applies to the header value alone.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param int       $delay Ladder delay for this attempt, in seconds.
 	 * @param \WP_Error $error The failure being retried.

--- a/includes/class-icons.php
+++ b/includes/class-icons.php
@@ -29,7 +29,7 @@ namespace Atmosphere;
  * allow-list; ours use `<svg>` and `<path>`, monochrome, with the fill
  * inherited so the Icon block's color tools apply.
  *
- * @since unreleased
+ * @since 2.2.0
  */
 class Icons {
 
@@ -45,7 +45,7 @@ class Icons {
 	 *
 	 * Hooked on `init`, where core registers its own collections.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 */
 	public static function register(): void {
 		if ( ! \function_exists( 'wp_register_icon_collection' ) ) {
@@ -82,7 +82,7 @@ class Icons {
 	/**
 	 * The icons the plugin ships, as file name => label.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @return array<string, string>
 	 */

--- a/includes/class-publisher.php
+++ b/includes/class-publisher.php
@@ -405,7 +405,7 @@ class Publisher {
 	 * bsky-oriented paths (reaction/reply sync, in-place thread updates) stay
 	 * inert for this post.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param \WP_Post $post          WordPress post.
 	 * @param bool     $original_time Reserve the document rkey from the post's original publish date rather than "now".
@@ -434,7 +434,7 @@ class Publisher {
 	 * `Document::*` meta — no `Post::*` meta — so downstream bsky-oriented paths
 	 * (reaction/reply sync, in-place thread updates) stay inert for this post.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param \WP_Post $post WordPress post.
 	 * @param string   $op   applyWrites op — `create` or `update`.
@@ -487,7 +487,7 @@ class Publisher {
 	 * unmoved (`written => null`), so a transient error can neither clobber
 	 * moderation state nor desync the marker.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param \WP_Post $post      WordPress post.
 	 * @param string   $rkey      The post's root rkey, shared by the threadgate.
@@ -608,7 +608,7 @@ class Publisher {
 	/**
 	 * Read the live threadgate record for merging.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param string $rkey Root rkey shared by the threadgate.
 	 * @return array|null|false The record `value` when present, null when the
@@ -639,7 +639,7 @@ class Publisher {
 	 * `hiddenReplies` and any field a newer lexicon adds — survive the write.
 	 * The record's original `createdAt` is kept when it already has one.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param array|null $current The live record value, or null to build fresh.
 	 * @param \WP_Post   $post    WordPress post.
@@ -664,7 +664,7 @@ class Publisher {
 	/**
 	 * Build an `applyWrites` create/update entry for a threadgate.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param string $op    applyWrites op — `create` or `update`.
 	 * @param string $rkey  Root rkey shared by the threadgate.
@@ -683,7 +683,7 @@ class Publisher {
 	/**
 	 * Build the `applyWrites#delete` entry for a threadgate at `$rkey`.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param string $rkey The post's root rkey, shared by the threadgate.
 	 * @return array applyWrites#delete entry.
@@ -703,7 +703,7 @@ class Publisher {
 	 * the records it gated. Returns nothing when no gate is live or the root
 	 * rkey is unknown.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param \WP_Post $post   WordPress post.
 	 * @param array[]  $stored Stored bsky records (root first).
@@ -725,7 +725,7 @@ class Publisher {
 	 * in-flight write cannot desync the marker from what was actually sent
 	 * (see the in-flight-state rule in the code-style docs).
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param int  $post_id WordPress post ID.
 	 * @param bool $written Whether the submitted batch leaves a gate live.
@@ -1036,7 +1036,7 @@ class Publisher {
 	/**
 	 * Error-data key carrying the failure that triggered a rollback.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @var string
 	 */
@@ -1045,7 +1045,7 @@ class Publisher {
 	/**
 	 * Error-data key carrying the failure the rollback itself hit.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @var string
 	 */
@@ -1066,7 +1066,7 @@ class Publisher {
 	 * can classify the error itself and then walk this without
 	 * special-casing the shape.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param \WP_Error $error Failure returned by the Publisher.
 	 * @return \WP_Error[] The nested failures, in declaration order.
@@ -1465,7 +1465,7 @@ class Publisher {
 	 * the one the stored URI already points at, so it surfaces an
 	 * `atmosphere_missing_tid` error instead — again mirroring {@see self::update_post()}.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param \WP_Post $post WordPress post.
 	 * @return array|\WP_Error applyWrites response or error.

--- a/includes/cli/class-backfill-command.php
+++ b/includes/cli/class-backfill-command.php
@@ -524,7 +524,7 @@ class Backfill_Command extends \WP_CLI_Command {
 	 * zero. A publish-to-the-internet command must refuse to run on a
 	 * value it had to guess at.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param array  $assoc_args Flag arguments.
 	 * @param string $flag       Flag name, without the leading dashes.
@@ -574,7 +574,7 @@ class Backfill_Command extends \WP_CLI_Command {
 	 * of the queue is just as rate-limited either way, hence the walk
 	 * through the wrapped failures.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param \WP_Error $error Failure returned by the Publisher.
 	 * @return string|null Message to warn with, or null to keep going.
@@ -596,7 +596,7 @@ class Backfill_Command extends \WP_CLI_Command {
 	/**
 	 * A publish failure plus whatever failures it wraps.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param \WP_Error $error Failure returned by the Publisher.
 	 * @return \WP_Error[] The failure itself first, then its causes.
@@ -614,7 +614,7 @@ class Backfill_Command extends \WP_CLI_Command {
 	 * after it would sleep for nothing. A failed thread rollback keeps
 	 * its status one level down, hence the walk.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param \WP_Error $error Failure returned by the Publisher.
 	 * @return bool
@@ -639,7 +639,7 @@ class Backfill_Command extends \WP_CLI_Command {
 	 * missing or unreadable the error carries no reset and the message
 	 * drops that sentence instead of guessing at a number.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param \WP_Error $error Rate-limit error from the publisher.
 	 * @return string

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -112,7 +112,7 @@ function appview_url( string $path, array $context = array() ): string {
  * so every caller inherits the same strictness and the same
  * {@see appview_url()} host and route filters.
  *
- * @since unreleased
+ * @since 2.2.0
  *
  * @param string $uri AT-URI of a Bluesky post record.
  * @return string Web URL, or '' when the URI is not one of our post records.
@@ -154,7 +154,7 @@ function post_web_url( string $uri ): string {
  * Shared by the editor panel's `atmosphere_url` REST field and the posts-list
  * column, so both link to the same place and agree on what "not shared" means.
  *
- * @since unreleased
+ * @since 2.2.0
  *
  * @param int $post_id Post ID.
  * @return string Web URL, or '' until the post has a Bluesky record.
@@ -540,7 +540,7 @@ function has_identity(): bool {
  * directly, so the option's shape and its autoload flag (which
  * {@see get_identity()}'s lazy migration also relies on) live in one place.
  *
- * @since unreleased
+ * @since 2.2.0
  *
  * @param array $identity Identity to store. Only `did`, `handle`, and
  *                        `pds_endpoint` are persisted; a missing or
@@ -666,7 +666,7 @@ function needs_reauth(): bool {
  * refreshed since, or the server did not say. Callers must treat null as
  * "no information", not as "nothing granted".
  *
- * @since unreleased
+ * @since 2.2.0
  *
  * @return string[]|null Granted scope tokens, or null when unknown.
  */
@@ -689,7 +689,7 @@ function connection_scopes(): ?array {
  * through the normal publish error. Hiding a working feature on every
  * pre-existing install would be worse than the occasional failed write.
  *
- * @since unreleased
+ * @since 2.2.0
  *
  * @return bool
  */
@@ -782,7 +782,7 @@ function reauth_reason_lead(): string {
  * cause, a non-admin gets nothing at all: that is a state the administrator
  * chose, not a problem for every author to worry about.
  *
- * @since unreleased
+ * @since 2.2.0
  *
  * @return string Translated, unescaped sentence. Empty when no reconnect is needed.
  */
@@ -839,7 +839,7 @@ function reauth_lead_for_current_user(): string {
  * where the panel stays quiet but "will this post be shared" still needs an
  * answer.
  *
- * @since unreleased
+ * @since 2.2.0
  *
  * @return array{state: string, message: string, reason: string, severity: string, action: bool, can_share: bool, sharing_enabled: bool}
  */
@@ -932,7 +932,7 @@ function settings_url(): string {
  * page is hidden (connection-only mode) and the Connectors API is available,
  * or nowhere when neither exists.
  *
- * @since unreleased
+ * @since 2.2.0
  *
  * @return string Unescaped admin URL, or '' when there is no reconnect destination.
  */
@@ -954,7 +954,7 @@ function reconnect_url(): string {
 	 * text, which is what happens by default when there is no screen to
 	 * link to.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param string $url Admin URL to reconnect at, or '' when there is none.
 	 */
@@ -1328,7 +1328,7 @@ function is_publication_sync_enabled(): bool {
  *
  * The post is passed to the filter so a callback can answer per post.
  *
- * @since unreleased
+ * @since 2.2.0
  *
  * @param \WP_Post $post The post being published.
  * @return bool True when the Bluesky companion post should be published. Default true.
@@ -1341,7 +1341,7 @@ function is_bluesky_post_enabled( \WP_Post $post ): bool {
 	 * Return false to publish documents only. Forward-only: it does not remove
 	 * Bluesky posts published before it was enabled.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param bool     $enabled Whether to publish the Bluesky companion post. Default true.
 	 * @param \WP_Post $post    The post being published.

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -41,7 +41,7 @@ class Client {
 	 * Named so the surfaces that check for it and the list that requests
 	 * it cannot drift apart.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @var string
 	 */

--- a/includes/oauth/class-resolver.php
+++ b/includes/oauth/class-resolver.php
@@ -152,7 +152,7 @@ class Resolver {
 	 * branches on it today; the improvement users actually see is the
 	 * message. Returns null for a 2xx response so the caller parses.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param array  $response `wp_remote_*` response array.
 	 * @param string $label    Human label for the fetched resource.

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -199,7 +199,7 @@ abstract class Base {
 	 * `atmosphere_record_tags` runs, so a filter cannot push a record
 	 * past what the lexicons accept.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @var int
 	 */
@@ -257,7 +257,7 @@ abstract class Base {
 		 * tag names rather than picking from existing terms should keep
 		 * them short itself.
 		 *
-		 * @since unreleased
+		 * @since 2.2.0
 		 *
 		 * @param string[] $tags Tag names collected from the post's tags and categories.
 		 * @param \WP_Post $post WordPress post.

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -1408,7 +1408,7 @@ class Post extends Base {
 	/**
 	 * Force, or stop forcing, blob re-upload on subsequent uploads.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param bool $force Whether to bypass the blob-ref cache.
 	 * @return void

--- a/includes/transformer/class-threadgate.php
+++ b/includes/transformer/class-threadgate.php
@@ -182,7 +182,7 @@ class Threadgate extends Base {
 		 * Filters that return a non-array fall back to the pre-filter
 		 * record.
 		 *
-		 * @since unreleased
+		 * @since 2.2.0
 		 *
 		 * @param array    $record Threadgate record.
 		 * @param \WP_Post $post   WordPress post.

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -560,7 +560,7 @@ class Admin {
 	 * site-wide, so it does not earn a place on every screen. The admin
 	 * who can reconnect is the one on this page.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 */
 	public static function maybe_render_threadgate_scope_notice(): void {
 		if ( ! \current_user_can( 'manage_options' ) ) {

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -49,7 +49,7 @@ class Health_Check {
 	 * `health-check-` and replacing the first underscore with a hyphen,
 	 * so it must carry exactly one underscore.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @var string
 	 */
@@ -58,7 +58,7 @@ class Health_Check {
 	/**
 	 * The admin-ajax action core calls for {@see self::REACHABILITY_TEST}.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @var string
 	 */
@@ -195,7 +195,7 @@ class Health_Check {
 	 * Same nonce and capability core used for its own admin-ajax tests.
 	 * The screen reads `response.data`, hence `wp_send_json_success()`.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 */
 	public static function ajax_client_metadata(): void {
 		\check_ajax_referer( 'health-check-site-status' );
@@ -231,7 +231,7 @@ class Health_Check {
 	 * than critical, since split-horizon setups can fail validation from
 	 * the server itself while being perfectly valid from outside.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @return array Site Health test result.
 	 */
@@ -341,7 +341,7 @@ class Health_Check {
 	/**
 	 * Describe what is wrong with a client-metadata response, or '' when nothing is.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param array|\WP_Error $response Result of the loopback request.
 	 * @param string          $url      The client metadata URL that was fetched.
@@ -383,7 +383,7 @@ class Health_Check {
 	 * The audience is users who can install plugins, who can read the
 	 * page directly anyway.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param string $body Raw body.
 	 * @return string
@@ -403,7 +403,7 @@ class Health_Check {
 	 * Recommended, not critical: posts still publish, only the restriction
 	 * is skipped.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @return array Site Health test result.
 	 */

--- a/includes/wp-admin/class-post-list.php
+++ b/includes/wp-admin/class-post-list.php
@@ -33,7 +33,7 @@ use function Atmosphere\post_share_url;
  * would hand a contributor the PDS failure text stored on someone
  * else's post.
  *
- * @since unreleased
+ * @since 2.2.0
  */
 class Post_List {
 
@@ -80,7 +80,7 @@ class Post_List {
 	 * present and inert. That also removes it in connection-only mode,
 	 * where a host plugin owns the sharing surfaces.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 */
 	public static function register(): void {
 		if ( ! is_auto_publish_enabled() ) {
@@ -105,7 +105,7 @@ class Post_List {
 	 * Registering it as a real column means Screen Options can hide it
 	 * without any extra setting of ours.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param array $columns Existing columns.
 	 * @return array
@@ -119,7 +119,7 @@ class Post_List {
 	/**
 	 * Render one cell.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param string $column  Column key being rendered.
 	 * @param int    $post_id Post ID for the row.
@@ -179,7 +179,7 @@ class Post_List {
 	 * sharing actions to this list, and a bare "Share now" would not say
 	 * where the post is going.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param array    $actions Existing row actions.
 	 * @param \WP_Post $post    Post for the row.
@@ -221,7 +221,7 @@ class Post_List {
 	 * behind it: a site can publish documents only for some posts and
 	 * keep the Bluesky companion for others.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param \WP_Post $post Post to test.
 	 * @return bool
@@ -246,7 +246,7 @@ class Post_List {
 	 * fifteen minutes and beyond, and a second worker must not be queued
 	 * alongside a retry that is still pending.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 *
 	 * @param \WP_Post $post Post to share.
 	 * @return string One of the `RESULT_*` constants.
@@ -264,7 +264,7 @@ class Post_List {
 	/**
 	 * Handle the row-action request.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 */
 	public static function handle_share(): void {
 		$post_id = isset( $_GET['post'] ) ? (int) $_GET['post'] : 0;
@@ -289,7 +289,7 @@ class Post_List {
 	/**
 	 * Tell the user what happened after a share request.
 	 *
-	 * @since unreleased
+	 * @since 2.2.0
 	 */
 	public static function maybe_render_share_notice(): void {
 		$screen = \function_exists( 'get_current_screen' ) ? \get_current_screen() : null;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: at-protocol, bluesky, connector, atproto, crossposting
 Requires at least: 6.5
 Tested up to: 7.1
 Requires PHP: 8.2
-Stable tag: 2.1.0
+Stable tag: 2.2.0
 License: GPL-2.0-or-later
 License URI: https://spdx.org/licenses/GPL-2.0-or-later.html
 
@@ -103,6 +103,34 @@ Not at this time. ATmosphere is designed for a single WordPress site. On a Netwo
 
 == Changelog ==
 
+### 2.2.0 - 2026-08-31
+#### Security
+- Strip HTML from the display names of Bluesky accounts whose replies, likes, and reposts are imported as comments, and keep names containing an ampersand from breaking the comment feeds.
+- Treat the text of imported Bluesky replies as plain text, so markup in a reply can no longer alter the look of your site.
+
+#### Added
+- Add a Bluesky column to the posts list showing whether a post was shared, with a link to it, plus a "Share to Bluesky" action to share a post that did not make it the first time.
+- Add a Site Health check that tells you when Bluesky cannot reach your site, which is why connecting silently fails when a security plugin limits the REST API.
+- Add a way for sites to change the tags and keywords sent to Bluesky and standard.site, so leftover terms from an import stay out of the records.
+- Add the ATmosphere and Bluesky icons to the WordPress 7.1 icon library, so you can use them in the Icon block.
+- Allow sites to publish posts as standard.site documents without also posting to Bluesky.
+- Compatible plugins can now decide per post whether it is also shared to Bluesky.
+- Handle Bluesky rate limits when sharing: a share that hits the limit now waits for it to lift before retrying, and bulk syncs can be paced so they stay under it.
+- The backfill command can now preserve each post's original publish date so historical posts appear in the right chronological order in Bluesky and standard.site readers.
+- The post editor now tells you when your Bluesky connection has expired so you can reconnect before publishing, and warns you in the editor before saving a change that removes a post from Bluesky.
+- You can now choose who is allowed to reply to a post on Bluesky: everyone, no one, people you mention, people you follow, or your followers. Sites that connected to Bluesky before this update need to reconnect once to turn it on.
+- Your posts and home page now name the AT Protocol records they were published as, so other apps can tell which record a page came from.
+
+#### Changed
+- Mention resolution now tells a temporarily unreachable handle host apart from a handle that has no verification set up.
+
+#### Fixed
+- Fixed a case where deleting a post or comment after reconnecting to a different Bluesky account could quietly leave the original records stranded on the old account. Atmosphere now stops and reports the mismatch instead.
+- Fix sharing to Bluesky failing with an "Invalid client ID" error on sites served through a reverse proxy or CDN.
+- Posts with images no longer fail to share when a stored image reference is no longer available on the server; the images are automatically re-uploaded and the post is shared on a second attempt.
+- Show a clearer error when your own domain, Bluesky's directory, or a login server is temporarily unavailable, instead of reporting the account as invalid.
+- The Bluesky pre-publish preview now shows a clear message when it can't be generated — including a distinct one for permission errors — instead of failing without explanation.
+
 ### 2.1.0 - 2026-07-22
 #### Added
 - Add a connection-only mode so another plugin can reuse just the Bluesky connection: automatic cross-posting, likes and reposts, and reply importing all stay off, and the ATmosphere settings screen is hidden.
@@ -156,6 +184,7 @@ See full Changelog on [GitHub](https://github.com/Automattic/wordpress-atmospher
 
 == Upgrade Notice ==
 
-= 0.1.0 =
+= 2.2.0 =
 
-Initial release.
+This release adds reply restrictions for Bluesky posts — sites connected before this update need to reconnect once to enable them. It also hardens how imported Bluesky replies and display names are rendered on your site.
+


### PR DESCRIPTION
## Proposed changes:

Cuts 2.2.0. `bin/release.js` rolled the 19 pending changelog entries into `CHANGELOG.md`, mirrored them into `readme.txt`, and bumped the version everywhere it's hardcoded.

This release also gets an Upgrade Notice, the first since 0.1.0. Reply restrictions only start working after a site reconnects, so that belongs on the update screen rather than buried in the changelog.

The second commit stamps `2.2.0` on four `_doing_it_wrong()` calls the release script left as `unreleased`. Its regex only rewrites the placeholder when the whole call fits on one line and the message argument is a quoted string; these four span several lines.

Two things I left out on purpose. 14 older `unreleased` markers shipped the same way back in 1.1.0 through 2.1.0, and the regex in `bin/release.js` still lets that happen. Backfilling historical version numbers isn't release bookkeeping, so both want their own PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

No new tests; this is version bookkeeping. `composer lint` and the full suite (1331 tests) pass on the branch.

## Testing instructions:

* Check out the branch. `atmosphere.php` should report `2.2.0` in both the plugin header and `ATMOSPHERE_VERSION`, and `readme.txt` should have `Stable tag: 2.2.0`.
* Read the new `### 2.2.0` block in `readme.txt` and `CHANGELOG.md`. Every line should make sense to someone who has never seen the code.
* Confirm the Upgrade Notice section names 2.2.0 and mentions the reconnect.
* `grep -rn "'unreleased'" includes/` should return 14 lines, all in code that shipped in earlier releases, and none in `class-atmosphere.php` or `class-threadgate.php`.
* Run `composer lint` and `npm run env-test`.

### Changelog entry

Release PRs don't need one. The "Release" label is already on this PR; add "Skip Changelog" if CI asks for it.
