### PR TITLE
Stamp the version markers the release script has been missing

### DIFF
--- a/bin/__tests__/release.test.js
+++ b/bin/__tests__/release.test.js
@@ -1,0 +1,145 @@
+/**
+ * Tests for the release script's version-marker replacement.
+ *
+ * These import the patterns the release actually runs, so a change to
+ * bin/version-patterns.js is covered here rather than in a copy of it.
+ */
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+const { phpVersionPatterns } = require( '../version-patterns' );
+
+const VERSION = '9.9.9';
+
+const rewrite = ( content ) =>
+	phpVersionPatterns( VERSION ).reduce(
+		( updated, { search, replace } ) => updated.replace( search, replace ),
+		content
+	);
+
+describe( 'Version markers in code', () => {
+	test.each( [
+		[
+			'a call wrapped across several lines',
+			`\t\t\t\\_doing_it_wrong(\n\t\t\t\t__METHOD__,\n\t\t\t\t\\esc_html__( 'must return an array.', 'atmosphere' ),\n\t\t\t\t'unreleased'\n\t\t\t);`,
+		],
+		[
+			'a wrapped call whose message is a variable, not a literal',
+			`\t\t\t\\_doing_it_wrong(\n\t\t\t\t\\esc_html( $method ),\n\t\t\t\t\\esc_html( $message ),\n\t\t\t\t'unreleased'\n\t\t\t);`,
+		],
+		[
+			'a single-line call whose message is a variable',
+			`\t\t\\_doing_it_wrong( \\esc_html( $method ), \\esc_html( $message ), 'unreleased' );`,
+		],
+		[
+			'a single-line call whose message is a literal',
+			`\t\t\\_doing_it_wrong( __METHOD__, 'Use new_method().', 'unreleased' );`,
+		],
+		[ '_deprecated_function', `\t\t\\_deprecated_function( __FUNCTION__, 'unreleased', 'new_function' );` ],
+		[ '_deprecated_argument', `\t\t\\_deprecated_argument( __FUNCTION__, 'unreleased', 'Pass an array.' );` ],
+		[
+			'apply_filters_deprecated, where the version is not the last argument',
+			`\t\t\\apply_filters_deprecated( 'atmosphere_old', array( $value ), 'unreleased', 'atmosphere_new' );`,
+		],
+		[
+			'do_action_deprecated',
+			`\t\tdo_action_deprecated( 'old_hook', array( $v ), 'unreleased', 'new_hook' );`,
+		],
+		[
+			'version_compare in a migration',
+			`\t\tif ( \\version_compare( $version_from_db, 'unreleased', '<' ) ) {`,
+		],
+		[
+			'a wrapped call whose message contains a semicolon',
+			`\t\t\t\\_doing_it_wrong(\n\t\t\t\t__METHOD__,\n\t\t\t\t\\esc_html__( 'Entries were not non-empty strings; those were skipped.', 'atmosphere' ),\n\t\t\t\t'unreleased'\n\t\t\t);`,
+		],
+		[
+			'a wrapped call whose message is a ternary spanning lines',
+			`\t\t\t\\_doing_it_wrong(\n\t\t\t\t__METHOD__,\n\t\t\t\t$fallback\n\t\t\t\t\t? \\esc_html__( 'Missing $type; falling back.', 'atmosphere' )\n\t\t\t\t\t: \\esc_html__( 'Missing $type; omitting.', 'atmosphere' ),\n\t\t\t\t'unreleased'\n\t\t\t);`,
+		],
+	] )( 'stamps the version on %s', ( _label, source ) => {
+		const result = rewrite( source );
+
+		expect( result ).toContain( `'${ VERSION }'` );
+		expect( result ).not.toContain( "'unreleased'" );
+	} );
+
+	test( 'stamps every marker in a file that has more than one', () => {
+		const source = `\t\t\\_doing_it_wrong(\n\t\t\t__METHOD__,\n\t\t\t'First.',\n\t\t\t'unreleased'\n\t\t);\n\n\t\t\\_doing_it_wrong(\n\t\t\t__METHOD__,\n\t\t\t'Second.',\n\t\t\t'unreleased'\n\t\t);`;
+
+		expect( rewrite( source ).match( /9\.9\.9/g ) ).toHaveLength( 2 );
+	} );
+} );
+
+describe( 'Version markers in docblocks', () => {
+	test( 'stamps @since and @deprecated, in any case', () => {
+		const source = `\t/**\n\t * @since unreleased\n\t * @since UNRELEASED Changed the return shape.\n\t * @deprecated unreleased\n\t */`;
+
+		const result = rewrite( source );
+
+		expect( result ).not.toMatch( /unreleased/i );
+		expect( result.match( /9\.9\.9/g ) ).toHaveLength( 3 );
+	} );
+} );
+
+describe( 'Text that only looks like a marker', () => {
+	test.each( [
+		[
+			'a documented example inside a block comment',
+			`\t\t/*\n\t\t * Example:\n\t\t *\n\t\t * if ( \\version_compare( $version_from_db, 'unreleased', '<' ) ) {\n\t\t *     // Update routine.\n\t\t * }\n\t\t */`,
+		],
+		[
+			'a documented call inside a docblock',
+			`\t\t * \\_doing_it_wrong( __METHOD__, 'Example.', 'unreleased' );`,
+		],
+		[
+			'a commented-out call',
+			`\t\t// \\_deprecated_function( __FUNCTION__, 'unreleased', 'x' );`,
+		],
+		[ 'prose describing the convention', `\t\t * Use 'unreleased' as the version number for new migrations.` ],
+		[ 'a variable assignment', `\t\t$unreleased_var = 'unreleased';` ],
+		[
+			'a user agent that ends in the word',
+			`\t\t\tarray( 'comment_agent' => 'ATmosphere/0.0.0-unreleased' )`,
+		],
+		[ 'a translated string', `\t\t$label = \\__( 'unreleased', 'atmosphere' );` ],
+	] )( 'leaves %s alone', ( _label, source ) => {
+		expect( rewrite( source ) ).toBe( source );
+	} );
+} );
+
+describe( 'The plugin as it stands', () => {
+	const pluginRoot = path.join( __dirname, '..', '..' );
+
+	const phpFiles = ( dir ) =>
+		fs.readdirSync( dir, { withFileTypes: true } ).flatMap( ( entry ) => {
+			const full = path.join( dir, entry.name );
+
+			if ( entry.isDirectory() ) {
+				return phpFiles( full );
+			}
+
+			return entry.name.endsWith( '.php' ) ? [ full ] : [];
+		} );
+
+	test( 'no marker is left behind in includes/', () => {
+		const leftovers = phpFiles( path.join( pluginRoot, 'includes' ) )
+			.map( ( file ) => [ file, rewrite( fs.readFileSync( file, 'utf8' ) ) ] )
+			.filter( ( [ , content ] ) => /'unreleased'|@(since|deprecated) unreleased/i.test( content ) )
+			.map( ( [ file ] ) => path.relative( pluginRoot, file ) );
+
+		expect( leftovers ).toEqual( [] );
+	} );
+
+	test( 'the release leaves the test suite untouched', () => {
+		const tests = phpFiles( path.join( pluginRoot, 'tests' ) );
+
+		expect( tests.length ).toBeGreaterThan( 0 );
+
+		tests.forEach( ( file ) => {
+			const content = fs.readFileSync( file, 'utf8' );
+
+			expect( rewrite( content ) ).toBe( content );
+		} );
+	} );
+} );

