### PR TITLE
Check the Bluesky connection when the editor opens

### DIFF
--- a/.github/changelog/add-verify-connection-before-publish
+++ b/.github/changelog/add-verify-connection-before-publish
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-The pre-publish panel now checks with Bluesky that your connection still works, so a session you revoked is caught before you publish instead of after.
+The editor now checks with Bluesky that your connection still works when you open a post, so you can reconnect before writing instead of finding out after publishing.

--- a/.github/changelog/add-verify-connection-before-publish
+++ b/.github/changelog/add-verify-connection-before-publish
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+The pre-publish panel now checks with Bluesky that your connection still works, so a session you revoked is caught before you publish instead of after.

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -456,11 +456,17 @@ class API {
 	 *
 	 * @since unreleased
 	 *
+	 * @param int $timeout Seconds to wait. Defaults to the shared request
+	 *                     timeout; callers on an interactive path should
+	 *                     pass something far shorter, since a person is
+	 *                     waiting on the answer.
 	 * @return array|\WP_Error Session description, or the failure that
 	 *                         proves the credentials no longer work.
 	 */
-	public static function get_session(): array|\WP_Error {
-		return self::get( '/xrpc/com.atproto.server.getSession' );
+	public static function get_session( int $timeout = 0 ): array|\WP_Error {
+		$args = $timeout > 0 ? array( 'timeout' => $timeout ) : array();
+
+		return self::request( 'GET', '/xrpc/com.atproto.server.getSession', $args );
 	}
 
 	/**

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -443,6 +443,27 @@ class API {
 	}
 
 	/**
+	 * Ask the PDS to describe the session behind the stored credentials.
+	 *
+	 * `com.atproto.server.getSession` is the cheapest authenticated read
+	 * the PDS offers, which makes it the natural liveness probe: it either
+	 * comes back with the account it authenticated, or it fails the way any
+	 * other authenticated call would — including running the same 401 →
+	 * refresh → retry ladder in {@see self::request()}. That is the point.
+	 * A session whose refresh token has been revoked cannot be told apart
+	 * from a healthy one by reading local state, because revocation happens
+	 * at the auth server and leaves no local trace.
+	 *
+	 * @since unreleased
+	 *
+	 * @return array|\WP_Error Session description, or the failure that
+	 *                         proves the credentials no longer work.
+	 */
+	public static function get_session(): array|\WP_Error {
+		return self::get( '/xrpc/com.atproto.server.getSession' );
+	}
+
+	/**
 	 * Upload a blob (image) to the PDS.
 	 *
 	 * @param string $file_path Local file path.

--- a/includes/class-block-editor.php
+++ b/includes/class-block-editor.php
@@ -17,6 +17,7 @@ namespace Atmosphere;
 use Atmosphere\Rest\Admin\Pre_Publish_Controller;
 use Atmosphere\Transformer\Threadgate;
 use function Atmosphere\share_status;
+use function Atmosphere\verify_connection;
 use function Atmosphere\settings_url;
 use function Atmosphere\threadgate_needs_reconnect;
 use function Atmosphere\reconnect_url;
@@ -110,6 +111,28 @@ class Block_Editor {
 		 * link them into an authorization error.
 		 */
 		$can_manage = \current_user_can( 'manage_options' );
+
+		/*
+		 * Confirm the session with the PDS before resolving the share
+		 * status below. This is the earliest useful moment: the author has
+		 * the editor open and has not written anything yet, so a dead
+		 * connection surfaces as a reconnect prompt they can act on before
+		 * investing a post in it — rather than after clicking Publish.
+		 *
+		 * A revoked refresh token is indistinguishable from a working one
+		 * in local state, so `share_status()` alone cannot see it. The
+		 * probe records nothing of its own; it lets a dead session travel
+		 * the ordinary refresh path into `needs_reauth`, which the existing
+		 * banner already renders.
+		 *
+		 * Not gated on whether sharing is switched on: the connection is
+		 * shared infrastructure, and the reconnect prompt is connection
+		 * level rather than cross-posting level. Cached site-wide, and
+		 * bounded by a short timeout, so a slow PDS cannot hold up the
+		 * editor — the probe fails open and the banner simply keeps
+		 * whatever the last verdict was.
+		 */
+		verify_connection();
 
 		/*
 		 * One decision object rather than a set of loose flags. The panel

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -648,12 +648,16 @@ function is_comment_publishing_enabled(): bool {
  * connection row itself, and {@see is_connected()} answers from there
  * without touching the network.
  *
+ * @since unreleased
+ *
  * @var string
  */
 const SESSION_VERIFIED_TRANSIENT = 'atmosphere_session_verified';
 
 /**
  * How long a successful verification is trusted, in seconds.
+ *
+ * @since unreleased
  *
  * @var int
  */
@@ -682,6 +686,15 @@ const SESSION_VERIFY_TTL = 15 * MINUTE_IN_SECONDS;
  * the stored state exactly as they found it — the publish path has its
  * own retry ladder for that, and blocking an author because our probe
  * could not get through would be a worse bug than the one this fixes.
+ *
+ * Known gap: this verifies that the credentials still authenticate, not
+ * that the account may post. A deactivated, suspended, or taken-down
+ * account is rejected as a 400/403 rather than a 401, so it never enters
+ * the refresh ladder, nothing flags the row, and the probe reports
+ * healthy. `getSession` carries `active` and `status` fields that would
+ * settle it, but acting on them means new copy on every surface, so that
+ * is deliberately left for its own change. {@see \Atmosphere\Tests\Test_Verify_Connection}
+ * pins the current behavior so the gap cannot close by accident.
  *
  * @since unreleased
  *

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -641,6 +641,111 @@ function is_comment_publishing_enabled(): bool {
 }
 
 /**
+ * Transient holding the "the PDS accepted our credentials" verdict.
+ *
+ * Only ever set on success. A failed probe needs no cache entry: a
+ * permanent rejection has already flipped `needs_reauth` on the
+ * connection row itself, and {@see is_connected()} answers from there
+ * without touching the network.
+ *
+ * @var string
+ */
+const SESSION_VERIFIED_TRANSIENT = 'atmosphere_session_verified';
+
+/**
+ * How long a successful verification is trusted, in seconds.
+ *
+ * @var int
+ */
+const SESSION_VERIFY_TTL = 15 * MINUTE_IN_SECONDS;
+
+/**
+ * Confirm with the PDS that the stored session still authenticates.
+ *
+ * {@see is_connected()} reads three stored fields and never leaves the
+ * site, which is the right answer almost everywhere — but it cannot
+ * detect the one failure that matters before publishing. A refresh token
+ * the user revoked from their Bluesky account looks byte-for-byte
+ * identical on disk to a working one; revocation happens at the auth
+ * server and writes nothing locally. Only asking can tell them apart.
+ *
+ * The probe deliberately records nothing itself. `API::get_session()`
+ * runs the ordinary authenticated request path, so a dead session
+ * travels the existing 401 → refresh → `mark_needs_reauth()` route and
+ * lands in the connection row. This function's whole job is to make that
+ * happen *before* a caller reads local state, so every surface already
+ * built on `is_connected()` and `needs_reauth()` reports the truth with
+ * its existing copy. Nothing new to display, nothing new to translate.
+ *
+ * Failure is not evidence. A timeout, a 5xx, or a rate limit says the
+ * check did not complete, not that the session is dead, so those leave
+ * the stored state exactly as they found it — the publish path has its
+ * own retry ladder for that, and blocking an author because our probe
+ * could not get through would be a worse bug than the one this fixes.
+ *
+ * @since unreleased
+ *
+ * @param bool $force Skip the cache and probe unconditionally.
+ * @return bool Whether the site holds credentials the PDS will accept.
+ */
+function verify_connection( bool $force = false ): bool {
+	// Nothing to verify, and the existing surfaces already explain why.
+	if ( ! is_connected() ) {
+		return false;
+	}
+
+	if ( ! $force && false !== \get_transient( SESSION_VERIFIED_TRANSIENT ) ) {
+		return true;
+	}
+
+	$result = API::get_session();
+
+	if ( \is_wp_error( $result ) ) {
+		/*
+		 * Re-read the connection rather than classifying the error code.
+		 * When the request path gives up on these credentials it flags
+		 * the row itself, and that flag — not the code that happened to
+		 * surface — is what every other caller will see. Reading the
+		 * outcome instead of predicting it keeps this correct no matter
+		 * which layer decided, and picks up any future path that reaches
+		 * the same conclusion by a different route.
+		 */
+		if ( ! is_connected() ) {
+			return false;
+		}
+
+		debug_log(
+			\sprintf(
+				'session probe inconclusive (%s): %s',
+				$result->get_error_code(),
+				$result->get_error_message()
+			)
+		);
+
+		return true;
+	}
+
+	/**
+	 * Filters how long a successful session verification is trusted.
+	 *
+	 * Raising this trades freshness for fewer PDS round-trips; lowering it
+	 * does the reverse. The floor is one probe per editor session either
+	 * way, since the cache is only ever populated on success.
+	 *
+	 * @since unreleased
+	 *
+	 * @param int $ttl Seconds to trust a successful probe. Default 15 minutes.
+	 */
+	$ttl = (int) \apply_filters( 'atmosphere_session_verify_ttl', SESSION_VERIFY_TTL );
+
+	if ( $ttl > 0 ) {
+		\set_transient( SESSION_VERIFIED_TRANSIENT, 1, $ttl );
+	}
+
+	return true;
+}
+
+/**
  * Whether the connection requires the user to re-authorize.
  *
  * True when an identity is on file but the credentials option is

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -664,6 +664,21 @@ const SESSION_VERIFIED_TRANSIENT = 'atmosphere_session_verified';
 const SESSION_VERIFY_TTL = 15 * MINUTE_IN_SECONDS;
 
 /**
+ * How long the probe waits for the PDS, in seconds.
+ *
+ * Deliberately far below the shared 30-second request timeout. Every
+ * caller of this probe is on a path where a person is waiting — an
+ * editor rendering, a panel opening — and the answer is optional: the
+ * probe fails open, so giving up early costs a stale verdict for one
+ * cache window, while waiting costs the author a frozen editor.
+ *
+ * @since unreleased
+ *
+ * @var int
+ */
+const SESSION_VERIFY_TIMEOUT = 5;
+
+/**
  * Confirm with the PDS that the stored session still authenticates.
  *
  * {@see is_connected()} reads three stored fields and never leaves the
@@ -711,7 +726,7 @@ function verify_connection( bool $force = false ): bool {
 		return true;
 	}
 
-	$result = API::get_session();
+	$result = API::get_session( SESSION_VERIFY_TIMEOUT );
 
 	if ( \is_wp_error( $result ) ) {
 		/*

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -733,6 +733,16 @@ class Client {
 		\delete_option( self::DISCONNECTED_OPTION );
 
 		/*
+		 * Drop any cached "the PDS accepted our credentials" verdict. This
+		 * path is reached without a preceding `disconnect()` — the settings
+		 * connect field and the Connectors card both authorize straight over
+		 * a live connection — so reconnecting, and in particular switching
+		 * to a different account, would otherwise inherit the previous
+		 * session's clean bill of health for the rest of the TTL.
+		 */
+		\delete_transient( SESSION_VERIFIED_TRANSIENT );
+
+		/*
 		 * Encrypted token blobs do not need to ride along in every
 		 * request's `alloptions` payload; they're only read on the
 		 * paths that actually talk to the PDS. WP 6.6+ honours the

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -17,6 +17,7 @@ use function Atmosphere\clear_scheduled_hooks;
 use function Atmosphere\debug_log;
 use function Atmosphere\get_connection;
 use function Atmosphere\set_identity;
+use const Atmosphere\SESSION_VERIFIED_TRANSIENT;
 use function Atmosphere\is_success_status;
 
 /**
@@ -1611,6 +1612,13 @@ class Client {
 
 		\delete_option( 'atmosphere_connection' );
 		\delete_option( self::REFRESH_LOCK_OPTION );
+
+		/*
+		 * Drop the session-verification cache so a reconnect — including
+		 * a reconnect to a *different* account — is probed fresh rather
+		 * than inheriting the previous account's clean bill of health.
+		 */
+		\delete_transient( SESSION_VERIFIED_TRANSIENT );
 
 		/*
 		 * Sweep a stale option from 1.0.0 installs. `atmosphere_publication_uri`

--- a/includes/rest/admin/class-pre-publish-controller.php
+++ b/includes/rest/admin/class-pre-publish-controller.php
@@ -21,7 +21,6 @@ use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
 use function Atmosphere\is_auto_publish_enabled;
-use function Atmosphere\is_connected;
 use function Atmosphere\is_supported_post_type;
 use function Atmosphere\needs_reauth;
 use function Atmosphere\share_status;
@@ -227,21 +226,6 @@ class Pre_Publish_Controller extends \WP_REST_Controller {
 		$draft->post_excerpt = (string) $request['excerpt'];
 
 		/*
-		 * Confirm the session with the PDS before reading any local
-		 * connection state below. This is the last moment where telling
-		 * the author their site is disconnected still saves them
-		 * something: the panel is open, the post is not away yet.
-		 *
-		 * The call records nothing of its own — it lets a dead session
-		 * travel the ordinary refresh path into `needs_reauth`, so the
-		 * decision below reaches the reconnect branch it already has.
-		 * Cached, so this costs one PDS round-trip per quarter hour
-		 * rather than one per panel open, and it must run before the
-		 * projection's `pre_http_request` block goes up.
-		 */
-		verify_connection();
-
-		/*
 		 * Whether the post will actually be shared is decided from the
 		 * *intended* visibility in the editor (private / password-protected
 		 * posts are never shared), not from the saved revision.
@@ -430,48 +414,74 @@ class Pre_Publish_Controller extends \WP_REST_Controller {
 			);
 		}
 
-		if ( ! is_connected() ) {
-			/*
-			 * `is_connected()` is false for both a dead session and a site
-			 * that never connected. Only the first is fixable by an admin,
-			 * so it gets its own copy and lifts the panel's notice from
-			 * info to warning.
-			 */
-			if ( needs_reauth() ) {
-				/*
-				 * The cause sentence is shared with the document panel via
-				 * {@see \Atmosphere\share_status()}, so a
-				 * `key_changed` (or any other recorded) cause reads
-				 * identically on both surfaces, including the
-				 * operator-disconnect swap. The consequence sentence is
-				 * this panel's own.
-				 *
-				 * `needs_reconnect` tracks whether a cause sentence is
-				 * actually shown, not just whether the connection is dead:
-				 * a non-admin reading a suppressed operator-disconnect gets
-				 * `false`, matching the document panel showing no banner
-				 * for the same reader.
-				 */
-				$lead   = $site['reason'];
-				$tail   = \__( 'This post will not be shared until your site is reconnected.', 'atmosphere' );
-				$reason = '' !== $lead ? $lead . ' ' . $tail : $tail;
+		/*
+		 * Every local gate has passed, so the connection is the last thing
+		 * that can change the answer — and the only one that cannot be
+		 * read locally. A refresh token the user revoked from their
+		 * Bluesky account is byte-for-byte identical on disk to a working
+		 * one, so this asks the PDS.
+		 *
+		 * Deliberately last. Every check above returns without consulting
+		 * the connection at all, so a site with sharing switched off — or
+		 * a private, password-protected, or opted-out post — would
+		 * otherwise spend a live round-trip on an answer nothing reads.
+		 * It also has to run before the projection's `pre_http_request`
+		 * block goes up, which it does: the caller installs that filter
+		 * after this decision returns.
+		 *
+		 * The probe records nothing itself. It lets a dead session travel
+		 * the ordinary refresh path into `needs_reauth`, which is why the
+		 * branch below needs no copy of its own.
+		 */
+		if ( verify_connection() ) {
+			return array(
+				'will_publish' => true,
+				'reason'       => null,
+			);
+		}
 
-				return array(
-					'will_publish'    => false,
-					'needs_reconnect' => '' !== $lead,
-					'reason'          => $reason,
-				);
-			}
+		/*
+		 * Re-resolve the site-level status. `$site` above was read before
+		 * the probe ran, so a session the probe just flagged would still
+		 * be carrying the healthy-connection reason.
+		 */
+		$site = share_status();
+
+		/*
+		 * The probe answers false for both a dead session and a site that
+		 * never connected. Only the first is fixable by an admin, so it
+		 * gets its own copy and lifts the panel's notice from info to
+		 * warning.
+		 */
+		if ( needs_reauth() ) {
+			/*
+			 * The cause sentence is shared with the document panel via
+			 * {@see \Atmosphere\share_status()}, so a
+			 * `key_changed` (or any other recorded) cause reads
+			 * identically on both surfaces, including the
+			 * operator-disconnect swap. The consequence sentence is
+			 * this panel's own.
+			 *
+			 * `needs_reconnect` tracks whether a cause sentence is
+			 * actually shown, not just whether the connection is dead:
+			 * a non-admin reading a suppressed operator-disconnect gets
+			 * `false`, matching the document panel showing no banner
+			 * for the same reader.
+			 */
+			$lead   = $site['reason'];
+			$tail   = \__( 'This post will not be shared until your site is reconnected.', 'atmosphere' );
+			$reason = '' !== $lead ? $lead . ' ' . $tail : $tail;
 
 			return array(
-				'will_publish' => false,
-				'reason'       => \__( 'Your site isn’t connected to Bluesky yet.', 'atmosphere' ),
+				'will_publish'    => false,
+				'needs_reconnect' => '' !== $lead,
+				'reason'          => $reason,
 			);
 		}
 
 		return array(
-			'will_publish' => true,
-			'reason'       => null,
+			'will_publish' => false,
+			'reason'       => \__( 'Your site isn’t connected to Bluesky yet.', 'atmosphere' ),
 		);
 	}
 }

--- a/includes/rest/admin/class-pre-publish-controller.php
+++ b/includes/rest/admin/class-pre-publish-controller.php
@@ -25,6 +25,7 @@ use function Atmosphere\is_connected;
 use function Atmosphere\is_supported_post_type;
 use function Atmosphere\needs_reauth;
 use function Atmosphere\share_status;
+use function Atmosphere\verify_connection;
 
 /**
  * Pre-publish preview controller.
@@ -224,6 +225,21 @@ class Pre_Publish_Controller extends \WP_REST_Controller {
 		$draft->post_title   = (string) $request['title'];
 		$draft->post_content = (string) $request['content'];
 		$draft->post_excerpt = (string) $request['excerpt'];
+
+		/*
+		 * Confirm the session with the PDS before reading any local
+		 * connection state below. This is the last moment where telling
+		 * the author their site is disconnected still saves them
+		 * something: the panel is open, the post is not away yet.
+		 *
+		 * The call records nothing of its own — it lets a dead session
+		 * travel the ordinary refresh path into `needs_reauth`, so the
+		 * decision below reaches the reconnect branch it already has.
+		 * Cached, so this costs one PDS round-trip per quarter hour
+		 * rather than one per panel open, and it must run before the
+		 * projection's `pre_http_request` block goes up.
+		 */
+		verify_connection();
 
 		/*
 		 * Whether the post will actually be shared is decided from the

--- a/tests/phpunit/tests/class-test-block-editor.php
+++ b/tests/phpunit/tests/class-test-block-editor.php
@@ -11,7 +11,10 @@ namespace Atmosphere\Tests;
 use Atmosphere\Block_Editor;
 use Atmosphere\Connectors;
 use Atmosphere\OAuth\Client;
+use Atmosphere\OAuth\DPoP;
+use Atmosphere\OAuth\Encryption;
 use function Atmosphere\settings_url;
+use const Atmosphere\SESSION_VERIFIED_TRANSIENT;
 
 /**
  * Tests for the config the editor scripts receive as `window.atmosphereEditor`.
@@ -31,6 +34,8 @@ class Test_Block_Editor extends \WP_UnitTestCase {
 		\delete_option( 'atmosphere_auto_publish' );
 		\remove_all_filters( 'atmosphere_should_auto_publish' );
 		\remove_all_filters( 'atmosphere_connection_only_mode' );
+		\remove_all_filters( 'pre_http_request' );
+		\delete_transient( SESSION_VERIFIED_TRANSIENT );
 		parent::tear_down();
 	}
 
@@ -325,5 +330,177 @@ class Test_Block_Editor extends \WP_UnitTestCase {
 
 		$this->assertTrue( $data['shareStatus']['sharing_enabled'] );
 		$this->assertSame( '', $data['shareStatus']['message'] );
+	}
+
+	/**
+	 * Opening the editor is the earliest useful moment to notice a dead
+	 * connection: the author has written nothing yet.
+	 *
+	 * A session the user revoked from their Bluesky account leaves stored
+	 * credentials byte-for-byte identical to a working one, so the banner
+	 * would otherwise vouch for it right up until the publish failed. The
+	 * probe runs before the share status is resolved, so the prompt is
+	 * there on the first paint.
+	 */
+	public function test_editor_load_catches_a_revoked_session() {
+		$dpop_jwk = DPoP::generate_key();
+
+		\update_option( 'atmosphere_identity', array( 'did' => 'did:plc:test123' ) );
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'did'            => 'did:plc:test123',
+				'access_token'   => Encryption::encrypt( 'test-access-token' ),
+				'refresh_token'  => Encryption::encrypt( 'test-refresh-token' ),
+				'dpop_jwk'       => Encryption::encrypt( \wp_json_encode( $dpop_jwk ) ),
+				'pds_endpoint'   => 'https://pds.example.com',
+				'token_endpoint' => 'https://auth.example.com/oauth/token',
+				'expires_at'     => \time() + 3600,
+				'needs_reauth'   => false,
+			)
+		);
+		\update_option( 'atmosphere_auto_publish', '1' );
+
+		\add_filter(
+			'pre_http_request',
+			static function ( $response, $args, $url ) {
+				if ( false !== \strpos( $url, 'oauth/token' ) ) {
+					return array(
+						'response' => array( 'code' => 400 ),
+						'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+						'body'     => \wp_json_encode( array( 'error' => 'invalid_grant' ) ),
+					);
+				}
+
+				if ( false !== \strpos( $url, 'getSession' ) ) {
+					return array(
+						'response' => array( 'code' => 401 ),
+						'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+						'body'     => \wp_json_encode( array( 'error' => 'InvalidToken' ) ),
+					);
+				}
+
+				return $response;
+			},
+			1,
+			3
+		);
+
+		$data = $this->script_data();
+
+		$this->assertSame(
+			'needs_reconnect',
+			$data['shareStatus']['state'],
+			'A revoked session must surface as a reconnect prompt on editor load.'
+		);
+		$this->assertFalse(
+			$data['shareStatus']['can_share'],
+			'A revoked session must not be advertised as ready to share.'
+		);
+		$this->assertNotEmpty(
+			$data['shareStatus']['reason'],
+			'The banner needs a reason to render the reconnect prompt from.'
+		);
+	}
+
+	/**
+	 * The probe must not hold up the editor when the PDS is unreachable.
+	 *
+	 * Failing open here matters more than anywhere else: this runs during
+	 * `enqueue_block_editor_assets`, so treating a timeout as a
+	 * disconnection would greet an author with a reconnect prompt every
+	 * time their PDS had a bad minute.
+	 */
+	public function test_editor_load_ignores_an_unreachable_pds() {
+		$dpop_jwk = DPoP::generate_key();
+
+		\update_option( 'atmosphere_identity', array( 'did' => 'did:plc:test123' ) );
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'did'            => 'did:plc:test123',
+				'access_token'   => Encryption::encrypt( 'test-access-token' ),
+				'refresh_token'  => Encryption::encrypt( 'test-refresh-token' ),
+				'dpop_jwk'       => Encryption::encrypt( \wp_json_encode( $dpop_jwk ) ),
+				'pds_endpoint'   => 'https://pds.example.com',
+				'token_endpoint' => 'https://auth.example.com/oauth/token',
+				'expires_at'     => \time() + 3600,
+				'needs_reauth'   => false,
+			)
+		);
+		\update_option( 'atmosphere_auto_publish', '1' );
+
+		\add_filter(
+			'pre_http_request',
+			static function ( $response, $args, $url ) {
+				if ( false !== \strpos( $url, 'getSession' ) ) {
+					return new \WP_Error( 'http_request_failed', 'Connection timed out.' );
+				}
+
+				return $response;
+			},
+			1,
+			3
+		);
+
+		$data = $this->script_data();
+
+		$this->assertSame(
+			'ok',
+			$data['shareStatus']['state'],
+			'An unreachable PDS must not read as a disconnection.'
+		);
+		$this->assertTrue( $data['shareStatus']['can_share'] );
+	}
+
+	/**
+	 * The probe waits far less than the shared request timeout.
+	 *
+	 * This one runs while the editor renders, so the ceiling is the
+	 * difference between a slow load and a frozen one.
+	 */
+	public function test_editor_load_probe_uses_a_short_timeout() {
+		$dpop_jwk = DPoP::generate_key();
+
+		\update_option( 'atmosphere_identity', array( 'did' => 'did:plc:test123' ) );
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'did'            => 'did:plc:test123',
+				'access_token'   => Encryption::encrypt( 'test-access-token' ),
+				'refresh_token'  => Encryption::encrypt( 'test-refresh-token' ),
+				'dpop_jwk'       => Encryption::encrypt( \wp_json_encode( $dpop_jwk ) ),
+				'pds_endpoint'   => 'https://pds.example.com',
+				'token_endpoint' => 'https://auth.example.com/oauth/token',
+				'expires_at'     => \time() + 3600,
+				'needs_reauth'   => false,
+			)
+		);
+
+		$captured = null;
+
+		\add_filter(
+			'pre_http_request',
+			static function ( $response, $args, $url ) use ( &$captured ) {
+				if ( false !== \strpos( $url, 'getSession' ) ) {
+					$captured = $args;
+
+					return array(
+						'response' => array( 'code' => 200 ),
+						'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+						'body'     => \wp_json_encode( array( 'did' => 'did:plc:test123' ) ),
+					);
+				}
+
+				return $response;
+			},
+			1,
+			3
+		);
+
+		$this->script_data();
+
+		$this->assertNotNull( $captured, 'The probe should have reached the transport.' );
+		$this->assertLessThanOrEqual( 5, $captured['timeout'], 'The editor must not wait 30 seconds on a probe.' );
 	}
 }