--- a/bin/release.js
+++ b/bin/release.js
@@ -3,6 +3,7 @@
 const { execSync } = require( 'child_process' );
 const readline = require( 'readline' );
 const fs = require( 'fs' );
+const { phpVersionPatterns, LEFTOVER_MARKER_GREP } = require( './version-patterns' );
 
 const rl = readline.createInterface( {
 	input: process.stdin,
@@ -248,31 +249,7 @@ async function createRelease() {
 	).split( '\n' );
 
 	phpFiles.forEach( ( filePath ) => {
-		updateVersionInFile( filePath, version, [
-			{
-				search: /@since unreleased/gi,
-				replace: `@since ${ version }`,
-			},
-			{
-				search: /@deprecated unreleased/gi,
-				replace: `@deprecated ${ version }`,
-			},
-			/*
-			 * Version arguments to _doing_it_wrong(), the _deprecated_*()
-			 * family, and the *_deprecated hook helpers.
-			 *
-			 * These match on the literal's argument position rather than on
-			 * the name of the function it belongs to. Matching by name meant
-			 * anchoring to `.*?`, which never crosses a newline, so a call
-			 * wrapped across several lines kept its placeholder. That is the
-			 * common style here, and it silently shipped `unreleased` in
-			 * every release up to 2.2.0.
-			 */
-			{
-				search: /(?<=[(,]\s*)'unreleased'(?=\s*[,)])/gi,
-				replace: `'${ version }'`,
-			},
-		] );
+		updateVersionInFile( filePath, version, phpVersionPatterns( version ) );
 	} );
 
 	/*
@@ -280,7 +257,7 @@ async function createRelease() {
 	 * placeholder instead of letting it reach a tag unnoticed.
 	 */
 	const leftovers = execWithOutput(
-		'grep -rnE "\'unreleased\'|@(since|deprecated) unreleased" --include="*.php" . --exclude-dir=vendor --exclude-dir=node_modules || true'
+		`grep -rnE "${ LEFTOVER_MARKER_GREP }" --include="*.php" . --exclude-dir=vendor --exclude-dir=node_modules || true`
 	);
 
 	if ( leftovers ) {

--- a/bin/release.js
+++ b/bin/release.js
@@ -243,7 +243,9 @@ async function createRelease() {
 	// Prompt for and update the upgrade notice section in readme.txt
 	await updateReadmeWithUpgradeNotice( version );
 
-	const phpFiles = execWithOutput( 'find . -name "*.php"' ).split( '\n' );
+	const phpFiles = execWithOutput(
+		'find . -name "*.php" -not -path "./vendor/*" -not -path "./node_modules/*"'
+	).split( '\n' );
 
 	phpFiles.forEach( ( filePath ) => {
 		updateVersionInFile( filePath, version, [
@@ -255,20 +257,37 @@ async function createRelease() {
 				search: /@deprecated unreleased/gi,
 				replace: `@deprecated ${ version }`,
 			},
+			/*
+			 * Version arguments to _doing_it_wrong(), the _deprecated_*()
+			 * family, and the *_deprecated hook helpers.
+			 *
+			 * These match on the literal's argument position rather than on
+			 * the name of the function it belongs to. Matching by name meant
+			 * anchoring to `.*?`, which never crosses a newline, so a call
+			 * wrapped across several lines kept its placeholder. That is the
+			 * common style here, and it silently shipped `unreleased` in
+			 * every release up to 2.2.0.
+			 */
 			{
-				search: /(?<=_deprecated_(?:function|class|constructor|file|argument|hook)\s*\(\s*.*?,\s*')unreleased(?=')/gi,
-				replace: ( match ) => match.replace( /unreleased/i, version ),
-			},
-			{
-				search: /(?<=_doing_it_wrong\s*\(\s*.*?,\s*'.*?',\s*')unreleased(?=')/gi,
-				replace: ( match ) => match.replace( /unreleased/i, version ),
-			},
-			{
-				search: /(?<=\b(?:apply_filters_deprecated|do_action_deprecated)\s*\(\s*'.*?'\s*,\s*array\s*\(.*?\)\s*,\s*')unreleased(?=['"],\s*['"])/gi,
-				replace: ( match ) => match.replace( /unreleased/i, version ),
+				search: /(?<=[(,]\s*)'unreleased'(?=\s*[,)])/gi,
+				replace: `'${ version }'`,
 			},
 		] );
 	} );
+
+	/*
+	 * The rewrite above is best-effort, so report anything still carrying the
+	 * placeholder instead of letting it reach a tag unnoticed.
+	 */
+	const leftovers = execWithOutput(
+		'grep -rnE "\'unreleased\'|@(since|deprecated) unreleased" --include="*.php" . --exclude-dir=vendor --exclude-dir=node_modules || true'
+	);
+
+	if ( leftovers ) {
+		console.warn( `\nWarning: \`unreleased\` is still present after the ${ version } rewrite:` );
+		console.warn( leftovers );
+		console.warn( 'Stamp each one with the release that added it before merging the release PR.\n' );
+	}
 
 	// Stage and commit changes
 	exec( 'git add .' );

--- a/bin/version-patterns.js
+++ b/bin/version-patterns.js
@@ -1,0 +1,61 @@
+/**
+ * Version-marker replacement patterns for the release script.
+ *
+ * Kept in its own module so `bin/__tests__/release.test.js` can exercise the
+ * patterns the release actually uses, rather than a copy that drifts from them.
+ */
+
+/*
+ * Skip a match sitting on a comment line.
+ *
+ * A docblock that documents the convention by showing a call with the marker
+ * still in it is instructions for the next developer, not code. Rewriting it
+ * every release would slowly destroy the example.
+ */
+const NOT_IN_COMMENT = '(?<!^[ \\t]*(?:\\*|//|#|/\\*)[^\\n]*)';
+
+/*
+ * A `'unreleased'` sitting where a function takes an argument.
+ *
+ * Anchoring on the name of the function it belongs to would be more precise,
+ * but it cannot be made to work here: the name and the version sit on
+ * different lines in most of these calls, `.` does not cross a newline, and
+ * every bound loose enough to span the arguments in between is also loose
+ * enough to swallow a `;` inside a translated message, which most of them
+ * have. What actually keeps this off unrelated text is the shape of the
+ * match: the literal has to be exactly `'unreleased'`, it has to sit in an
+ * argument slot, and it must not be on a comment line.
+ *
+ * The leading comma matters. None of these functions take the version first,
+ * so requiring one argument ahead of it leaves `\\__( 'unreleased', 'atmosphere' )`
+ * alone, where the word is the thing being translated rather than a version.
+ */
+const VERSION_ARGUMENT = `(?<=,\\s*)'unreleased'(?=\\s*[,)])`;
+
+/**
+ * Build the patterns for one version.
+ *
+ * @param {string} version The version being released.
+ * @return {Array<{search: RegExp, replace: string}>} Patterns for updateVersionInFile().
+ */
+const phpVersionPatterns = ( version ) => [
+	{
+		search: /@since unreleased/gi,
+		replace: `@since ${ version }`,
+	},
+	{
+		search: /@deprecated unreleased/gi,
+		replace: `@deprecated ${ version }`,
+	},
+	{
+		search: new RegExp( NOT_IN_COMMENT + VERSION_ARGUMENT, 'gim' ),
+		replace: `'${ version }'`,
+	},
+];
+
+/**
+ * Marker shapes the patterns above are meant to clear, for the post-rewrite check.
+ */
+const LEFTOVER_MARKER_GREP = `'unreleased'|@(since|deprecated) unreleased`;
+
+module.exports = { phpVersionPatterns, LEFTOVER_MARKER_GREP };

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -847,7 +847,7 @@ class Atmosphere {
 			\_doing_it_wrong(
 				__METHOD__,
 				\esc_html__( 'The atmosphere_at_tags filter must return an array keyed by tag name.', 'atmosphere' ),
-				'unreleased'
+				'2.2.0'
 			);
 			return;
 		}
@@ -886,7 +886,7 @@ class Atmosphere {
 			\_doing_it_wrong(
 				__METHOD__,
 				\esc_html__( 'The atmosphere_at_tags filter produced entries that were not non-empty strings; those were skipped.', 'atmosphere' ),
-				'unreleased'
+				'2.2.0'
 			);
 		}
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -204,7 +204,7 @@ function appview_base_url( string $base ): string {
 		\_doing_it_wrong(
 			__FUNCTION__,
 			\esc_html__( 'atmosphere_appview_host must return a host (optionally with a scheme and path prefix); falling back to bsky.app.', 'atmosphere' ),
-			'unreleased'
+			'2.0.0'
 		);
 		return 'https://bsky.app';
 	}

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -431,7 +431,7 @@ abstract class Base {
 		}
 
 		if ( ! \is_array( $value ) || empty( $value['$type'] ) || ! \is_string( $value['$type'] ) ) {
-			\_doing_it_wrong( \esc_html( $method ), \esc_html( $message ), 'unreleased' );
+			\_doing_it_wrong( \esc_html( $method ), \esc_html( $message ), '2.0.0' );
 			return null;
 		}
 
@@ -459,7 +459,7 @@ abstract class Base {
 			\_doing_it_wrong(
 				\esc_html( $method ),
 				\esc_html__( 'Self-label filters must return a com.atproto.label.defs#selfLabels object with a values array; omitting the labels field.', 'atmosphere' ),
-				'unreleased'
+				'2.0.0'
 			);
 			return null;
 		}
@@ -469,7 +469,7 @@ abstract class Base {
 				\_doing_it_wrong(
 					\esc_html( $method ),
 					\esc_html__( 'Self-label values must be arrays with a non-empty string val field; omitting the labels field.', 'atmosphere' ),
-					'unreleased'
+					'2.0.0'
 				);
 				return null;
 			}

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -268,7 +268,7 @@ abstract class Base {
 			\_doing_it_wrong(
 				__METHOD__,
 				\esc_html__( 'atmosphere_record_tags must return an array; falling back to the unfiltered tags.', 'atmosphere' ),
-				'unreleased'
+				'2.2.0'
 			);
 			$filtered = $tags;
 		}

--- a/includes/transformer/class-document.php
+++ b/includes/transformer/class-document.php
@@ -268,7 +268,7 @@ class Document extends Base {
 			\_doing_it_wrong(
 				__METHOD__,
 				\esc_html__( 'atmosphere_document_contributors must return an array of contributor objects; omitting the contributors field.', 'atmosphere' ),
-				'unreleased'
+				'2.0.0'
 			);
 			return null;
 		}
@@ -279,7 +279,7 @@ class Document extends Base {
 				\_doing_it_wrong(
 					__METHOD__,
 					\esc_html__( 'Document contributors must include a non-empty DID string; omitting the contributors field.', 'atmosphere' ),
-					'unreleased'
+					'2.0.0'
 				);
 				return null;
 			}
@@ -381,7 +381,7 @@ class Document extends Base {
 			\_doing_it_wrong(
 				__METHOD__,
 				\esc_html__( 'atmosphere_document_content must return an array; falling back to the parser output.', 'atmosphere' ),
-				'unreleased'
+				'1.2.0'
 			);
 			return $content;
 		}
@@ -406,7 +406,7 @@ class Document extends Base {
 				$fallback_to_parser
 					? \esc_html__( 'Content parsers must return a non-empty $type field; falling back to the parser output.', 'atmosphere' )
 					: \esc_html__( 'Content parsers must return a non-empty $type field; omitting the content field.', 'atmosphere' ),
-				'unreleased'
+				'1.2.0'
 			);
 			return null;
 		}
@@ -417,7 +417,7 @@ class Document extends Base {
 				$fallback_to_parser
 					? \esc_html__( 'Content parsers must return a $type field matching get_type(); falling back to the parser output.', 'atmosphere' )
 					: \esc_html__( 'Content parsers must return a $type field matching get_type(); omitting the content field.', 'atmosphere' ),
-				'unreleased'
+				'1.2.0'
 			);
 			return null;
 		}

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -1961,7 +1961,7 @@ class Post extends Base {
 			\_doing_it_wrong(
 				__METHOD__,
 				\esc_html__( 'atmosphere_post_embed must return an array or null; falling back to the unfiltered embed.', 'atmosphere' ),
-				'unreleased'
+				'1.1.0'
 			);
 			return $embed;
 		}
@@ -1981,7 +1981,7 @@ class Post extends Base {
 			\_doing_it_wrong(
 				__METHOD__,
 				\esc_html__( 'atmosphere_post_embed must return an embed array with a non-empty $type string, or null; falling back to the unfiltered embed.', 'atmosphere' ),
-				'unreleased'
+				'1.1.0'
 			);
 			return $embed;
 		}

--- a/includes/transformer/class-preview.php
+++ b/includes/transformer/class-preview.php
@@ -242,7 +242,7 @@ class Preview {
 			\_doing_it_wrong(
 				__METHOD__,
 				\esc_html__( 'atmosphere_atproto_preview_transformers must return an array; falling back to the built-in transformers.', 'atmosphere' ),
-				'unreleased'
+				'2.0.0'
 			);
 			$transformers = $defaults;
 		}

--- a/includes/transformer/class-publication.php
+++ b/includes/transformer/class-publication.php
@@ -192,7 +192,7 @@ class Publication extends Base {
 			\_doing_it_wrong(
 				__METHOD__,
 				\esc_html__( 'atmosphere_publication_show_in_discover must return true, false, or null; omitting the preferences field.', 'atmosphere' ),
-				'unreleased'
+				'2.0.0'
 			);
 		}
 
@@ -310,7 +310,7 @@ class Publication extends Base {
 			\_doing_it_wrong(
 				__METHOD__,
 				\esc_html__( 'atmosphere_publication_basic_theme must return an array or null; falling back to the unfiltered basicTheme value.', 'atmosphere' ),
-				'unreleased'
+				'2.1.0'
 			);
 
 			return $basic_theme;

--- a/includes/transformer/class-threadgate.php
+++ b/includes/transformer/class-threadgate.php
@@ -193,7 +193,7 @@ class Threadgate extends Base {
 			\_doing_it_wrong(
 				__METHOD__,
 				\esc_html__( 'atmosphere_transform_threadgate must return an array; falling back to the unfiltered record.', 'atmosphere' ),
-				'unreleased'
+				'2.2.0'
 			);
 			return $record;
 		}


### PR DESCRIPTION
## Proposed changes:

Every release since 1.1.0 has shipped `'unreleased'` as the version argument on some of our `_doing_it_wrong()` calls, so anyone running with `WP_DEBUG` on sees "since version unreleased" in the notice. 2.2.0 added four more. This clears all 18 and stops the next release adding to the pile.

`bin/release.js` does try to handle these, but it matched a version literal by the name of the function it belonged to, anchoring across the arguments in between with `.*?`. That never crosses a newline, so any call wrapped over several lines kept its placeholder, which is how most of them are written here. The single-line `@since unreleased` docblocks were rewritten correctly all along, which is what made the mismatch visible.

Two things keep the new pattern off unrelated text:

* The match must not be on a comment line. A docblock that documents the convention by showing a call with the marker still in it is instructions for the next developer, and rewriting it every release would slowly destroy the example. ActivityPub hit this and added a guard in #1221; we never had one, so an example in a docblock was already being rewritten before this branch.
* The literal needs an argument ahead of it. None of these functions take the version first, so `\__( 'unreleased', 'atmosphere' )` stays put, where the word is the thing being translated rather than a version.

Anchoring on the function name would be more precise, but it can't be made to work: the name and the version sit on different lines, and every bound wide enough to span the arguments in between also swallows a `;` inside a translated message. Sixteen of our eighteen messages have one, so that was not a theoretical problem.

The script also warns now if a marker survives the rewrite, listing file and line. This has been silent through five releases, and a warning in the release output is what would have caught it. The rewrite pass skips `vendor/` and `node_modules/` too; it was walking every PHP file in the repo and editing third-party code in place, which was harmless because both are gitignored, but there's no reason to.

The patterns move to `bin/version-patterns.js` with a suite in `bin/__tests__/release.test.js`, so the tests exercise what the release actually runs rather than a copy of it. ActivityPub's equivalent tests had already drifted from their script, which is part of how this hid for so long.

Each of the 18 gets the version of the release that added the warning, which is what `_doing_it_wrong()`'s third argument means: not when the hook appeared, but when the notice did. I took it from `git blame` on the warning line and the earliest tag containing that commit, then checked it against the `@since` on the surrounding docblock where there was one. The 2.2.0 group is the three filters new in this release; the rest land on 1.1.0, 1.2.0, 2.0.0, and 2.1.0.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

`bin/__tests__/release.test.js` covers each call shape that should be stamped, each lookalike that should not, and two checks against the plugin's own files: nothing is left behind in `includes/`, and a release leaves `tests/` untouched. 76 JS tests pass, along with `composer lint`, `npm run lint:js`, and the 1331 PHP tests.

Two cases in there are worth calling out, because both were found by running the patterns over the real files rather than over examples I wrote. A message containing a semicolon broke the first bound I tried, and `\__( 'unreleased', 'atmosphere' )` was rewritten until the pattern started requiring a preceding comma.

One wart I left alone: `updateVersionInFile()` still has a branch that calls a function-valued `replace` as `replace( version )` rather than passing it to `String.replace` as a callback. Nothing uses it after this change. Removing it is unrelated cleanup.

## Testing instructions:

* `grep -rnE "'unreleased'|@(since|deprecated) unreleased" --include="*.php" . --exclude-dir=vendor --exclude-dir=node_modules` returns nothing on this branch. On trunk it returns 18 lines.
* Spot-check that a version matches its docblock: `atmosphere_publication_basic_theme` in `includes/transformer/class-publication.php` is `@since 2.1.0` and its `_doing_it_wrong()` now passes `'2.1.0'`. Same for `atmosphere_publication_show_in_discover` at 2.0.0 and `atmosphere_atproto_preview_transformers` at 2.0.0.
* To see the patterns work without cutting a release, run `phpVersionPatterns()` from `bin/version-patterns.js` over `git show origin/trunk:includes/transformer/class-document.php`. All five markers in that file should come out rewritten; the old pattern rewrote none of them.
* Same check against ActivityPub's `includes/class-migration.php`, which documents the convention inside a comment: no lines should change. That file is the reason for the comment guard, and the matching fix there is Automattic/wordpress-activitypub#3695.
* `grep -n unreleased tests/phpunit/tests/class-test-atmosphere.php` should still show line 945 unchanged. `'ATmosphere/0.0.0-unreleased'` is a user-agent fixture rather than a marker, and neither the new pattern nor the new warning matches it.
* Run `composer lint` and `npm run env-test`.

### Changelog entry

Needs the "Skip Changelog" label. The version only shows up in a `WP_DEBUG` notice aimed at plugin developers, and the rest is release tooling, so there's nothing here for a site owner to read on the update screen.