--- a/tests/phpunit/tests/class-test-verify-connection.php
+++ b/tests/phpunit/tests/class-test-verify-connection.php
@@ -1,0 +1,272 @@
+<?php
+/**
+ * Tests for the pre-publish session verification probe.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group oauth
+ */
+
+namespace Atmosphere\Tests;
+
+use Atmosphere\OAuth\Client;
+use Atmosphere\OAuth\DPoP;
+use Atmosphere\OAuth\Encryption;
+use function Atmosphere\is_connected;
+use function Atmosphere\needs_reauth;
+use function Atmosphere\verify_connection;
+use const Atmosphere\SESSION_VERIFIED_TRANSIENT;
+
+/**
+ * Session verification tests.
+ */
+class Test_Verify_Connection extends \WP_UnitTestCase {
+
+	/**
+	 * Token endpoint URL used in tests.
+	 *
+	 * @var string
+	 */
+	private const TOKEN_ENDPOINT = 'https://auth.example.com/oauth/token';
+
+	/**
+	 * Requests the mocked transport saw, by URL.
+	 *
+	 * @var string[]
+	 */
+	private array $requests = array();
+
+	/**
+	 * Set up a live, decryptable connection before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->requests = array();
+
+		$dpop_jwk = DPoP::generate_key();
+
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'access_token'   => Encryption::encrypt( 'test-access-token' ),
+				'refresh_token'  => Encryption::encrypt( 'test-refresh-token' ),
+				'dpop_jwk'       => Encryption::encrypt( \wp_json_encode( $dpop_jwk ) ),
+				'did'            => 'did:plc:test123',
+				'handle'         => 'test.example.com',
+				'pds_endpoint'   => 'https://pds.example.com',
+				'token_endpoint' => self::TOKEN_ENDPOINT,
+				'expires_at'     => \time() + 3600,
+				'needs_reauth'   => false,
+			)
+		);
+
+		\update_option(
+			'atmosphere_identity',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'test.example.com',
+				'pds_endpoint' => 'https://pds.example.com',
+			)
+		);
+	}
+
+	/**
+	 * Tear down each test.
+	 */
+	public function tear_down(): void {
+		\delete_option( 'atmosphere_connection' );
+		\delete_option( 'atmosphere_identity' );
+		\delete_option( Client::REFRESH_LOCK_OPTION );
+		\delete_option( Client::DISCONNECTED_OPTION );
+		\delete_transient( SESSION_VERIFIED_TRANSIENT );
+		\remove_all_filters( 'pre_http_request' );
+		\remove_all_filters( 'atmosphere_session_verify_ttl' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Mock the PDS session endpoint, and optionally the token endpoint.
+	 *
+	 * @param int   $session_status HTTP status for `getSession`.
+	 * @param array $session_body   Response body for `getSession`.
+	 * @param int   $token_status   HTTP status for the token endpoint.
+	 * @param array $token_body     Response body for the token endpoint.
+	 */
+	private function mock_transport( int $session_status, array $session_body, int $token_status = 200, array $token_body = array() ): void {
+		\add_filter(
+			'pre_http_request',
+			function ( $response, $args, $url ) use ( $session_status, $session_body, $token_status, $token_body ) {
+				$this->requests[] = $url;
+
+				if ( false !== \strpos( $url, 'oauth/token' ) ) {
+					return array(
+						'response' => array( 'code' => $token_status ),
+						'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+						'body'     => \wp_json_encode( $token_body ),
+					);
+				}
+
+				if ( false !== \strpos( $url, 'getSession' ) ) {
+					return array(
+						'response' => array( 'code' => $session_status ),
+						'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+						'body'     => \wp_json_encode( $session_body ),
+					);
+				}
+
+				return $response;
+			},
+			1,
+			3
+		);
+	}
+
+	/**
+	 * How many times the session endpoint was called.
+	 *
+	 * @return int
+	 */
+	private function session_calls(): int {
+		return \count(
+			\array_filter(
+				$this->requests,
+				static fn( string $url ): bool => false !== \strpos( $url, 'getSession' )
+			)
+		);
+	}
+
+	/**
+	 * A disconnected site is never probed: there is nothing to ask about,
+	 * and the existing surfaces already explain the state.
+	 */
+	public function test_disconnected_site_is_not_probed() {
+		\delete_option( 'atmosphere_connection' );
+		\delete_option( 'atmosphere_identity' );
+
+		$this->mock_transport( 200, array( 'did' => 'did:plc:test123' ) );
+
+		$this->assertFalse( verify_connection() );
+		$this->assertSame( 0, $this->session_calls(), 'A disconnected site must not reach the network.' );
+	}
+
+	/**
+	 * A session the PDS accepts verifies, and the verdict is cached so the
+	 * keystroke-adjacent panel does not re-probe on every open.
+	 */
+	public function test_accepted_session_verifies_and_caches() {
+		$this->mock_transport(
+			200,
+			array(
+				'did'    => 'did:plc:test123',
+				'handle' => 'test.example.com',
+			)
+		);
+
+		$this->assertTrue( verify_connection() );
+		$this->assertSame( 1, $this->session_calls() );
+
+		$this->assertTrue( verify_connection() );
+		$this->assertSame( 1, $this->session_calls(), 'The second call must be served from cache.' );
+	}
+
+	/**
+	 * `$force` is the escape hatch for a caller that needs certainty now.
+	 */
+	public function test_force_bypasses_the_cache() {
+		$this->mock_transport( 200, array( 'did' => 'did:plc:test123' ) );
+
+		verify_connection();
+		verify_connection( true );
+
+		$this->assertSame( 2, $this->session_calls() );
+	}
+
+	/**
+	 * A TTL of zero disables caching without disabling the probe.
+	 */
+	public function test_zero_ttl_disables_caching() {
+		$this->mock_transport( 200, array( 'did' => 'did:plc:test123' ) );
+		\add_filter( 'atmosphere_session_verify_ttl', '__return_zero' );
+
+		verify_connection();
+		verify_connection();
+
+		$this->assertFalse( \get_transient( SESSION_VERIFIED_TRANSIENT ) );
+		$this->assertSame( 2, $this->session_calls() );
+	}
+
+	/**
+	 * A revoked session is the case this probe exists for.
+	 *
+	 * The PDS rejects the access token, the request path refreshes, the auth
+	 * server refuses the refresh token, and the connection ends up flagged —
+	 * all through the ordinary machinery, so every surface built on
+	 * `is_connected()` reports it without new copy.
+	 */
+	public function test_revoked_session_fails_verification_and_flags_the_connection() {
+		$this->mock_transport(
+			401,
+			array( 'error' => 'InvalidToken' ),
+			400,
+			array(
+				'error'             => 'invalid_grant',
+				'error_description' => 'Refresh token revoked.',
+			)
+		);
+
+		$this->assertFalse( verify_connection(), 'A revoked session must not verify.' );
+		$this->assertTrue( needs_reauth(), 'The probe must leave the connection flagged for reconnect.' );
+		$this->assertFalse( is_connected(), 'Every surface reading local state must now agree.' );
+		$this->assertFalse(
+			\get_transient( SESSION_VERIFIED_TRANSIENT ),
+			'A failed probe must never be cached as a success.'
+		);
+	}
+
+	/**
+	 * An inconclusive probe is not evidence of a dead session.
+	 *
+	 * A PDS 5xx says the check did not complete. Treating that as a
+	 * disconnection would block an author over our own inability to ask,
+	 * which is worse than the bug the probe fixes.
+	 */
+	public function test_unreachable_pds_leaves_the_connection_alone() {
+		$this->mock_transport( 503, array( 'error' => 'InternalServerError' ) );
+
+		$this->assertTrue( verify_connection(), 'An inconclusive probe must not report a dead session.' );
+		$this->assertFalse( needs_reauth(), 'A transient PDS failure must not flag the connection.' );
+		$this->assertTrue( is_connected() );
+		$this->assertFalse(
+			\get_transient( SESSION_VERIFIED_TRANSIENT ),
+			'An inconclusive probe must not be cached as a success.'
+		);
+	}
+
+	/**
+	 * A rate-limited probe is inconclusive for the same reason.
+	 */
+	public function test_rate_limited_probe_leaves_the_connection_alone() {
+		$this->mock_transport( 429, array( 'error' => 'RateLimitExceeded' ) );
+
+		$this->assertTrue( verify_connection() );
+		$this->assertFalse( needs_reauth() );
+	}
+
+	/**
+	 * Disconnecting drops the cached verdict, so a reconnect — especially to
+	 * a different account — is probed fresh instead of inheriting the
+	 * previous account's clean bill of health.
+	 */
+	public function test_disconnect_clears_the_cached_verdict() {
+		$this->mock_transport( 200, array( 'did' => 'did:plc:test123' ) );
+
+		verify_connection();
+		$this->assertNotFalse( \get_transient( SESSION_VERIFIED_TRANSIENT ) );
+
+		Client::disconnect();
+
+		$this->assertFalse( \get_transient( SESSION_VERIFIED_TRANSIENT ) );
+	}
+}

--- a/tests/phpunit/tests/class-test-verify-connection.php
+++ b/tests/phpunit/tests/class-test-verify-connection.php
@@ -269,4 +269,80 @@ class Test_Verify_Connection extends \WP_UnitTestCase {
 
 		$this->assertFalse( \get_transient( SESSION_VERIFIED_TRANSIENT ) );
 	}
+
+	/**
+	 * An account the PDS refuses to let post is NOT caught by this probe.
+	 *
+	 * Deactivation, suspension, and takedown come back as 400/403 rather
+	 * than 401, so they never enter the refresh ladder and nothing flags
+	 * the connection. `getSession` carries `active`/`status` fields that
+	 * would settle it, but acting on them needs new copy on every surface.
+	 * This pins the gap so closing it is a deliberate change with a
+	 * failing test, rather than a silent behavior shift.
+	 */
+	public function test_taken_down_account_is_a_known_gap() {
+		$this->mock_transport( 400, array( 'error' => 'AccountTakedown' ) );
+
+		$this->assertTrue( verify_connection(), 'Documented gap: a takedown is not detected today.' );
+		$this->assertFalse( needs_reauth() );
+	}
+
+	/**
+	 * Reconnecting without disconnecting first must re-probe.
+	 *
+	 * Both connect surfaces — the settings field and the Connectors card —
+	 * authorize straight over a live connection, so this path never passes
+	 * through `disconnect()`. Inheriting the previous account's verdict
+	 * would leave the panel vouching for credentials it has never seen,
+	 * which is the exact staleness the probe exists to remove.
+	 */
+	public function test_reconnect_clears_the_cached_verdict() {
+		$this->mock_transport( 200, array( 'did' => 'did:plc:test123' ) );
+
+		verify_connection();
+		$this->assertNotFalse( \get_transient( SESSION_VERIFIED_TRANSIENT ) );
+
+		/*
+		 * Drive a real OAuth callback. Nothing calls `disconnect()` first:
+		 * this is the reconnect-over-a-live-connection path both connect
+		 * surfaces actually take.
+		 */
+		$jwk = DPoP::generate_key();
+
+		\set_transient( 'atmosphere_oauth_state', 'state-abc', \HOUR_IN_SECONDS );
+		\set_transient( 'atmosphere_oauth_verifier', 'verifier-xyz', \HOUR_IN_SECONDS );
+		\set_transient( 'atmosphere_oauth_dpop_jwk', Encryption::encrypt( (string) \wp_json_encode( $jwk ) ), \HOUR_IN_SECONDS );
+		\set_transient(
+			'atmosphere_oauth_resolved',
+			array(
+				'did'          => 'did:plc:other456',
+				'pds_endpoint' => 'https://pds.example.com',
+				'auth_server'  => array(
+					'token_endpoint' => self::TOKEN_ENDPOINT,
+					'issuer_url'     => 'https://auth.example.com',
+				),
+				'handle'       => 'someone-else.example.com',
+			),
+			\HOUR_IN_SECONDS
+		);
+
+		\remove_all_filters( 'pre_http_request' );
+		$this->mock_transport(
+			200,
+			array( 'did' => 'did:plc:other456' ),
+			200,
+			array(
+				'access_token'  => 'new-access-token',
+				'refresh_token' => 'new-refresh-token',
+				'expires_in'    => 3600,
+			)
+		);
+
+		$this->assertTrue( Client::handle_callback( 'code-123', 'state-abc' ) );
+
+		$this->assertFalse(
+			\get_transient( SESSION_VERIFIED_TRANSIENT ),
+			'A reconnect must not inherit the previous session\'s verdict.'
+		);
+	}
 }

--- a/tests/phpunit/tests/rest/admin/class-test-pre-publish-controller.php
+++ b/tests/phpunit/tests/rest/admin/class-test-pre-publish-controller.php
@@ -10,9 +10,12 @@
 namespace Atmosphere\Tests\Rest\Admin;
 
 use Atmosphere\OAuth\Client;
+use Atmosphere\OAuth\DPoP;
+use Atmosphere\OAuth\Encryption;
 use Atmosphere\Rest\Admin\Pre_Publish_Controller;
 use WP_REST_Request;
 use WP_UnitTestCase;
+use const Atmosphere\SESSION_VERIFIED_TRANSIENT;
 
 /**
  * Pre-publish preview controller tests.
@@ -36,15 +39,48 @@ class Test_Pre_Publish_Controller extends WP_UnitTestCase {
 
 		$this->controller = new Pre_Publish_Controller();
 
+		/*
+		 * Real, decryptable credentials rather than a placeholder string:
+		 * the endpoint now verifies the session with the PDS before it
+		 * reads local connection state, so a fixture holding credentials
+		 * nothing can decrypt is a *broken* connection, not a connected
+		 * site, and every preview here would correctly report that.
+		 */
+		$dpop_jwk = DPoP::generate_key();
+
 		\update_option(
 			'atmosphere_connection',
 			array(
-				'did'          => 'did:plc:test123',
-				'handle'       => 'me.example.com',
-				'access_token' => 'test-token',
+				'did'            => 'did:plc:test123',
+				'handle'         => 'me.example.com',
+				'access_token'   => Encryption::encrypt( 'test-access-token' ),
+				'refresh_token'  => Encryption::encrypt( 'test-refresh-token' ),
+				'dpop_jwk'       => Encryption::encrypt( \wp_json_encode( $dpop_jwk ) ),
+				'pds_endpoint'   => 'https://pds.example.com',
+				'token_endpoint' => 'https://auth.example.com/oauth/token',
+				'expires_at'     => \time() + 3600,
+				'needs_reauth'   => false,
 			)
 		);
 		\update_option( 'atmosphere_auto_publish', '1' );
+
+		// A PDS that accepts the session, so the probe is a no-op here.
+		\add_filter(
+			'pre_http_request',
+			static function ( $response, $args, $url ) {
+				if ( false !== \strpos( $url, 'getSession' ) ) {
+					return array(
+						'response' => array( 'code' => 200 ),
+						'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+						'body'     => \wp_json_encode( array( 'did' => 'did:plc:test123' ) ),
+					);
+				}
+
+				return $response;
+			},
+			1,
+			3
+		);
 	}
 
 	/**
@@ -56,6 +92,8 @@ class Test_Pre_Publish_Controller extends WP_UnitTestCase {
 		\delete_option( 'atmosphere_auto_publish' );
 		\delete_option( 'atmosphere_support_post_types' );
 		\delete_option( Client::DISCONNECTED_OPTION );
+		\delete_transient( SESSION_VERIFIED_TRANSIENT );
+		\remove_all_filters( 'pre_http_request' );
 		\remove_all_filters( 'atmosphere_long_form_composition' );
 		\remove_all_filters( 'atmosphere_connection_only_mode' );
 		\wp_set_current_user( 0 );
@@ -744,5 +782,82 @@ class Test_Pre_Publish_Controller extends WP_UnitTestCase {
 		$this->assertFalse( $data['will_publish'] );
 		$this->assertFalse( $data['needs_reconnect'] );
 		$this->assertStringContainsString( 'switched off', $data['reason'] );
+	}
+
+	/**
+	 * The whole point of the probe: a session the user revoked from their
+	 * Bluesky account is caught while the panel is still open.
+	 *
+	 * Local state cannot see this. The stored credentials are byte-for-byte
+	 * what a working connection holds, so without asking the PDS the panel
+	 * would promise a share that is already impossible. The probe runs the
+	 * ordinary request path, the flag lands on the connection row, and the
+	 * decision below reaches its existing reconnect branch — no new copy.
+	 */
+	public function test_revoked_session_is_caught_before_the_author_publishes() {
+		$this->login_as_admin();
+
+		// Replace the accepting PDS from set_up() with one that rejects.
+		\remove_all_filters( 'pre_http_request' );
+		\add_filter(
+			'pre_http_request',
+			static function ( $response, $args, $url ) {
+				if ( false !== \strpos( $url, 'oauth/token' ) ) {
+					return array(
+						'response' => array( 'code' => 400 ),
+						'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+						'body'     => \wp_json_encode( array( 'error' => 'invalid_grant' ) ),
+					);
+				}
+
+				if ( false !== \strpos( $url, 'getSession' ) ) {
+					return array(
+						'response' => array( 'code' => 401 ),
+						'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+						'body'     => \wp_json_encode( array( 'error' => 'InvalidToken' ) ),
+					);
+				}
+
+				return $response;
+			},
+			1,
+			3
+		);
+
+		$post = self::factory()->post->create( array( 'post_status' => 'draft' ) );
+		$data = \rest_do_request( $this->make_request( $post ) )->get_data();
+
+		$this->assertFalse( $data['will_publish'], 'A revoked session must not promise a share.' );
+		$this->assertTrue( $data['needs_reconnect'], 'The panel must offer the reconnect prompt.' );
+		$this->assertNotEmpty( $data['reason'] );
+	}
+
+	/**
+	 * A PDS we cannot reach is not a disconnection.
+	 *
+	 * Reporting one would block an author over our own inability to ask —
+	 * a worse failure than the stale verdict the probe exists to fix.
+	 */
+	public function test_unreachable_pds_does_not_block_the_share() {
+		$this->login_as_admin();
+
+		\remove_all_filters( 'pre_http_request' );
+		\add_filter(
+			'pre_http_request',
+			static function ( $response, $args, $url ) {
+				if ( false !== \strpos( $url, 'getSession' ) ) {
+					return new \WP_Error( 'http_request_failed', 'Connection timed out.' );
+				}
+
+				return $response;
+			},
+			1,
+			3
+		);
+
+		$post = self::factory()->post->create( array( 'post_status' => 'draft' ) );
+		$data = \rest_do_request( $this->make_request( $post ) )->get_data();
+
+		$this->assertTrue( $data['will_publish'], 'An unreachable PDS must not be read as a disconnection.' );
 	}
 }


### PR DESCRIPTION
## Proposed changes:

The editor decided whether a post would reach Bluesky by reading three stored fields and never leaving the site. That is the right answer almost everywhere, but it cannot answer the one question the panel is actually asked.

A refresh token the user revoked from their Bluesky account is byte-for-byte identical on disk to a working one. Revocation happens at the auth server and writes nothing locally, so `is_connected()` has no way to see it. The panel would promise a share that was already impossible, and the author only found out afterwards.

So the editor asks, when it opens.

* **`API::get_session()`** wraps `com.atproto.server.getSession`, the cheapest authenticated read the PDS offers.
* **`Atmosphere\verify_connection()`** runs it through the *ordinary* request path, which matters: a dead session travels the existing 401 → refresh → `mark_needs_reauth()` ladder on its own. The probe records nothing itself. Its whole job is to make local state honest before the decision reads it, so every surface already built on `is_connected()` and `needs_reauth()` reports the truth with the copy it already has. No new strings, nothing new to translate.
* **`Block_Editor::script_data()`** calls it before resolving the share status the document panel renders, so an author with a revoked session gets the reconnect prompt on the first paint — nothing written, nothing invested. The pre-publish panel calls it too; behind the shared cache that costs nothing and still covers a session that dies after the editor loaded.

### Design notes worth reviewing

**It fails open.** A timeout, a 5xx, or a rate limit says the check did not complete, not that the session is dead. Those leave stored state untouched and the panel still says the post will publish. Blocking an author because our own probe could not get through would be a worse bug than the staleness this fixes.

**It reads the outcome instead of classifying the error.** On `WP_Error`, `verify_connection()` re-reads `is_connected()` rather than inspecting the error code. When the request path gives up on the credentials it flags the row itself, and that flag is what every other caller sees. This keeps the helper correct no matter which layer decided, and picks up any future path reaching the same conclusion by another route.

**Timeout.** Bounded at 5 seconds rather than the shared 30. This runs while the editor renders, which is the difference between a slow load and a frozen one, and since the probe fails open, giving up early costs a stale verdict for one cache window while waiting costs the author their editor.

**Where it is and is not gated.** In the pre-publish decision it runs last, after every local gate — those all return without consulting the connection, so a private or opted-out post would otherwise spend a round-trip on an answer nothing reads. On editor load it is deliberately *not* gated on whether sharing is switched on: the connection is shared infrastructure and the reconnect prompt is connection level, not cross-posting level. The enqueue already limits it to editors for supported post types.

**Caching.** Successes only, 15 minutes, filterable via `atmosphere_session_verify_ttl`. A permanent rejection needs no cache entry: it lives on the connection row, where `is_connected()` reads it without touching the network. Cleared on both `disconnect()` **and** `handle_callback()` — neither connect surface goes through `disconnect()`, so without the second one a reconnect (especially an account switch) would inherit the previous session's verdict.

### Known gap, deliberately not closed

This verifies that the credentials still authenticate, not that the account may post. A deactivated, suspended, or taken-down account is rejected as a 400/403 rather than a 401, so it never enters the refresh ladder and nothing flags the connection — the probe reports healthy. `getSession` carries `active` and `status` fields that would settle it, but acting on them means new copy on several surfaces. `test_taken_down_account_is_a_known_gap` pins the current behaviour so closing it stays a deliberate change with a failing test behind it.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

`tests/phpunit/tests/class-test-block-editor.php` covers the editor-load path: a revoked session surfacing as `needs_reconnect` on first paint, an unreachable PDS not being read as a disconnection, and the short timeout actually reaching the transport.

`tests/phpunit/tests/class-test-verify-connection.php` (10 tests) covers the disconnected short-circuit, cache hit / `$force` bypass / zero-TTL, the revoked-session path, inconclusive 5xx and 429 handling, cache clearing on both disconnect and reconnect, and the documented takedown gap. Two more in `class-test-pre-publish-controller.php` cover the endpoint end-to-end.

One fixture change worth a look: that controller's `set_up()` held `'access_token' => 'test-token'`, a placeholder nothing can decrypt. Now that the endpoint exercises the credentials, that is a broken connection rather than a connected site, and two tests failed. It holds real encrypted credentials instead. Every test covering the disconnected / `needs_reauth` states still exits `verify_connection()` at the `is_connected()` early return before any network call, so none of their assertions were weakened.

## Testing instructions:

**Automated**

```bash
npm run env-test -- --filter='Test_Verify_Connection|Test_Pre_Publish_Controller|Test_Block_Editor'
```

Full suite and lint clean: 1381 tests, PHPCS 43/43.

Two of these were verified red before their fix — `test_revoked_session_fails_verification_and_flags_the_connection` and `test_reconnect_clears_the_cached_verdict`.

**Manual**

1. Connect a Bluesky account under Settings → ATmosphere.
2. Revoke the plugin's access from the Bluesky side, leaving the stored credentials in place.
3. Open any post in the editor.

*Before:* the ATmosphere panel says the post will be shared. You write it, click Publish, confirm, and the share fails afterwards.

*After:* the panel carries the reconnect prompt as soon as the editor loads, before anything is written.

To check the fail-open path, block outbound requests to the PDS instead of revoking. The panel should still say the post will publish.

To check the reconnect path, reconnect **without** disconnecting first and confirm the panel re-probes rather than reusing the previous verdict.

### Changelog entry

Committed on the branch as `.github/changelog/add-verify-connection-before-publish`.

-   [ ] Automatically create a changelog entry from the details below.
